### PR TITLE
chore: regenerate all packages, copyright changes only

### DIFF
--- a/packages/google-ads-admanager/.flake8
+++ b/packages/google-ads-admanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/MANIFEST.in
+++ b/packages/google-ads-admanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager/gapic_version.py
+++ b/packages/google-ads-admanager/google/ads/admanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/gapic_version.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_break_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_break_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_break_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_break_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_review_center_ad_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_review_center_ad_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_review_center_ad_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_review_center_ad_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_review_center_ad_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_review_center_ad_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_unit_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_unit_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_unit_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_unit_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_unit_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_unit_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/admanager_error.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/admanager_error.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/application_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/application_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/application_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/application_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/application_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/application_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/applied_label.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/applied_label.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/audience_segment_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/audience_segment_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/audience_segment_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/audience_segment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/bandwidth_group_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/bandwidth_group_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/bandwidth_group_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/bandwidth_group_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_language_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_language_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_language_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_language_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/child_publisher_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/child_publisher_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_key_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_key_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_key_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_key_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_key_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_key_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_value_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_value_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_value_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_value_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_value_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_value_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/company_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/company_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/company_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/company_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/company_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/company_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/contact_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/contact_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/contact_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/contact_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/contact_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/contact_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/content_bundle_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/content_bundle_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/content_bundle_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/content_bundle_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/content_label_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/content_label_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/content_label_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/content_label_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/content_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/content_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/content_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/content_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_variable_url_type_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_variable_url_type_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_value.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_value.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_key_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_key_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_key_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_key_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_key_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_key_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_value_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_value_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_value_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_value_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_value_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_value_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/deal_buyer_permission_type_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/deal_buyer_permission_type_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/device_capability_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/device_capability_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/device_capability_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/device_capability_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/device_category_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/device_category_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/device_category_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/device_category_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/device_manufacturer_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/device_manufacturer_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/device_manufacturer_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/device_manufacturer_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/early_ad_break_notification_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/early_ad_break_notification_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/entity_signals_mapping_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/entity_signals_mapping_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/entity_signals_mapping_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/entity_signals_mapping_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/environment_type_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/environment_type_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/exchange_syndication_product_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/exchange_syndication_product_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/frequency_cap.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/frequency_cap.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/geo_target_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/geo_target_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/geo_target_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/geo_target_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/goal.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/goal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/goal_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/goal_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/label_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/label_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/label_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/label_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/label_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/label_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/line_item_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/line_item_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/line_item_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/line_item_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/line_item_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/line_item_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/linked_device_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/linked_device_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/linked_device_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/linked_device_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/linked_device_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/linked_device_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/live_stream_event_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/live_stream_event_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mcm_earnings_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mcm_earnings_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mcm_earnings_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mcm_earnings_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mcm_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mcm_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_carrier_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_carrier_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_carrier_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_carrier_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_submodel_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_submodel_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_submodel_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_submodel_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/network_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/network_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/network_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/network_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_version_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_version_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_version_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_version_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/order_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/order_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/order_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/order_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/order_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/order_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/placement_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/placement_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/placement_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/placement_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/placement_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/placement_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_deal_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_deal_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_deal_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_deal_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/private_marketplace_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/private_marketplace_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/programmatic_buyer_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/programmatic_buyer_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/programmatic_buyer_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/programmatic_buyer_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/report_definition.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/report_definition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/report_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/report_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/report_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/report_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/report_value.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/report_value.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/request_platform_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/request_platform_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/rich_media_ads_company_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/rich_media_ads_company_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/rich_media_ads_company_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/rich_media_ads_company_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/rich_media_ads_company_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/rich_media_ads_company_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/role_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/role_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/role_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/role_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/role_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/role_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/site_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/site_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/site_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/site_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/site_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/site_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/size.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/size.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/size_type_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/size_type_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/targeted_video_bumper_type_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/targeted_video_bumper_type_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/targeting.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/targeting.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/taxonomy_category_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/taxonomy_category_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/taxonomy_category_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/taxonomy_category_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/taxonomy_type_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/taxonomy_type_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/team_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/team_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/team_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/team_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/team_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/team_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/time_unit_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/time_unit_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/user_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/user_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/user_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/user_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/video_position_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/video_position_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/web_property.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/web_property.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_create_ad_break_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_create_ad_break_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_delete_ad_break_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_delete_ad_break_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_get_ad_break_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_get_ad_break_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_list_ad_breaks_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_list_ad_breaks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_update_ad_break_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_update_ad_break_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_review_center_ad_service_batch_allow_ad_review_center_ads_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_review_center_ad_service_batch_allow_ad_review_center_ads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_review_center_ad_service_batch_block_ad_review_center_ads_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_review_center_ad_service_batch_block_ad_review_center_ads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_review_center_ad_service_search_ad_review_center_ads_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_review_center_ad_service_search_ad_review_center_ads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_activate_ad_units_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_activate_ad_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_archive_ad_units_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_archive_ad_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_create_ad_units_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_create_ad_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_deactivate_ad_units_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_deactivate_ad_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_update_ad_units_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_update_ad_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_create_ad_unit_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_create_ad_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_get_ad_unit_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_get_ad_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_list_ad_unit_sizes_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_list_ad_unit_sizes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_list_ad_units_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_list_ad_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_update_ad_unit_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_update_ad_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_archive_applications_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_archive_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_create_applications_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_create_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_unarchive_applications_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_unarchive_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_update_applications_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_update_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_create_application_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_create_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_get_application_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_get_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_list_applications_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_list_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_update_application_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_update_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_audience_segment_service_get_audience_segment_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_audience_segment_service_get_audience_segment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_audience_segment_service_list_audience_segments_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_audience_segment_service_list_audience_segments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_bandwidth_group_service_get_bandwidth_group_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_bandwidth_group_service_get_bandwidth_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_bandwidth_group_service_list_bandwidth_groups_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_bandwidth_group_service_list_bandwidth_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_language_service_get_browser_language_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_language_service_get_browser_language_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_language_service_list_browser_languages_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_language_service_list_browser_languages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_service_get_browser_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_service_get_browser_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_service_list_browsers_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_service_list_browsers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_batch_activate_cms_metadata_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_batch_activate_cms_metadata_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_batch_deactivate_cms_metadata_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_batch_deactivate_cms_metadata_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_get_cms_metadata_key_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_get_cms_metadata_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_list_cms_metadata_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_list_cms_metadata_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_batch_activate_cms_metadata_values_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_batch_activate_cms_metadata_values_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_batch_deactivate_cms_metadata_values_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_batch_deactivate_cms_metadata_values_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_get_cms_metadata_value_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_get_cms_metadata_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_list_cms_metadata_values_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_list_cms_metadata_values_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_company_service_get_company_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_company_service_get_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_company_service_list_companies_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_company_service_list_companies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_batch_create_contacts_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_batch_create_contacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_batch_update_contacts_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_batch_update_contacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_create_contact_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_create_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_get_contact_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_get_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_list_contacts_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_list_contacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_update_contact_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_update_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_bundle_service_get_content_bundle_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_bundle_service_get_content_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_bundle_service_list_content_bundles_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_bundle_service_list_content_bundles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_label_service_get_content_label_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_label_service_get_content_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_label_service_list_content_labels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_label_service_list_content_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_service_get_content_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_service_get_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_service_list_content_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_service_list_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_creative_template_service_get_creative_template_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_creative_template_service_get_creative_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_creative_template_service_list_creative_templates_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_creative_template_service_list_creative_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_activate_custom_fields_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_activate_custom_fields_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_create_custom_fields_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_create_custom_fields_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_deactivate_custom_fields_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_deactivate_custom_fields_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_update_custom_fields_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_update_custom_fields_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_create_custom_field_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_create_custom_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_get_custom_field_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_get_custom_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_list_custom_fields_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_list_custom_fields_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_update_custom_field_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_update_custom_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_activate_custom_targeting_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_activate_custom_targeting_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_create_custom_targeting_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_create_custom_targeting_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_deactivate_custom_targeting_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_deactivate_custom_targeting_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_update_custom_targeting_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_update_custom_targeting_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_create_custom_targeting_key_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_create_custom_targeting_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_get_custom_targeting_key_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_get_custom_targeting_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_list_custom_targeting_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_list_custom_targeting_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_update_custom_targeting_key_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_update_custom_targeting_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_value_service_get_custom_targeting_value_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_value_service_get_custom_targeting_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_value_service_list_custom_targeting_values_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_value_service_list_custom_targeting_values_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_capability_service_get_device_capability_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_capability_service_get_device_capability_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_capability_service_list_device_capabilities_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_capability_service_list_device_capabilities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_category_service_get_device_category_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_category_service_get_device_category_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_category_service_list_device_categories_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_category_service_list_device_categories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_manufacturer_service_get_device_manufacturer_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_manufacturer_service_get_device_manufacturer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_manufacturer_service_list_device_manufacturers_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_manufacturer_service_list_device_manufacturers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_batch_create_entity_signals_mappings_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_batch_create_entity_signals_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_batch_update_entity_signals_mappings_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_batch_update_entity_signals_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_create_entity_signals_mapping_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_create_entity_signals_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_get_entity_signals_mapping_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_get_entity_signals_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_list_entity_signals_mappings_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_list_entity_signals_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_update_entity_signals_mapping_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_update_entity_signals_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_geo_target_service_get_geo_target_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_geo_target_service_get_geo_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_geo_target_service_list_geo_targets_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_geo_target_service_list_geo_targets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_activate_labels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_activate_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_create_labels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_create_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_deactivate_labels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_deactivate_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_update_labels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_update_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_create_label_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_create_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_get_label_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_get_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_list_labels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_list_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_update_label_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_update_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_line_item_service_get_line_item_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_line_item_service_get_line_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_line_item_service_list_line_items_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_line_item_service_list_line_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_linked_device_service_get_linked_device_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_linked_device_service_get_linked_device_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_linked_device_service_list_linked_devices_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_linked_device_service_list_linked_devices_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mcm_earnings_service_fetch_mcm_earnings_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mcm_earnings_service_fetch_mcm_earnings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_carrier_service_get_mobile_carrier_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_carrier_service_get_mobile_carrier_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_carrier_service_list_mobile_carriers_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_carrier_service_list_mobile_carriers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_service_get_mobile_device_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_service_get_mobile_device_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_service_list_mobile_devices_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_service_list_mobile_devices_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_submodel_service_get_mobile_device_submodel_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_submodel_service_get_mobile_device_submodel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_submodel_service_list_mobile_device_submodels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_submodel_service_list_mobile_device_submodels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_network_service_get_network_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_network_service_get_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_network_service_list_networks_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_network_service_list_networks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_service_get_operating_system_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_service_get_operating_system_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_service_list_operating_systems_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_service_list_operating_systems_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_version_service_get_operating_system_version_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_version_service_get_operating_system_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_version_service_list_operating_system_versions_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_version_service_list_operating_system_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_order_service_get_order_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_order_service_get_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_order_service_list_orders_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_order_service_list_orders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_activate_placements_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_activate_placements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_archive_placements_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_archive_placements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_create_placements_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_create_placements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_deactivate_placements_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_deactivate_placements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_update_placements_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_update_placements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_create_placement_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_create_placement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_get_placement_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_get_placement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_list_placements_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_list_placements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_update_placement_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_update_placement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_create_private_auction_deal_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_create_private_auction_deal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_get_private_auction_deal_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_get_private_auction_deal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_list_private_auction_deals_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_list_private_auction_deals_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_update_private_auction_deal_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_update_private_auction_deal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_create_private_auction_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_create_private_auction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_get_private_auction_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_get_private_auction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_list_private_auctions_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_list_private_auctions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_update_private_auction_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_update_private_auction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_programmatic_buyer_service_get_programmatic_buyer_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_programmatic_buyer_service_get_programmatic_buyer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_programmatic_buyer_service_list_programmatic_buyers_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_programmatic_buyer_service_list_programmatic_buyers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_create_report_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_create_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_fetch_report_result_rows_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_fetch_report_result_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_get_report_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_get_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_list_reports_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_list_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_run_report_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_run_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_update_report_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_update_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_rich_media_ads_company_service_get_rich_media_ads_company_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_rich_media_ads_company_service_get_rich_media_ads_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_rich_media_ads_company_service_list_rich_media_ads_companies_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_rich_media_ads_company_service_list_rich_media_ads_companies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_role_service_get_role_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_role_service_get_role_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_role_service_list_roles_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_role_service_list_roles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_create_sites_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_create_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_deactivate_sites_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_deactivate_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_submit_sites_for_approval_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_submit_sites_for_approval_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_update_sites_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_update_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_create_site_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_create_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_get_site_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_get_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_list_sites_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_list_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_update_site_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_update_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_taxonomy_category_service_get_taxonomy_category_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_taxonomy_category_service_get_taxonomy_category_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_taxonomy_category_service_list_taxonomy_categories_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_taxonomy_category_service_list_taxonomy_categories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_activate_teams_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_activate_teams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_create_teams_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_create_teams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_deactivate_teams_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_deactivate_teams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_update_teams_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_update_teams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_create_team_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_create_team_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_get_team_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_get_team_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_list_teams_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_list_teams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_update_team_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_update_team_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_user_service_get_user_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_user_service_get_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/tests/__init__.py
+++ b/packages/google-ads-admanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/tests/unit/__init__.py
+++ b/packages/google-ads-admanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/tests/unit/gapic/__init__.py
+++ b/packages/google-ads-admanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/tests/unit/gapic/admanager_v1/__init__.py
+++ b/packages/google-ads-admanager/tests/unit/gapic/admanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/.flake8
+++ b/packages/google-ads-datamanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/MANIFEST.in
+++ b/packages/google-ads-datamanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager/gapic_version.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/gapic_version.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/async_client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/grpc.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/rest.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/rest_base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/async_client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/grpc.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/rest.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/rest_base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/async_client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/pagers.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/grpc.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/rest.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/rest_base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/async_client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/pagers.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/grpc.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/rest.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/rest_base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/async_client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/pagers.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/grpc.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/rest.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/rest_base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/async_client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/pagers.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/grpc.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/rest.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/rest_base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/age_range.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/age_range.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/audience.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/audience.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/cart_data.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/cart_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/consent.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/consent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/destination.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/destination.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/device_info.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/device_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/encryption_info.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/encryption_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/error.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/error.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/event.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/experimental_field.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/experimental_field.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/gender.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/gender.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/ingestion_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/ingestion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/insights_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/insights_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/item_parameter.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/item_parameter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/match_rate.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/match_rate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/partner_link_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/partner_link_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/processing_errors.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/processing_errors.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/request_status_per_destination.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/request_status_per_destination.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/terms_of_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/terms_of_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_data.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_direct_license.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_direct_license.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_direct_license_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_direct_license_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_global_license.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_global_license.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_global_license_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_global_license_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_global_license_type.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_global_license_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_client_account_type.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_client_account_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_metrics.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_metrics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_pricing.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_pricing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_status.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_status.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_properties.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_properties.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_audience_members_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_audience_members_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_audience_members_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_audience_members_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_events_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_events_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_remove_audience_members_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_remove_audience_members_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_remove_audience_members_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_remove_audience_members_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_retrieve_request_status_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_retrieve_request_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_retrieve_request_status_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_retrieve_request_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_marketing_data_insights_service_retrieve_insights_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_marketing_data_insights_service_retrieve_insights_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_marketing_data_insights_service_retrieve_insights_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_marketing_data_insights_service_retrieve_insights_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_create_partner_link_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_create_partner_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_create_partner_link_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_create_partner_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_delete_partner_link_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_delete_partner_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_delete_partner_link_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_delete_partner_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_search_partner_links_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_search_partner_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_search_partner_links_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_search_partner_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_create_user_list_direct_license_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_create_user_list_direct_license_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_create_user_list_direct_license_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_create_user_list_direct_license_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_get_user_list_direct_license_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_get_user_list_direct_license_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_get_user_list_direct_license_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_get_user_list_direct_license_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_list_user_list_direct_licenses_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_list_user_list_direct_licenses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_list_user_list_direct_licenses_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_list_user_list_direct_licenses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_update_user_list_direct_license_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_update_user_list_direct_license_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_update_user_list_direct_license_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_update_user_list_direct_license_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_create_user_list_global_license_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_create_user_list_global_license_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_create_user_list_global_license_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_create_user_list_global_license_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_get_user_list_global_license_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_get_user_list_global_license_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_get_user_list_global_license_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_get_user_list_global_license_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_license_customer_infos_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_license_customer_infos_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_license_customer_infos_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_license_customer_infos_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_licenses_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_licenses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_licenses_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_licenses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_update_user_list_global_license_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_update_user_list_global_license_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_update_user_list_global_license_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_update_user_list_global_license_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_create_user_list_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_create_user_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_create_user_list_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_create_user_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_delete_user_list_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_delete_user_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_delete_user_list_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_delete_user_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_get_user_list_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_get_user_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_get_user_list_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_get_user_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_list_user_lists_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_list_user_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_list_user_lists_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_list_user_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_update_user_list_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_update_user_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_update_user_list_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_update_user_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/tests/__init__.py
+++ b/packages/google-ads-datamanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/tests/unit/__init__.py
+++ b/packages/google-ads-datamanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/tests/unit/gapic/__init__.py
+++ b/packages/google-ads-datamanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/tests/unit/gapic/datamanager_v1/__init__.py
+++ b/packages/google-ads-datamanager/tests/unit/gapic/datamanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/.flake8
+++ b/packages/google-ads-marketingplatform-admin/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/MANIFEST.in
+++ b/packages/google-ads-marketingplatform-admin/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin/gapic_version.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/gapic_version.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/async_client.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/client.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/pagers.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/base.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/grpc.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/rest.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/rest_base.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/types/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/types/marketingplatform_admin.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/types/marketingplatform_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/types/resources.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_create_analytics_account_link_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_create_analytics_account_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_create_analytics_account_link_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_create_analytics_account_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_delete_analytics_account_link_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_delete_analytics_account_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_delete_analytics_account_link_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_delete_analytics_account_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_find_sales_partner_managed_clients_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_find_sales_partner_managed_clients_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_find_sales_partner_managed_clients_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_find_sales_partner_managed_clients_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_get_organization_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_get_organization_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_get_organization_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_get_organization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_analytics_account_links_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_analytics_account_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_analytics_account_links_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_analytics_account_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_organizations_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_organizations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_organizations_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_organizations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_report_property_usage_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_report_property_usage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_report_property_usage_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_report_property_usage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_set_property_service_level_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_set_property_service_level_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_set_property_service_level_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_set_property_service_level_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/tests/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/tests/unit/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/tests/unit/gapic/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/tests/unit/gapic/marketingplatform_admin_v1alpha/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/tests/unit/gapic/marketingplatform_admin_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/.flake8
+++ b/packages/google-ai-generativelanguage/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/MANIFEST.in
+++ b/packages/google-ai-generativelanguage/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/citation.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/citation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/content.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/generative_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/generative_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/model_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/safety.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/cache_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/cache_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/cached_content.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/cached_content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/citation.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/citation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/content.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/discuss_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/discuss_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/file.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/file_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/file_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/generative_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/generative_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/model_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/permission.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/permission.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/permission_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/permission_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/prediction_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/retriever.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/retriever.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/retriever_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/retriever_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/safety.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/text_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/text_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/tuned_model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/tuned_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/cache_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/cache_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/cached_content.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/cached_content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/citation.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/citation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/content.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/discuss_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/discuss_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/file.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/file_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/file_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/generative_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/generative_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/model_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/permission.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/permission.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/permission_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/permission_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/prediction_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/safety.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/text_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/text_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/tuned_model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/tuned_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/citation.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/citation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/discuss_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/discuss_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/model_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/safety.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/text_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/text_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/citation.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/citation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/discuss_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/discuss_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/model_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/permission_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/permission_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/safety.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/text_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/text_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/tuned_model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/tuned_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_batch_embed_contents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_batch_embed_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_batch_embed_contents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_batch_embed_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_count_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_count_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_count_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_count_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_embed_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_embed_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_embed_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_embed_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_stream_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_stream_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_stream_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_stream_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_get_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_get_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_list_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_list_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_create_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_create_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_create_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_create_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_delete_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_delete_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_delete_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_delete_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_get_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_get_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_get_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_get_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_list_cached_contents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_list_cached_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_list_cached_contents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_list_cached_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_update_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_update_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_update_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_update_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_count_message_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_count_message_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_count_message_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_count_message_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_generate_message_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_generate_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_generate_message_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_generate_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_create_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_create_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_create_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_create_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_delete_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_delete_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_delete_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_delete_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_get_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_get_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_get_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_get_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_list_files_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_list_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_list_files_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_list_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_batch_embed_contents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_batch_embed_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_batch_embed_contents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_batch_embed_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_bidi_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_bidi_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_bidi_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_bidi_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_count_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_count_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_count_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_count_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_embed_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_embed_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_embed_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_embed_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_answer_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_answer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_answer_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_answer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_stream_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_stream_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_stream_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_stream_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_create_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_create_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_delete_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_delete_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_delete_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_delete_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_tuned_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_tuned_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_tuned_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_tuned_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_update_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_update_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_update_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_update_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_create_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_create_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_create_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_create_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_delete_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_delete_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_delete_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_delete_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_get_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_get_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_get_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_get_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_list_permissions_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_list_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_list_permissions_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_list_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_transfer_ownership_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_transfer_ownership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_transfer_ownership_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_transfer_ownership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_update_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_update_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_update_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_update_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_prediction_service_predict_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_prediction_service_predict_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_create_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_create_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_create_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_create_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_delete_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_delete_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_delete_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_delete_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_update_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_update_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_update_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_update_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_corpora_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_corpora_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_corpora_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_corpora_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_documents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_documents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_batch_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_batch_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_batch_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_batch_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_count_text_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_count_text_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_count_text_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_count_text_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_generate_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_generate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_generate_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_generate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_count_message_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_count_message_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_count_message_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_count_message_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_generate_message_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_generate_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_generate_message_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_generate_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_get_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_get_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_list_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_list_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_generate_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_generate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_generate_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_generate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_count_message_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_count_message_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_count_message_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_count_message_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_generate_message_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_generate_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_generate_message_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_generate_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_create_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_create_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_delete_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_delete_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_delete_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_delete_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_tuned_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_tuned_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_tuned_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_tuned_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_update_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_update_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_update_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_update_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_create_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_create_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_create_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_create_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_delete_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_delete_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_delete_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_delete_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_get_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_get_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_get_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_get_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_list_permissions_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_list_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_list_permissions_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_list_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_transfer_ownership_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_transfer_ownership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_transfer_ownership_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_transfer_ownership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_update_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_update_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_update_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_update_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_batch_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_batch_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_batch_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_batch_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_count_text_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_count_text_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_count_text_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_count_text_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_generate_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_generate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_generate_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_generate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_create_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_create_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_create_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_create_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_delete_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_delete_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_delete_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_delete_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_get_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_get_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_get_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_get_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_list_cached_contents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_list_cached_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_list_cached_contents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_list_cached_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_update_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_update_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_update_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_update_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_count_message_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_count_message_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_count_message_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_count_message_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_generate_message_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_generate_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_generate_message_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_generate_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_create_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_create_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_create_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_create_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_delete_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_delete_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_delete_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_delete_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_download_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_download_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_download_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_download_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_get_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_get_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_get_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_get_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_list_files_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_list_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_list_files_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_list_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_batch_embed_contents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_batch_embed_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_batch_embed_contents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_batch_embed_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_bidi_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_bidi_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_bidi_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_bidi_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_count_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_count_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_count_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_count_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_embed_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_embed_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_embed_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_embed_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_answer_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_answer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_answer_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_answer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_stream_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_stream_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_stream_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_stream_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_create_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_create_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_delete_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_delete_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_delete_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_delete_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_tuned_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_tuned_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_tuned_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_tuned_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_update_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_update_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_update_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_update_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_create_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_create_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_create_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_create_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_delete_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_delete_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_delete_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_delete_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_get_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_get_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_get_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_get_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_list_permissions_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_list_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_list_permissions_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_list_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_transfer_ownership_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_transfer_ownership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_transfer_ownership_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_transfer_ownership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_update_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_update_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_update_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_update_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_prediction_service_predict_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_prediction_service_predict_long_running_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_prediction_service_predict_long_running_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_prediction_service_predict_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_create_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_create_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_create_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_create_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_delete_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_delete_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_delete_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_delete_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_update_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_update_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_update_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_update_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_corpora_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_corpora_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_corpora_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_corpora_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_documents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_documents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_batch_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_batch_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_batch_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_batch_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_count_text_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_count_text_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_count_text_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_count_text_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_generate_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_generate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_generate_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_generate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/gapic/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1alpha/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta2/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta3/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/.flake8
+++ b/packages/google-analytics-admin/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/MANIFEST.in
+++ b/packages/google-analytics-admin/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin/gapic_version.py
+++ b/packages/google-analytics-admin/google/analytics/admin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/gapic_version.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/async_client.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/client.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/pagers.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/base.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/grpc.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/grpc_asyncio.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/rest.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/rest_base.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/access_report.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/access_report.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/analytics_admin.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/analytics_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/audience.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/audience.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/channel_group.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/channel_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/event_create_and_edit.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/event_create_and_edit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/expanded_data_set.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/expanded_data_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/resources.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/subproperty_event_filter.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/subproperty_event_filter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/gapic_version.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/async_client.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/client.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/pagers.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/base.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/grpc.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/grpc_asyncio.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/rest.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/rest_base.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/types/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/types/access_report.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/types/access_report.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/types/analytics_admin.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/types/analytics_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/types/resources.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_acknowledge_user_data_collection_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_acknowledge_user_data_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_acknowledge_user_data_collection_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_acknowledge_user_data_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_dimension_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_dimension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_dimension_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_dimension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_metric_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_metric_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_conversion_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_conversion_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_conversion_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_conversion_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_dimension_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_dimension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_dimension_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_dimension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_metric_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_metric_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_data_stream_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_data_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_data_stream_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_data_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_firebase_link_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_firebase_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_firebase_link_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_firebase_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_google_ads_link_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_google_ads_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_google_ads_link_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_google_ads_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_key_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_key_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_key_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_key_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_measurement_protocol_secret_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_measurement_protocol_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_measurement_protocol_secret_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_measurement_protocol_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_property_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_property_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_property_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_property_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_account_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_account_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_conversion_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_conversion_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_conversion_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_conversion_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_data_stream_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_data_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_data_stream_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_data_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_firebase_link_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_firebase_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_firebase_link_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_firebase_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_google_ads_link_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_google_ads_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_google_ads_link_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_google_ads_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_key_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_key_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_key_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_key_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_measurement_protocol_secret_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_measurement_protocol_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_measurement_protocol_secret_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_measurement_protocol_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_property_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_property_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_property_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_property_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_account_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_account_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_conversion_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_conversion_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_conversion_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_conversion_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_dimension_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_dimension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_dimension_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_dimension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_metric_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_metric_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_retention_settings_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_retention_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_retention_settings_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_retention_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_sharing_settings_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_sharing_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_sharing_settings_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_sharing_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_stream_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_stream_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_key_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_key_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_key_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_key_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_measurement_protocol_secret_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_measurement_protocol_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_measurement_protocol_secret_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_measurement_protocol_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_property_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_property_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_property_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_property_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_account_summaries_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_account_summaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_account_summaries_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_account_summaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_accounts_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_accounts_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_conversion_events_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_conversion_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_conversion_events_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_conversion_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_dimensions_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_dimensions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_dimensions_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_dimensions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_metrics_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_metrics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_metrics_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_data_streams_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_data_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_data_streams_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_data_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_firebase_links_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_firebase_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_firebase_links_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_firebase_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_google_ads_links_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_google_ads_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_google_ads_links_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_google_ads_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_key_events_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_key_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_key_events_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_key_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_measurement_protocol_secrets_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_measurement_protocol_secrets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_measurement_protocol_secrets_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_measurement_protocol_secrets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_properties_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_properties_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_properties_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_properties_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_provision_account_ticket_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_provision_account_ticket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_provision_account_ticket_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_provision_account_ticket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_run_access_report_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_run_access_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_run_access_report_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_run_access_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_search_change_history_events_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_search_change_history_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_search_change_history_events_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_search_change_history_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_account_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_account_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_conversion_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_conversion_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_conversion_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_conversion_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_dimension_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_dimension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_dimension_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_dimension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_metric_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_metric_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_retention_settings_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_retention_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_retention_settings_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_retention_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_stream_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_stream_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_google_ads_link_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_google_ads_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_google_ads_link_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_google_ads_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_key_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_key_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_key_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_key_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_measurement_protocol_secret_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_measurement_protocol_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_measurement_protocol_secret_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_measurement_protocol_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_property_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_property_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_property_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_property_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/tests/__init__.py
+++ b/packages/google-analytics-admin/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/tests/unit/__init__.py
+++ b/packages/google-analytics-admin/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/tests/unit/gapic/__init__.py
+++ b/packages/google-analytics-admin/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/tests/unit/gapic/admin_v1alpha/__init__.py
+++ b/packages/google-analytics-admin/tests/unit/gapic/admin_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/tests/unit/gapic/admin_v1beta/__init__.py
+++ b/packages/google-analytics-admin/tests/unit/gapic/admin_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/.flake8
+++ b/packages/google-analytics-data/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/MANIFEST.in
+++ b/packages/google-analytics-data/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data/gapic_version.py
+++ b/packages/google-analytics-data/google/analytics/data/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/gapic_version.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/client.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/pagers.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/base.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/grpc.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/grpc_asyncio.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/rest.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/rest_base.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/types/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/types/analytics_data_api.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/types/analytics_data_api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/types/data.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/types/data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/gapic_version.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/client.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/pagers.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/base.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/grpc.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/grpc_asyncio.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/rest.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/rest_base.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/types/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/types/analytics_data_api.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/types/analytics_data_api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/types/data.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/types/data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_audience_list_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_audience_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_recurring_audience_list_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_recurring_audience_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_recurring_audience_list_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_recurring_audience_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_report_task_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_report_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_audience_list_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_audience_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_audience_list_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_audience_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_metadata_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_metadata_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_metadata_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_property_quotas_snapshot_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_property_quotas_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_property_quotas_snapshot_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_property_quotas_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_recurring_audience_list_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_recurring_audience_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_recurring_audience_list_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_recurring_audience_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_report_task_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_report_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_report_task_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_report_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_audience_lists_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_audience_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_audience_lists_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_audience_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_recurring_audience_lists_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_recurring_audience_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_recurring_audience_lists_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_recurring_audience_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_report_tasks_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_report_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_report_tasks_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_report_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_audience_list_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_audience_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_audience_list_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_audience_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_report_task_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_report_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_report_task_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_report_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_funnel_report_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_funnel_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_funnel_report_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_funnel_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_report_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_report_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_pivot_reports_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_pivot_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_pivot_reports_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_pivot_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_reports_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_reports_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_check_compatibility_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_check_compatibility_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_check_compatibility_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_check_compatibility_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_create_audience_export_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_create_audience_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_audience_export_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_audience_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_audience_export_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_audience_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_metadata_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_metadata_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_metadata_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_list_audience_exports_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_list_audience_exports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_list_audience_exports_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_list_audience_exports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_query_audience_export_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_query_audience_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_query_audience_export_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_query_audience_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_pivot_report_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_pivot_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_pivot_report_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_pivot_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_realtime_report_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_realtime_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_realtime_report_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_realtime_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_report_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_report_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/tests/__init__.py
+++ b/packages/google-analytics-data/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/tests/unit/__init__.py
+++ b/packages/google-analytics-data/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/tests/unit/gapic/__init__.py
+++ b/packages/google-analytics-data/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/tests/unit/gapic/data_v1alpha/__init__.py
+++ b/packages/google-analytics-data/tests/unit/gapic/data_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/tests/unit/gapic/data_v1beta/__init__.py
+++ b/packages/google-analytics-data/tests/unit/gapic/data_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/.flake8
+++ b/packages/google-apps-card/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/MANIFEST.in
+++ b/packages/google-apps-card/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/google/apps/card/__init__.py
+++ b/packages/google-apps-card/google/apps/card/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/google/apps/card/gapic_version.py
+++ b/packages/google-apps-card/google/apps/card/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/google/apps/card_v1/gapic_version.py
+++ b/packages/google-apps-card/google/apps/card_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/google/apps/card_v1/services/__init__.py
+++ b/packages/google-apps-card/google/apps/card_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/google/apps/card_v1/types/__init__.py
+++ b/packages/google-apps-card/google/apps/card_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/google/apps/card_v1/types/card.py
+++ b/packages/google-apps-card/google/apps/card_v1/types/card.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/tests/__init__.py
+++ b/packages/google-apps-card/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/tests/unit/__init__.py
+++ b/packages/google-apps-card/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/tests/unit/gapic/__init__.py
+++ b/packages/google-apps-card/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/tests/unit/gapic/card_v1/__init__.py
+++ b/packages/google-apps-card/tests/unit/gapic/card_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/.flake8
+++ b/packages/google-apps-chat/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/MANIFEST.in
+++ b/packages/google-apps-chat/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat/__init__.py
+++ b/packages/google-apps-chat/google/apps/chat/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat/gapic_version.py
+++ b/packages/google-apps-chat/google/apps/chat/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/gapic_version.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/__init__.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/__init__.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/client.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/pagers.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/__init__.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/base.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/rest.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/rest_base.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/__init__.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/action_status.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/action_status.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/annotation.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/attachment.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/attachment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/chat_service.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/chat_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/contextual_addon.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/contextual_addon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/deletion_metadata.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/deletion_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/event_payload.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/event_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/group.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/history_state.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/history_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/matched_url.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/matched_url.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/membership.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/membership.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/message.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/reaction.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/reaction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/section.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/section.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/slash_command.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/slash_command.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/space.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/space.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/space_event.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/space_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/space_notification_setting.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/space_notification_setting.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/space_read_state.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/space_read_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/space_setup.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/space_setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/thread_read_state.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/thread_read_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/user.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/user.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/widgets.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/widgets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_complete_import_space_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_complete_import_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_complete_import_space_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_complete_import_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_custom_emoji_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_custom_emoji_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_custom_emoji_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_custom_emoji_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_membership_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_membership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_membership_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_message_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_message_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_reaction_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_reaction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_reaction_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_reaction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_section_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_section_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_section_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_section_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_space_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_space_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_custom_emoji_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_custom_emoji_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_custom_emoji_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_custom_emoji_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_membership_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_membership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_membership_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_message_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_message_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_reaction_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_reaction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_reaction_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_reaction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_section_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_section_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_section_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_section_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_space_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_space_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_direct_message_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_direct_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_direct_message_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_direct_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_group_chats_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_group_chats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_group_chats_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_group_chats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_attachment_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_attachment_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_custom_emoji_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_custom_emoji_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_custom_emoji_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_custom_emoji_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_membership_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_membership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_membership_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_message_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_message_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_event_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_event_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_notification_setting_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_notification_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_notification_setting_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_notification_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_read_state_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_read_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_read_state_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_read_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_thread_read_state_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_thread_read_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_thread_read_state_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_thread_read_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_custom_emojis_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_custom_emojis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_custom_emojis_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_custom_emojis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_memberships_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_memberships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_memberships_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_memberships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_messages_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_messages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_messages_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_messages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_reactions_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_reactions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_reactions_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_reactions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_section_items_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_section_items_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_section_items_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_section_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_sections_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_sections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_sections_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_sections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_space_events_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_space_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_space_events_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_space_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_spaces_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_spaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_spaces_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_spaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_move_section_item_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_move_section_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_move_section_item_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_move_section_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_position_section_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_position_section_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_position_section_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_position_section_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_search_spaces_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_search_spaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_search_spaces_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_search_spaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_set_up_space_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_set_up_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_set_up_space_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_set_up_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_membership_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_membership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_membership_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_message_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_message_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_section_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_section_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_section_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_section_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_notification_setting_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_notification_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_notification_setting_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_notification_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_read_state_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_read_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_read_state_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_read_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_upload_attachment_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_upload_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_upload_attachment_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_upload_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/tests/__init__.py
+++ b/packages/google-apps-chat/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/tests/unit/__init__.py
+++ b/packages/google-apps-chat/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/tests/unit/gapic/__init__.py
+++ b/packages/google-apps-chat/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/tests/unit/gapic/chat_v1/__init__.py
+++ b/packages/google-apps-chat/tests/unit/gapic/chat_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/.flake8
+++ b/packages/google-apps-events-subscriptions/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/MANIFEST.in
+++ b/packages/google-apps-events-subscriptions/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions/gapic_version.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/gapic_version.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/client.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/pagers.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/base.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/grpc.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/grpc_asyncio.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/rest.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/rest_base.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/types/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/types/subscription_resource.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/types/subscription_resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/types/subscriptions_service.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/types/subscriptions_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/gapic_version.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/client.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/pagers.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/base.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/grpc.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/grpc_asyncio.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/rest.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/rest_base.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/types/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/types/subscription_resource.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/types/subscription_resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/types/subscriptions_service.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/types/subscriptions_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_create_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_create_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_delete_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_delete_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_get_subscription_async.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_get_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_get_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_get_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_list_subscriptions_async.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_list_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_list_subscriptions_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_list_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_reactivate_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_reactivate_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_update_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_update_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_create_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_create_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_delete_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_delete_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_get_subscription_async.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_get_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_get_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_get_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_list_subscriptions_async.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_list_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_list_subscriptions_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_list_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_reactivate_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_reactivate_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_update_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_update_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/tests/__init__.py
+++ b/packages/google-apps-events-subscriptions/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/tests/unit/__init__.py
+++ b/packages/google-apps-events-subscriptions/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/tests/unit/gapic/__init__.py
+++ b/packages/google-apps-events-subscriptions/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/tests/unit/gapic/events_subscriptions_v1/__init__.py
+++ b/packages/google-apps-events-subscriptions/tests/unit/gapic/events_subscriptions_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/tests/unit/gapic/events_subscriptions_v1beta/__init__.py
+++ b/packages/google-apps-events-subscriptions/tests/unit/gapic/events_subscriptions_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/.flake8
+++ b/packages/google-apps-meet/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/MANIFEST.in
+++ b/packages/google-apps-meet/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet/gapic_version.py
+++ b/packages/google-apps-meet/google/apps/meet/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/gapic_version.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/async_client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/pagers.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/grpc.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/grpc_asyncio.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/rest.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/rest_base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/async_client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/grpc.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/grpc_asyncio.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/rest.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/rest_base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/types/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/types/resource.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/types/service.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/gapic_version.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/async_client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/pagers.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/grpc.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/grpc_asyncio.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/rest.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/rest_base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/async_client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/pagers.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/grpc.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/grpc_asyncio.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/rest.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/rest_base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/types/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/types/resource.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/types/service.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_conference_record_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_conference_record_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_conference_record_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_conference_record_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_session_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_session_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_recording_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_recording_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_recording_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_recording_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_entry_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_entry_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_conference_records_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_conference_records_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_conference_records_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_conference_records_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participant_sessions_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participant_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participant_sessions_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participant_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participants_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participants_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_recordings_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_recordings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_recordings_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_recordings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcript_entries_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcript_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcript_entries_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcript_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcripts_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcripts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcripts_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcripts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_create_space_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_create_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_create_space_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_create_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_end_active_conference_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_end_active_conference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_end_active_conference_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_end_active_conference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_get_space_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_get_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_get_space_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_get_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_update_space_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_update_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_update_space_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_update_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_conference_record_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_conference_record_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_conference_record_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_conference_record_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_session_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_session_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_recording_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_recording_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_recording_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_recording_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_entry_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_entry_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_conference_records_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_conference_records_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_conference_records_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_conference_records_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participant_sessions_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participant_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participant_sessions_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participant_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participants_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participants_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_recordings_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_recordings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_recordings_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_recordings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcript_entries_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcript_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcript_entries_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcript_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcripts_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcripts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcripts_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcripts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_connect_active_conference_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_connect_active_conference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_connect_active_conference_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_connect_active_conference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_member_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_member_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_member_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_member_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_space_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_space_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_delete_member_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_delete_member_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_delete_member_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_delete_member_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_end_active_conference_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_end_active_conference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_end_active_conference_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_end_active_conference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_member_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_member_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_member_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_member_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_space_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_space_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_list_members_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_list_members_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_list_members_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_list_members_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_update_space_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_update_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_update_space_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_update_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/tests/__init__.py
+++ b/packages/google-apps-meet/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/tests/unit/__init__.py
+++ b/packages/google-apps-meet/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/tests/unit/gapic/__init__.py
+++ b/packages/google-apps-meet/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/tests/unit/gapic/meet_v2/__init__.py
+++ b/packages/google-apps-meet/tests/unit/gapic/meet_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/tests/unit/gapic/meet_v2beta/__init__.py
+++ b/packages/google-apps-meet/tests/unit/gapic/meet_v2beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/.flake8
+++ b/packages/google-apps-script-type/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/MANIFEST.in
+++ b/packages/google-apps-script-type/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/calendar/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/calendar/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/calendar/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/calendar/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/calendar/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/calendar/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/calendar/types/calendar_addon_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/calendar/types/calendar_addon_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/docs/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/docs/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/docs/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/docs/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/docs/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/docs/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/docs/types/docs_addon_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/docs/types/docs_addon_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/drive/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/drive/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/drive/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/drive/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/drive/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/drive/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/drive/types/drive_addon_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/drive/types/drive_addon_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/gmail/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/gmail/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/gmail/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/gmail/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/gmail/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/gmail/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/gmail/types/gmail_addon_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/gmail/types/gmail_addon_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/sheets/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/sheets/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/sheets/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/sheets/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/sheets/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/sheets/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/sheets/types/sheets_addon_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/sheets/types/sheets_addon_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/slides/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/slides/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/slides/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/slides/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/slides/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/slides/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/slides/types/slides_addon_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/slides/types/slides_addon_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/types/addon_widget_set.py
+++ b/packages/google-apps-script-type/google/apps/script/type/types/addon_widget_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/types/extension_point.py
+++ b/packages/google-apps-script-type/google/apps/script/type/types/extension_point.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/types/script_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/types/script_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/__init__.py
+++ b/packages/google-apps-script-type/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/calendar/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/calendar/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/docs/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/docs/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/drive/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/drive/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/gmail/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/gmail/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/sheets/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/sheets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/slides/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/slides/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/type/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/type/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/.flake8
+++ b/packages/google-area120-tables/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/MANIFEST.in
+++ b/packages/google-area120-tables/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables/__init__.py
+++ b/packages/google-area120-tables/google/area120/tables/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables/gapic_version.py
+++ b/packages/google-area120-tables/google/area120/tables/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/gapic_version.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/__init__.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/__init__.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/async_client.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/client.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/pagers.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/__init__.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/base.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/grpc.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/grpc_asyncio.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/rest.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/rest_base.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/types/__init__.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/types/tables.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/types/tables.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_create_rows_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_create_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_create_rows_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_create_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_delete_rows_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_delete_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_delete_rows_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_delete_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_update_rows_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_update_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_update_rows_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_update_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_create_row_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_create_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_create_row_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_create_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_delete_row_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_delete_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_delete_row_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_delete_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_row_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_row_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_table_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_table_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_workspace_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_workspace_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_rows_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_rows_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_tables_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_tables_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_workspaces_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_workspaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_workspaces_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_workspaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_update_row_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_update_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_update_row_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_update_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/tests/__init__.py
+++ b/packages/google-area120-tables/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/tests/unit/__init__.py
+++ b/packages/google-area120-tables/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/tests/unit/gapic/__init__.py
+++ b/packages/google-area120-tables/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/tests/unit/gapic/tables_v1alpha1/__init__.py
+++ b/packages/google-area120-tables/tests/unit/gapic/tables_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/.flake8
+++ b/packages/google-cloud-access-approval/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/MANIFEST.in
+++ b/packages/google-cloud-access-approval/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval/__init__.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval/gapic_version.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/gapic_version.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/__init__.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/__init__.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/async_client.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/client.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/pagers.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/__init__.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/base.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/grpc.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/grpc_asyncio.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/rest.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/rest_base.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/services/access_approval/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/types/__init__.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/types/accessapproval.py
+++ b/packages/google-cloud-access-approval/google/cloud/accessapproval_v1/types/accessapproval.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_approve_approval_request_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_approve_approval_request_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_approve_approval_request_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_approve_approval_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_delete_access_approval_settings_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_delete_access_approval_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_delete_access_approval_settings_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_delete_access_approval_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_dismiss_approval_request_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_dismiss_approval_request_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_dismiss_approval_request_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_dismiss_approval_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_service_account_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_service_account_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_settings_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_settings_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_access_approval_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_approval_request_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_approval_request_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_approval_request_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_get_approval_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_invalidate_approval_request_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_invalidate_approval_request_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_invalidate_approval_request_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_invalidate_approval_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_list_approval_requests_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_list_approval_requests_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_list_approval_requests_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_list_approval_requests_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_update_access_approval_settings_async.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_update_access_approval_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_update_access_approval_settings_sync.py
+++ b/packages/google-cloud-access-approval/samples/generated_samples/accessapproval_v1_generated_access_approval_update_access_approval_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/tests/__init__.py
+++ b/packages/google-cloud-access-approval/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/tests/unit/__init__.py
+++ b/packages/google-cloud-access-approval/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-access-approval/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-access-approval/tests/unit/gapic/accessapproval_v1/__init__.py
+++ b/packages/google-cloud-access-approval/tests/unit/gapic/accessapproval_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/.flake8
+++ b/packages/google-cloud-advisorynotifications/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/MANIFEST.in
+++ b/packages/google-cloud-advisorynotifications/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications/__init__.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications/gapic_version.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/gapic_version.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/__init__.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/__init__.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/async_client.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/client.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/pagers.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/__init__.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/base.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/grpc.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/rest.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/rest_base.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/services/advisory_notifications_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/types/__init__.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/types/service.py
+++ b/packages/google-cloud-advisorynotifications/google/cloud/advisorynotifications_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_notification_async.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_notification_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_notification_sync.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_notification_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_settings_async.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_settings_sync.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_get_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_list_notifications_async.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_list_notifications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_list_notifications_sync.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_list_notifications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_update_settings_async.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_update_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_update_settings_sync.py
+++ b/packages/google-cloud-advisorynotifications/samples/generated_samples/advisorynotifications_v1_generated_advisory_notifications_service_update_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/tests/__init__.py
+++ b/packages/google-cloud-advisorynotifications/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/tests/unit/__init__.py
+++ b/packages/google-cloud-advisorynotifications/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-advisorynotifications/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-advisorynotifications/tests/unit/gapic/advisorynotifications_v1/__init__.py
+++ b/packages/google-cloud-advisorynotifications/tests/unit/gapic/advisorynotifications_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/.flake8
+++ b/packages/google-cloud-alloydb-connectors/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/MANIFEST.in
+++ b/packages/google-cloud-alloydb-connectors/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors/gapic_version.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/gapic_version.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/services/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/types/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/types/resources.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/gapic_version.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/services/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/types/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/types/resources.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1alpha/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/gapic_version.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/services/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/types/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/types/resources.py
+++ b/packages/google-cloud-alloydb-connectors/google/cloud/alloydb/connectors_v1beta/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/tests/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/tests/unit/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/tests/unit/gapic/connectors_v1/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/tests/unit/gapic/connectors_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/tests/unit/gapic/connectors_v1alpha/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/tests/unit/gapic/connectors_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb-connectors/tests/unit/gapic/connectors_v1beta/__init__.py
+++ b/packages/google-cloud-alloydb-connectors/tests/unit/gapic/connectors_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/.flake8
+++ b/packages/google-cloud-alloydb/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/MANIFEST.in
+++ b/packages/google-cloud-alloydb/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb/gapic_version.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/gapic_version.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/client.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/pagers.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/grpc.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/rest.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/rest_base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_db_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/client.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/grpc.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/rest.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/rest_base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/services/alloy_dbcsql_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/csql_resources.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/csql_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/csql_service.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/csql_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/data_model.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/data_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/service.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/gapic_version.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/client.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/pagers.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/grpc.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/rest.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/rest_base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_db_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/client.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/grpc.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/rest.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/rest_base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/services/alloy_dbcsql_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/csql_resources.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/csql_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/csql_service.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/csql_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/data_model.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/data_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/gemini.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/gemini.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/service.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/gapic_version.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/client.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/pagers.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/grpc.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/rest.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/rest_base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_db_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/client.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/grpc.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/rest.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/rest_base.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/services/alloy_dbcsql_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/__init__.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/csql_resources.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/csql_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/csql_service.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/csql_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/data_model.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/data_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/gemini.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/gemini.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/service.py
+++ b/packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_batch_create_instances_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_batch_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_secondary_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_secondary_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_secondary_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_secondary_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_create_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_delete_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_execute_sql_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_execute_sql_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_execute_sql_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_execute_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_export_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_export_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_failover_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_failover_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_generate_client_certificate_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_generate_client_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_generate_client_certificate_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_generate_client_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_backup_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_cluster_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_connection_info_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_connection_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_connection_info_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_connection_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_instance_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_get_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_import_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_import_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_inject_fault_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_inject_fault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_backups_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_backups_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_clusters_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_clusters_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_databases_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_databases_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_instances_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_instances_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_supported_database_flags_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_supported_database_flags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_supported_database_flags_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_supported_database_flags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_users_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_users_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_list_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_promote_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_promote_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_restart_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_restart_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_restore_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_restore_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_switchover_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_switchover_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_update_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_upgrade_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_db_admin_upgrade_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_dbcsql_admin_restore_from_cloud_sql_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1_generated_alloy_dbcsql_admin_restore_from_cloud_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_batch_create_instances_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_batch_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_database_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_database_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_secondary_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_secondary_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_secondary_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_secondary_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_create_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_delete_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_execute_sql_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_execute_sql_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_execute_sql_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_execute_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_export_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_export_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_failover_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_failover_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_generate_client_certificate_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_generate_client_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_generate_client_certificate_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_generate_client_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_backup_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_cluster_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_connection_info_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_connection_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_connection_info_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_connection_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_instance_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_get_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_import_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_import_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_inject_fault_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_inject_fault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_backups_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_backups_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_clusters_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_clusters_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_databases_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_databases_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_instances_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_instances_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_supported_database_flags_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_supported_database_flags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_supported_database_flags_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_supported_database_flags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_users_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_users_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_list_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_promote_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_promote_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_restart_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_restart_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_restore_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_restore_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_switchover_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_switchover_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_update_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_upgrade_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_db_admin_upgrade_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_dbcsql_admin_restore_from_cloud_sql_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1alpha_generated_alloy_dbcsql_admin_restore_from_cloud_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_batch_create_instances_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_batch_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_database_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_database_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_secondary_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_secondary_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_secondary_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_secondary_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_create_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_delete_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_execute_sql_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_execute_sql_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_execute_sql_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_execute_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_export_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_export_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_failover_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_failover_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_generate_client_certificate_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_generate_client_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_generate_client_certificate_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_generate_client_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_backup_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_cluster_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_connection_info_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_connection_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_connection_info_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_connection_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_instance_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_get_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_import_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_import_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_inject_fault_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_inject_fault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_backups_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_backups_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_clusters_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_clusters_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_databases_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_databases_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_instances_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_instances_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_supported_database_flags_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_supported_database_flags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_supported_database_flags_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_supported_database_flags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_users_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_users_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_list_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_promote_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_promote_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_restart_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_restart_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_restore_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_restore_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_switchover_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_switchover_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_backup_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_instance_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_user_async.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_user_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_update_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_upgrade_cluster_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_db_admin_upgrade_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_dbcsql_admin_restore_from_cloud_sql_sync.py
+++ b/packages/google-cloud-alloydb/samples/generated_samples/alloydb_v1beta_generated_alloy_dbcsql_admin_restore_from_cloud_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/tests/__init__.py
+++ b/packages/google-cloud-alloydb/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/tests/unit/__init__.py
+++ b/packages/google-cloud-alloydb/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-alloydb/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/tests/unit/gapic/alloydb_v1/__init__.py
+++ b/packages/google-cloud-alloydb/tests/unit/gapic/alloydb_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/tests/unit/gapic/alloydb_v1alpha/__init__.py
+++ b/packages/google-cloud-alloydb/tests/unit/gapic/alloydb_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-alloydb/tests/unit/gapic/alloydb_v1beta/__init__.py
+++ b/packages/google-cloud-alloydb/tests/unit/gapic/alloydb_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/.flake8
+++ b/packages/google-cloud-api-gateway/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/MANIFEST.in
+++ b/packages/google-cloud-api-gateway/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway/__init__.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway/gapic_version.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/gapic_version.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/__init__.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/__init__.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/client.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/pagers.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/__init__.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/base.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/grpc.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/rest.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/rest_base.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/services/api_gateway_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/types/__init__.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/types/apigateway.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/types/apigateway.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/types/apigateway_service.py
+++ b/packages/google-cloud-api-gateway/google/cloud/apigateway_v1/types/apigateway_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_create_api_config_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_create_api_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_create_api_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_create_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_create_gateway_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_create_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_delete_api_config_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_delete_api_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_delete_api_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_delete_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_delete_gateway_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_delete_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_async.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_config_async.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_config_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_gateway_async.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_gateway_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_gateway_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_get_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_api_configs_async.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_api_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_api_configs_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_api_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_apis_async.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_apis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_apis_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_apis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_gateways_async.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_gateways_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_gateways_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_list_gateways_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_update_api_config_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_update_api_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_update_api_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_update_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_update_gateway_sync.py
+++ b/packages/google-cloud-api-gateway/samples/generated_samples/apigateway_v1_generated_api_gateway_service_update_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/tests/__init__.py
+++ b/packages/google-cloud-api-gateway/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/tests/unit/__init__.py
+++ b/packages/google-cloud-api-gateway/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-api-gateway/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-gateway/tests/unit/gapic/apigateway_v1/__init__.py
+++ b/packages/google-cloud-api-gateway/tests/unit/gapic/apigateway_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/.flake8
+++ b/packages/google-cloud-api-keys/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/MANIFEST.in
+++ b/packages/google-cloud-api-keys/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys/__init__.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys/gapic_version.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/gapic_version.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/__init__.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/__init__.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/client.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/pagers.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/__init__.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/base.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/grpc.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/grpc_asyncio.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/rest.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/rest_base.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/services/api_keys/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/types/__init__.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/types/apikeys.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/types/apikeys.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/google/cloud/api_keys_v2/types/resources.py
+++ b/packages/google-cloud-api-keys/google/cloud/api_keys_v2/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_create_key_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_create_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_delete_key_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_delete_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_async.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_string_async.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_string_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_string_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_string_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_get_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_list_keys_async.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_list_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_list_keys_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_list_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_lookup_key_async.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_lookup_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_lookup_key_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_lookup_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_undelete_key_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_undelete_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_update_key_sync.py
+++ b/packages/google-cloud-api-keys/samples/generated_samples/apikeys_v2_generated_api_keys_update_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/tests/__init__.py
+++ b/packages/google-cloud-api-keys/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/tests/unit/__init__.py
+++ b/packages/google-cloud-api-keys/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-api-keys/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-api-keys/tests/unit/gapic/api_keys_v2/__init__.py
+++ b/packages/google-cloud-api-keys/tests/unit/gapic/api_keys_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/.flake8
+++ b/packages/google-cloud-apigee-connect/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/MANIFEST.in
+++ b/packages/google-cloud-apigee-connect/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect/gapic_version.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/gapic_version.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/async_client.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/client.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/pagers.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/base.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/grpc.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/connection_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/async_client.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/client.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/base.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/grpc.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/services/tether/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/types/__init__.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/types/connection.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/types/connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/types/tether.py
+++ b/packages/google-cloud-apigee-connect/google/cloud/apigeeconnect_v1/types/tether.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_connection_service_list_connections_async.py
+++ b/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_connection_service_list_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_connection_service_list_connections_sync.py
+++ b/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_connection_service_list_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_tether_egress_async.py
+++ b/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_tether_egress_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_tether_egress_sync.py
+++ b/packages/google-cloud-apigee-connect/samples/generated_samples/apigeeconnect_v1_generated_tether_egress_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/tests/__init__.py
+++ b/packages/google-cloud-apigee-connect/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/tests/unit/__init__.py
+++ b/packages/google-cloud-apigee-connect/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-apigee-connect/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-connect/tests/unit/gapic/apigeeconnect_v1/__init__.py
+++ b/packages/google-cloud-apigee-connect/tests/unit/gapic/apigeeconnect_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/.flake8
+++ b/packages/google-cloud-apigee-registry/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/MANIFEST.in
+++ b/packages/google-cloud-apigee-registry/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry/gapic_version.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/gapic_version.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/client.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/base.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/grpc.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/rest.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/rest_base.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/provisioning/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/async_client.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/client.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/pagers.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/base.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/grpc.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/rest.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/rest_base.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/services/registry/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/__init__.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/provisioning_service.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/provisioning_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/registry_models.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/registry_models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/registry_service.py
+++ b/packages/google-cloud-apigee-registry/google/cloud/apigee_registry_v1/types/registry_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_create_instance_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_delete_instance_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_get_instance_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_get_instance_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_provisioning_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_deployment_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_deployment_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_spec_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_spec_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_version_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_version_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_api_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_artifact_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_artifact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_artifact_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_create_artifact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_revision_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_revision_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_revision_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_revision_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_version_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_version_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_api_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_artifact_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_artifact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_artifact_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_delete_artifact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_deployment_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_deployment_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_contents_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_contents_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_version_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_version_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_api_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_contents_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_contents_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_get_artifact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployment_revisions_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployment_revisions_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployments_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployments_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_spec_revisions_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_spec_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_spec_revisions_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_spec_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_specs_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_specs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_specs_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_specs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_versions_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_versions_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_api_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_apis_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_apis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_apis_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_apis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_artifacts_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_artifacts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_artifacts_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_list_artifacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_replace_artifact_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_replace_artifact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_replace_artifact_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_replace_artifact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_deployment_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_deployment_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_spec_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_spec_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_rollback_api_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_deployment_revision_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_deployment_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_deployment_revision_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_deployment_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_spec_revision_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_spec_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_spec_revision_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_tag_api_spec_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_deployment_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_deployment_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_spec_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_spec_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_version_async.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_version_sync.py
+++ b/packages/google-cloud-apigee-registry/samples/generated_samples/apigeeregistry_v1_generated_registry_update_api_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/tests/__init__.py
+++ b/packages/google-cloud-apigee-registry/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/tests/unit/__init__.py
+++ b/packages/google-cloud-apigee-registry/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-apigee-registry/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apigee-registry/tests/unit/gapic/apigee_registry_v1/__init__.py
+++ b/packages/google-cloud-apigee-registry/tests/unit/gapic/apigee_registry_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/.flake8
+++ b/packages/google-cloud-apihub/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/MANIFEST.in
+++ b/packages/google-cloud-apihub/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub/gapic_version.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/gapic_version.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_collect/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_curate/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_dependencies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_discovery/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/api_hub_plugin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/host_project_registration_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/linting_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/provisioning/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/async_client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/client.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/pagers.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/grpc.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/rest.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/rest_base.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/services/runtime_project_attachment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/__init__.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/apihub_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/apihub_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/collect_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/collect_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/common_fields.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/common_fields.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/curate_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/curate_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/discovery_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/discovery_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/host_project_registration_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/host_project_registration_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/linting_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/linting_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/plugin_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/plugin_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/provisioning_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/provisioning_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/google/cloud/apihub_v1/types/runtime_project_attachment_service.py
+++ b/packages/google-cloud-apihub/google/cloud/apihub_v1/types/runtime_project_attachment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_collect_collect_api_data_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_collect_collect_api_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_operation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_operation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_attribute_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_attribute_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_deployment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_deployment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_external_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_external_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_external_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_external_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_spec_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_spec_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_version_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_version_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_create_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_create_curation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_create_curation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_create_curation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_create_curation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_delete_curation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_delete_curation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_delete_curation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_delete_curation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_get_curation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_get_curation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_get_curation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_get_curation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_list_curations_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_list_curations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_list_curations_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_list_curations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_update_curation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_update_curation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_update_curation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_curate_update_curation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_operation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_operation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_attribute_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_attribute_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_deployment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_deployment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_external_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_external_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_external_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_external_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_spec_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_spec_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_version_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_version_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_create_dependency_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_create_dependency_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_create_dependency_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_create_dependency_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_delete_dependency_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_delete_dependency_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_delete_dependency_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_delete_dependency_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_get_dependency_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_get_dependency_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_get_dependency_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_get_dependency_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_list_dependencies_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_list_dependencies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_list_dependencies_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_list_dependencies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_update_dependency_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_update_dependency_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_update_dependency_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_dependencies_update_dependency_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_observation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_observation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_observation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_observation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_operation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_operation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_get_discovered_api_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_observations_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_observations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_observations_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_observations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_operations_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_operations_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_discovery_list_discovered_api_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_operation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_operation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_attribute_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_attribute_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_definition_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_definition_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_definition_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_definition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_deployment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_deployment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_external_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_external_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_external_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_external_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_contents_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_contents_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_version_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_version_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_api_operations_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_api_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_api_operations_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_api_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_apis_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_apis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_apis_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_apis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_attributes_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_attributes_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_deployments_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_deployments_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_external_apis_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_external_apis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_external_apis_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_external_apis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_specs_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_specs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_specs_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_specs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_versions_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_versions_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_create_plugin_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_create_plugin_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_create_plugin_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_create_plugin_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_create_plugin_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_create_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_delete_plugin_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_delete_plugin_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_delete_plugin_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_delete_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_disable_plugin_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_disable_plugin_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_disable_plugin_instance_action_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_disable_plugin_instance_action_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_disable_plugin_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_disable_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_enable_plugin_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_enable_plugin_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_enable_plugin_instance_action_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_enable_plugin_instance_action_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_enable_plugin_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_enable_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_execute_plugin_instance_action_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_execute_plugin_instance_action_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_instance_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_get_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugin_instances_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugin_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugin_instances_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugin_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugins_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugins_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugins_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_list_plugins_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_update_plugin_instance_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_update_plugin_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_update_plugin_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_plugin_update_plugin_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_search_resources_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_search_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_search_resources_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_search_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_operation_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_operation_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_attribute_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_attribute_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_deployment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_deployment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_external_api_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_external_api_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_external_api_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_external_api_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_spec_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_spec_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_version_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_version_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_api_hub_update_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_create_host_project_registration_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_create_host_project_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_create_host_project_registration_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_create_host_project_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_get_host_project_registration_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_get_host_project_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_get_host_project_registration_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_get_host_project_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_list_host_project_registrations_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_list_host_project_registrations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_list_host_project_registrations_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_host_project_registration_service_list_host_project_registrations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_contents_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_contents_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_get_style_guide_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_lint_spec_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_lint_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_lint_spec_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_lint_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_update_style_guide_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_update_style_guide_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_update_style_guide_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_linting_service_update_style_guide_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_create_api_hub_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_create_api_hub_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_delete_api_hub_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_delete_api_hub_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_get_api_hub_instance_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_get_api_hub_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_get_api_hub_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_get_api_hub_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_lookup_api_hub_instance_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_lookup_api_hub_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_lookup_api_hub_instance_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_provisioning_lookup_api_hub_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_create_runtime_project_attachment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_create_runtime_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_create_runtime_project_attachment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_create_runtime_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_delete_runtime_project_attachment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_delete_runtime_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_delete_runtime_project_attachment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_delete_runtime_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_get_runtime_project_attachment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_get_runtime_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_get_runtime_project_attachment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_get_runtime_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_list_runtime_project_attachments_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_list_runtime_project_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_list_runtime_project_attachments_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_list_runtime_project_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_lookup_runtime_project_attachment_async.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_lookup_runtime_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_lookup_runtime_project_attachment_sync.py
+++ b/packages/google-cloud-apihub/samples/generated_samples/apihub_v1_generated_runtime_project_attachment_service_lookup_runtime_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/tests/__init__.py
+++ b/packages/google-cloud-apihub/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/tests/unit/__init__.py
+++ b/packages/google-cloud-apihub/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-apihub/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apihub/tests/unit/gapic/apihub_v1/__init__.py
+++ b/packages/google-cloud-apihub/tests/unit/gapic/apihub_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/.flake8
+++ b/packages/google-cloud-apiregistry/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/MANIFEST.in
+++ b/packages/google-cloud-apiregistry/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry/__init__.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry/gapic_version.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/gapic_version.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/__init__.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/__init__.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/async_client.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/client.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/pagers.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/__init__.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/base.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/grpc.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/rest.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/rest_base.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/services/cloud_api_registry/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/__init__.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/common.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/resources.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/service.py
+++ b/packages/google-cloud-apiregistry/google/cloud/apiregistry_v1beta/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_server_async.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_server_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_server_sync.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_tool_async.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_tool_sync.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_get_mcp_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_servers_async.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_servers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_servers_sync.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_servers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_tools_async.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_tools_sync.py
+++ b/packages/google-cloud-apiregistry/samples/generated_samples/cloudapiregistry_v1beta_generated_cloud_api_registry_list_mcp_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/tests/__init__.py
+++ b/packages/google-cloud-apiregistry/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/tests/unit/__init__.py
+++ b/packages/google-cloud-apiregistry/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-apiregistry/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apiregistry/tests/unit/gapic/apiregistry_v1beta/__init__.py
+++ b/packages/google-cloud-apiregistry/tests/unit/gapic/apiregistry_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/.flake8
+++ b/packages/google-cloud-appengine-admin/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/MANIFEST.in
+++ b/packages/google-cloud-appengine-admin/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin/gapic_version.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/gapic_version.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/applications/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/async_client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_certificates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/async_client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/authorized_domains/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/domain_mappings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/async_client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/firewall/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/client.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/pagers.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/grpc.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/rest.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/rest_base.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/services/versions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/__init__.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/app_yaml.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/app_yaml.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/appengine.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/appengine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/application.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/application.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/audit_data.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/audit_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/certificate.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/certificate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/deploy.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/deploy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/deployed_files.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/deployed_files.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/domain.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/domain.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/domain_mapping.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/domain_mapping.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/firewall.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/firewall.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/instance.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/location.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/location.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/network_settings.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/network_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/operation.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/operation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/service.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/version.py
+++ b/packages/google-cloud-appengine-admin/google/cloud/appengine_admin_v1/types/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_create_application_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_create_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_get_application_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_get_application_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_get_application_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_get_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_repair_application_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_repair_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_update_application_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_applications_update_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_create_authorized_certificate_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_create_authorized_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_create_authorized_certificate_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_create_authorized_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_delete_authorized_certificate_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_delete_authorized_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_delete_authorized_certificate_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_delete_authorized_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_get_authorized_certificate_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_get_authorized_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_get_authorized_certificate_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_get_authorized_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_list_authorized_certificates_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_list_authorized_certificates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_list_authorized_certificates_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_list_authorized_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_update_authorized_certificate_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_update_authorized_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_update_authorized_certificate_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_certificates_update_authorized_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_domains_list_authorized_domains_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_domains_list_authorized_domains_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_domains_list_authorized_domains_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_authorized_domains_list_authorized_domains_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_create_domain_mapping_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_create_domain_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_delete_domain_mapping_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_delete_domain_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_get_domain_mapping_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_get_domain_mapping_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_get_domain_mapping_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_get_domain_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_list_domain_mappings_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_list_domain_mappings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_list_domain_mappings_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_list_domain_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_update_domain_mapping_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_domain_mappings_update_domain_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_batch_update_ingress_rules_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_batch_update_ingress_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_batch_update_ingress_rules_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_batch_update_ingress_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_create_ingress_rule_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_create_ingress_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_create_ingress_rule_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_create_ingress_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_delete_ingress_rule_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_delete_ingress_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_delete_ingress_rule_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_delete_ingress_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_get_ingress_rule_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_get_ingress_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_get_ingress_rule_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_get_ingress_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_list_ingress_rules_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_list_ingress_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_list_ingress_rules_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_list_ingress_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_update_ingress_rule_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_update_ingress_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_update_ingress_rule_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_firewall_update_ingress_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_debug_instance_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_debug_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_delete_instance_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_get_instance_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_get_instance_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_list_instances_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_list_instances_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_instances_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_delete_service_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_get_service_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_get_service_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_list_services_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_list_services_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_update_service_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_services_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_create_version_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_create_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_delete_version_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_get_version_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_get_version_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_list_versions_async.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_list_versions_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_update_version_sync.py
+++ b/packages/google-cloud-appengine-admin/samples/generated_samples/appengine_v1_generated_versions_update_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/tests/__init__.py
+++ b/packages/google-cloud-appengine-admin/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/tests/unit/__init__.py
+++ b/packages/google-cloud-appengine-admin/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-appengine-admin/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-admin/tests/unit/gapic/appengine_admin_v1/__init__.py
+++ b/packages/google-cloud-appengine-admin/tests/unit/gapic/appengine_admin_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/.flake8
+++ b/packages/google-cloud-appengine-logging/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/MANIFEST.in
+++ b/packages/google-cloud-appengine-logging/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/google/cloud/appengine_logging/__init__.py
+++ b/packages/google-cloud-appengine-logging/google/cloud/appengine_logging/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/google/cloud/appengine_logging/gapic_version.py
+++ b/packages/google-cloud-appengine-logging/google/cloud/appengine_logging/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/gapic_version.py
+++ b/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/services/__init__.py
+++ b/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/types/__init__.py
+++ b/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/types/request_log.py
+++ b/packages/google-cloud-appengine-logging/google/cloud/appengine_logging_v1/types/request_log.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/tests/__init__.py
+++ b/packages/google-cloud-appengine-logging/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/tests/unit/__init__.py
+++ b/packages/google-cloud-appengine-logging/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-appengine-logging/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appengine-logging/tests/unit/gapic/appengine_logging_v1/__init__.py
+++ b/packages/google-cloud-appengine-logging/tests/unit/gapic/appengine_logging_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/.flake8
+++ b/packages/google-cloud-apphub/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/MANIFEST.in
+++ b/packages/google-cloud-apphub/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub/__init__.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub/gapic_version.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/gapic_version.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/__init__.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/__init__.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/client.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/pagers.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/__init__.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/base.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/grpc.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/grpc_asyncio.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/rest.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/rest_base.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/services/app_hub/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/__init__.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/apphub_service.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/apphub_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/application.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/application.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/attributes.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/service.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/service_project_attachment.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/service_project_attachment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/google/cloud/apphub_v1/types/workload.py
+++ b/packages/google-cloud-apphub/google/cloud/apphub_v1/types/workload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_application_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_service_project_attachment_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_service_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_service_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_workload_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_create_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_application_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_service_project_attachment_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_service_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_service_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_workload_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_delete_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_detach_service_project_attachment_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_detach_service_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_detach_service_project_attachment_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_detach_service_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_application_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_application_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_application_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_service_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_service_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_workload_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_workload_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_discovered_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_project_attachment_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_project_attachment_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_workload_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_workload_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_get_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_applications_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_applications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_applications_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_services_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_services_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_workloads_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_workloads_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_discovered_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_service_project_attachments_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_service_project_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_service_project_attachments_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_service_project_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_services_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_services_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_workloads_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_workloads_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_service_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_service_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_workload_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_workload_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_discovered_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_service_project_attachment_async.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_service_project_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_service_project_attachment_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_lookup_service_project_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_update_application_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_update_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_update_service_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_update_workload_sync.py
+++ b/packages/google-cloud-apphub/samples/generated_samples/apphub_v1_generated_app_hub_update_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/tests/__init__.py
+++ b/packages/google-cloud-apphub/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/tests/unit/__init__.py
+++ b/packages/google-cloud-apphub/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-apphub/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-apphub/tests/unit/gapic/apphub_v1/__init__.py
+++ b/packages/google-cloud-apphub/tests/unit/gapic/apphub_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/.flake8
+++ b/packages/google-cloud-appoptimize/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/MANIFEST.in
+++ b/packages/google-cloud-appoptimize/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize/__init__.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize/gapic_version.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/gapic_version.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/__init__.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/__init__.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/client.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/pagers.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/__init__.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/base.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/grpc.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/grpc_asyncio.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/rest.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/rest_base.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/services/app_optimize/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/types/__init__.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/types/app_optimize.py
+++ b/packages/google-cloud-appoptimize/google/cloud/appoptimize_v1beta/types/app_optimize.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_create_report_sync.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_create_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_delete_report_async.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_delete_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_delete_report_sync.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_delete_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_get_report_async.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_get_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_get_report_sync.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_get_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_list_reports_async.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_list_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_list_reports_sync.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_list_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_read_report_async.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_read_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_read_report_sync.py
+++ b/packages/google-cloud-appoptimize/samples/generated_samples/appoptimize_v1beta_generated_app_optimize_read_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/tests/__init__.py
+++ b/packages/google-cloud-appoptimize/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/tests/unit/__init__.py
+++ b/packages/google-cloud-appoptimize/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-appoptimize/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-appoptimize/tests/unit/gapic/appoptimize_v1beta/__init__.py
+++ b/packages/google-cloud-appoptimize/tests/unit/gapic/appoptimize_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/.flake8
+++ b/packages/google-cloud-artifact-registry/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/MANIFEST.in
+++ b/packages/google-cloud-artifact-registry/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry/gapic_version.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/gapic_version.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/client.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/pagers.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/base.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/grpc.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/grpc_asyncio.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/rest.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/rest_base.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/services/artifact_registry/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/apt_artifact.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/apt_artifact.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/artifact.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/artifact.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/attachment.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/attachment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/export.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/file.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/generic.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/generic.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/go.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/go.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/kfp_artifact.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/kfp_artifact.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/package.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/package.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/repository.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/repository.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/rule.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/rule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/service.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/settings.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/tag.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/tag.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/version.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/vpcsc_config.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/vpcsc_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/yum_artifact.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1/types/yum_artifact.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/gapic_version.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/client.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/pagers.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/base.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/grpc.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/grpc_asyncio.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/rest.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/rest_base.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/services/artifact_registry/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/__init__.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/apt_artifact.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/apt_artifact.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/file.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/package.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/package.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/repository.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/repository.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/service.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/settings.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/tag.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/tag.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/version.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/yum_artifact.py
+++ b/packages/google-cloud-artifact-registry/google/cloud/artifactregistry_v1beta2/types/yum_artifact.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_batch_delete_versions_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_batch_delete_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_attachment_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_rule_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_rule_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_create_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_attachment_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_file_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_rule_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_rule_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_version_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_export_artifact_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_export_artifact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_attachment_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_attachment_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_docker_image_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_docker_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_docker_image_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_docker_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_file_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_file_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_iam_policy_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_iam_policy_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_maven_artifact_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_maven_artifact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_maven_artifact_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_maven_artifact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_npm_package_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_npm_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_npm_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_npm_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_package_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_project_settings_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_project_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_project_settings_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_project_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_python_package_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_python_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_python_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_python_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_repository_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_rule_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_rule_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_version_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_version_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_vpcsc_config_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_vpcsc_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_vpcsc_config_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_get_vpcsc_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_import_apt_artifacts_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_import_apt_artifacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_import_yum_artifacts_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_import_yum_artifacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_attachments_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_attachments_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_docker_images_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_docker_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_docker_images_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_docker_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_files_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_files_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_maven_artifacts_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_maven_artifacts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_maven_artifacts_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_maven_artifacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_npm_packages_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_npm_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_npm_packages_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_npm_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_packages_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_packages_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_python_packages_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_python_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_python_packages_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_python_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_repositories_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_repositories_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_rules_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_rules_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_tags_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_tags_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_versions_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_versions_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_set_iam_policy_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_set_iam_policy_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_test_iam_permissions_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_test_iam_permissions_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_file_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_file_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_package_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_project_settings_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_project_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_project_settings_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_project_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_repository_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_rule_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_rule_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_version_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_version_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_vpcsc_config_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_vpcsc_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_vpcsc_config_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1_generated_artifact_registry_update_vpcsc_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_create_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_create_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_create_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_create_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_create_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_create_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_version_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_file_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_file_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_iam_policy_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_iam_policy_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_package_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_package_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_project_settings_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_project_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_project_settings_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_project_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_repository_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_version_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_version_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_import_apt_artifacts_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_import_apt_artifacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_import_yum_artifacts_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_import_yum_artifacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_files_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_files_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_packages_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_packages_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_repositories_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_repositories_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_tags_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_tags_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_versions_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_versions_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_set_iam_policy_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_set_iam_policy_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_test_iam_permissions_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_test_iam_permissions_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_project_settings_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_project_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_project_settings_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_project_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_repository_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_repository_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_tag_async.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_tag_sync.py
+++ b/packages/google-cloud-artifact-registry/samples/generated_samples/artifactregistry_v1beta2_generated_artifact_registry_update_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/tests/__init__.py
+++ b/packages/google-cloud-artifact-registry/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/tests/unit/__init__.py
+++ b/packages/google-cloud-artifact-registry/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-artifact-registry/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/tests/unit/gapic/artifactregistry_v1/__init__.py
+++ b/packages/google-cloud-artifact-registry/tests/unit/gapic/artifactregistry_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-artifact-registry/tests/unit/gapic/artifactregistry_v1beta2/__init__.py
+++ b/packages/google-cloud-artifact-registry/tests/unit/gapic/artifactregistry_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/.flake8
+++ b/packages/google-cloud-asset/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/MANIFEST.in
+++ b/packages/google-cloud-asset/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset/gapic_version.py
+++ b/packages/google-cloud-asset/google/cloud/asset/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/gapic_version.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/pagers.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/grpc.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/rest_base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/services/asset_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/types/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/types/asset_enrichment_resourceowners.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/types/asset_enrichment_resourceowners.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/types/asset_service.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/types/asset_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1/types/assets.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1/types/assets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/gapic_version.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/async_client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/pagers.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/grpc.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/rest.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/rest_base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/services/asset_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/types/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/types/asset_service.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/types/asset_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/types/assets.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p1beta1/types/assets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/gapic_version.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/async_client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/grpc.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/rest.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/rest_base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/services/asset_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/types/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/types/asset_service.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/types/asset_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/types/assets.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p2beta1/types/assets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/gapic_version.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/async_client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/client.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/pagers.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/grpc.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/rest.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/rest_base.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/services/asset_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/types/__init__.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/types/asset_service.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/types/asset_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/types/assets.py
+++ b/packages/google-cloud-asset/google/cloud/asset_v1p5beta1/types/assets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_longrunning_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_longrunning_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_move_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_move_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_move_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policies_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policies_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_assets_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_assets_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_containers_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_containers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_containers_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_containers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_assets_history_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_assets_history_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_assets_history_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_assets_history_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_effective_iam_policies_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_effective_iam_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_effective_iam_policies_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_effective_iam_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_saved_query_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_saved_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_saved_query_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_saved_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_saved_query_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_saved_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_saved_query_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_delete_saved_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_export_assets_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_export_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_saved_query_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_saved_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_saved_query_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_saved_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_assets_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_assets_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_feeds_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_feeds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_feeds_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_feeds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_saved_queries_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_saved_queries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_saved_queries_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_saved_queries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_query_assets_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_query_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_query_assets_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_query_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_iam_policies_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_iam_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_iam_policies_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_iam_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_resources_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_resources_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_saved_query_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_saved_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_saved_query_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_saved_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_iam_policies_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_iam_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_iam_policies_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_iam_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_resources_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_resources_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p1beta1_generated_asset_service_search_all_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_create_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_create_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_create_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_create_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_delete_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_delete_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_delete_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_delete_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_get_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_get_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_get_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_get_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_list_feeds_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_list_feeds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_list_feeds_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_list_feeds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_update_feed_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_update_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_update_feed_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p2beta1_generated_asset_service_update_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p5beta1_generated_asset_service_list_assets_async.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p5beta1_generated_asset_service_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p5beta1_generated_asset_service_list_assets_sync.py
+++ b/packages/google-cloud-asset/samples/generated_samples/cloudasset_v1p5beta1_generated_asset_service_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/__init__.py
+++ b/packages/google-cloud-asset/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/unit/__init__.py
+++ b/packages/google-cloud-asset/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-asset/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/unit/gapic/asset_v1/__init__.py
+++ b/packages/google-cloud-asset/tests/unit/gapic/asset_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/unit/gapic/asset_v1p1beta1/__init__.py
+++ b/packages/google-cloud-asset/tests/unit/gapic/asset_v1p1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/unit/gapic/asset_v1p2beta1/__init__.py
+++ b/packages/google-cloud-asset/tests/unit/gapic/asset_v1p2beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-asset/tests/unit/gapic/asset_v1p5beta1/__init__.py
+++ b/packages/google-cloud-asset/tests/unit/gapic/asset_v1p5beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/.flake8
+++ b/packages/google-cloud-assured-workloads/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/MANIFEST.in
+++ b/packages/google-cloud-assured-workloads/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads/gapic_version.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/gapic_version.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/client.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/pagers.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/base.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/grpc.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/rest.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/rest_base.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/services/assured_workloads_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/types/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/types/assuredworkloads.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1/types/assuredworkloads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/gapic_version.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/client.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/pagers.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/base.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/grpc.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/rest.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/rest_base.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/services/assured_workloads_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/types/__init__.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/types/assuredworkloads.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/types/assuredworkloads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/types/assuredworkloads_service.py
+++ b/packages/google-cloud-assured-workloads/google/cloud/assuredworkloads_v1beta1/types/assuredworkloads_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_acknowledge_violation_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_acknowledge_violation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_acknowledge_violation_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_acknowledge_violation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_create_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_create_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_delete_workload_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_delete_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_delete_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_delete_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_violation_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_violation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_violation_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_violation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_workload_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_get_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_violations_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_violations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_violations_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_violations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_workloads_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_workloads_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_restrict_allowed_resources_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_restrict_allowed_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_restrict_allowed_resources_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_restrict_allowed_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_update_workload_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_update_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_update_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1_generated_assured_workloads_service_update_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_analyze_workload_move_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_analyze_workload_move_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_analyze_workload_move_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_analyze_workload_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_create_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_create_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_delete_workload_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_delete_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_delete_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_delete_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_get_workload_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_get_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_get_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_get_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_list_workloads_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_list_workloads_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_restrict_allowed_resources_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_restrict_allowed_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_restrict_allowed_resources_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_restrict_allowed_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_update_workload_async.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_update_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_update_workload_sync.py
+++ b/packages/google-cloud-assured-workloads/samples/generated_samples/assuredworkloads_v1beta1_generated_assured_workloads_service_update_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/tests/__init__.py
+++ b/packages/google-cloud-assured-workloads/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/tests/unit/__init__.py
+++ b/packages/google-cloud-assured-workloads/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-assured-workloads/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/tests/unit/gapic/assuredworkloads_v1/__init__.py
+++ b/packages/google-cloud-assured-workloads/tests/unit/gapic/assuredworkloads_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-assured-workloads/tests/unit/gapic/assuredworkloads_v1beta1/__init__.py
+++ b/packages/google-cloud-assured-workloads/tests/unit/gapic/assuredworkloads_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/.flake8
+++ b/packages/google-cloud-auditmanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/MANIFEST.in
+++ b/packages/google-cloud-auditmanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager/__init__.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager/gapic_version.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/gapic_version.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/__init__.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/__init__.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/client.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/pagers.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/__init__.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/base.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/grpc.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/rest.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/rest_base.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/services/audit_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/types/__init__.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/types/auditmanager.py
+++ b/packages/google-cloud-auditmanager/google/cloud/auditmanager_v1/types/auditmanager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_enroll_resource_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_enroll_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_enroll_resource_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_enroll_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_generate_audit_report_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_generate_audit_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_generate_audit_scope_report_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_generate_audit_scope_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_generate_audit_scope_report_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_generate_audit_scope_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_audit_report_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_audit_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_audit_report_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_audit_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_resource_enrollment_status_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_resource_enrollment_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_resource_enrollment_status_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_get_resource_enrollment_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_audit_reports_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_audit_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_audit_reports_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_audit_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_controls_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_controls_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_resource_enrollment_statuses_async.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_resource_enrollment_statuses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_resource_enrollment_statuses_sync.py
+++ b/packages/google-cloud-auditmanager/samples/generated_samples/auditmanager_v1_generated_audit_manager_list_resource_enrollment_statuses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/tests/__init__.py
+++ b/packages/google-cloud-auditmanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/tests/unit/__init__.py
+++ b/packages/google-cloud-auditmanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-auditmanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-auditmanager/tests/unit/gapic/auditmanager_v1/__init__.py
+++ b/packages/google-cloud-auditmanager/tests/unit/gapic/auditmanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/.flake8
+++ b/packages/google-cloud-automl/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/MANIFEST.in
+++ b/packages/google-cloud-automl/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl/gapic_version.py
+++ b/packages/google-cloud-automl/google/cloud/automl/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/gapic_version.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/client.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/pagers.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/grpc.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/grpc_asyncio.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/rest.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/rest_base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/auto_ml/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/client.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/grpc.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/rest.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/rest_base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/annotation_payload.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/annotation_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/annotation_spec.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/annotation_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/classification.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/classification.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/data_items.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/data_items.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/dataset.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/detection.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/geometry.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/image.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/model.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/model_evaluation.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/model_evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/operations.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/prediction_service.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/service.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/text.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/text.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/text_extraction.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/text_extraction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/text_segment.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/text_segment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/text_sentiment.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/text_sentiment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1/types/translation.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1/types/translation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/gapic_version.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/client.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/pagers.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/grpc.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/grpc_asyncio.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/rest.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/rest_base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/auto_ml/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/client.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/grpc.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/rest.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/rest_base.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/__init__.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/annotation_payload.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/annotation_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/annotation_spec.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/annotation_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/classification.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/classification.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/column_spec.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/column_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/data_items.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/data_items.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/data_stats.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/data_stats.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/data_types.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/data_types.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/dataset.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/detection.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/geometry.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/image.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/io.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/io.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/model.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/model_evaluation.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/model_evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/operations.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/prediction_service.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/ranges.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/ranges.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/regression.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/regression.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/service.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/table_spec.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/table_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/tables.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/tables.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/temporal.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/temporal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text_extraction.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text_extraction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text_segment.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text_segment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text_sentiment.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/text_sentiment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/translation.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/translation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/video.py
+++ b/packages/google-cloud-automl/google/cloud/automl_v1beta1/types/video.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_create_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_create_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_create_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_delete_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_delete_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_delete_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_deploy_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_deploy_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_export_data_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_export_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_export_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_annotation_spec_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_annotation_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_annotation_spec_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_annotation_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_dataset_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_evaluation_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_evaluation_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_import_data_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_datasets_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_datasets_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_model_evaluations_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_model_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_model_evaluations_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_model_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_models_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_models_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_undeploy_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_undeploy_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_dataset_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_model_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_auto_ml_update_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_prediction_service_batch_predict_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_prediction_service_batch_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_prediction_service_predict_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_prediction_service_predict_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_create_dataset_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_create_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_create_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_create_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_create_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_delete_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_delete_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_delete_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_deploy_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_deploy_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_export_data_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_export_evaluated_examples_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_export_evaluated_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_export_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_export_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_annotation_spec_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_annotation_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_annotation_spec_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_annotation_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_column_spec_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_column_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_column_spec_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_column_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_dataset_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_evaluation_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_evaluation_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_table_spec_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_table_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_table_spec_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_get_table_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_import_data_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_column_specs_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_column_specs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_column_specs_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_column_specs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_datasets_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_datasets_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_model_evaluations_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_model_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_model_evaluations_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_model_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_models_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_models_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_table_specs_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_table_specs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_table_specs_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_list_table_specs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_undeploy_model_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_undeploy_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_column_spec_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_column_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_column_spec_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_column_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_dataset_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_dataset_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_table_spec_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_table_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_table_spec_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_auto_ml_update_table_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_prediction_service_batch_predict_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_prediction_service_batch_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_prediction_service_predict_async.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_prediction_service_predict_sync.py
+++ b/packages/google-cloud-automl/samples/generated_samples/automl_v1beta1_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/tests/__init__.py
+++ b/packages/google-cloud-automl/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/tests/unit/__init__.py
+++ b/packages/google-cloud-automl/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-automl/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/tests/unit/gapic/automl_v1/__init__.py
+++ b/packages/google-cloud-automl/tests/unit/gapic/automl_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-automl/tests/unit/gapic/automl_v1beta1/__init__.py
+++ b/packages/google-cloud-automl/tests/unit/gapic/automl_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/.flake8
+++ b/packages/google-cloud-backupdr/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/MANIFEST.in
+++ b/packages/google-cloud-backupdr/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr/gapic_version.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/gapic_version.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/client.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/pagers.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/base.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/grpc.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/grpc_asyncio.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/rest.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/rest_base.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/async_client.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/client.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/pagers.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/base.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/grpc.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/grpc_asyncio.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/rest.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/rest_base.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/services/backup_dr_protection_summary/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/__init__.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupdr.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupdr.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupplan.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupplan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupplanassociation.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupplanassociation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_alloydb.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_alloydb.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_ba.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_ba.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_cloudsql.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_cloudsql.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_disk.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_disk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_gce.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/backupvault_gce.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/datasourcereference.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/datasourcereference.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/protection_summary.py
+++ b/packages/google-cloud-backupdr/google/cloud/backupdr_v1/types/protection_summary.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_backup_plan_association_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_backup_plan_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_backup_plan_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_backup_vault_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_management_server_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_create_management_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_plan_association_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_plan_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_plan_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_vault_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_management_server_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_delete_management_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backup_plan_associations_for_resource_type_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backup_plan_associations_for_resource_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backup_plan_associations_for_resource_type_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backup_plan_associations_for_resource_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backups_for_resource_type_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backups_for_resource_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backups_for_resource_type_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_backups_for_resource_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_data_source_references_for_resource_type_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_data_source_references_for_resource_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_data_source_references_for_resource_type_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_data_source_references_for_resource_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_usable_backup_vaults_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_usable_backup_vaults_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_usable_backup_vaults_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_fetch_usable_backup_vaults_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_association_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_association_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_revision_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_revision_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_vault_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_vault_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_vault_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_reference_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_reference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_reference_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_reference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_management_server_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_management_server_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_management_server_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_get_management_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_initialize_service_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_initialize_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_associations_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_associations_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_revisions_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_revisions_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plan_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plans_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plans_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plans_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_plans_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_vaults_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_vaults_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_vaults_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backup_vaults_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backups_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backups_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_source_references_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_source_references_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_source_references_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_source_references_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_sources_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_sources_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_data_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_management_servers_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_management_servers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_management_servers_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_list_management_servers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_protection_summary_list_resource_backup_configs_async.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_protection_summary_list_resource_backup_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_protection_summary_list_resource_backup_configs_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_protection_summary_list_resource_backup_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_restore_backup_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_restore_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_trigger_backup_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_trigger_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_plan_association_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_plan_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_plan_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_vault_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_data_source_sync.py
+++ b/packages/google-cloud-backupdr/samples/generated_samples/backupdr_v1_generated_backup_dr_update_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/tests/__init__.py
+++ b/packages/google-cloud-backupdr/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/tests/unit/__init__.py
+++ b/packages/google-cloud-backupdr/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-backupdr/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-backupdr/tests/unit/gapic/backupdr_v1/__init__.py
+++ b/packages/google-cloud-backupdr/tests/unit/gapic/backupdr_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/.flake8
+++ b/packages/google-cloud-bare-metal-solution/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/MANIFEST.in
+++ b/packages/google-cloud-bare-metal-solution/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution/gapic_version.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/gapic_version.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/client.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/pagers.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/base.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/grpc.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/rest.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/rest_base.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/services/bare_metal_solution/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/baremetalsolution.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/baremetalsolution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/common.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/instance.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/lun.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/lun.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/network.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/network.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/nfs_share.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/nfs_share.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/osimage.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/osimage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/provisioning.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/provisioning.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/ssh_key.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/ssh_key.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/volume.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/volume.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/volume_snapshot.py
+++ b/packages/google-cloud-bare-metal-solution/google/cloud/bare_metal_solution_v2/types/volume_snapshot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_nfs_share_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_nfs_share_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_provisioning_config_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_provisioning_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_provisioning_config_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_provisioning_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_ssh_key_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_ssh_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_ssh_key_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_ssh_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_volume_snapshot_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_volume_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_volume_snapshot_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_create_volume_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_nfs_share_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_nfs_share_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_ssh_key_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_ssh_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_ssh_key_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_ssh_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_volume_snapshot_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_volume_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_volume_snapshot_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_delete_volume_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_detach_lun_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_detach_lun_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_disable_interactive_serial_console_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_disable_interactive_serial_console_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_enable_interactive_serial_console_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_enable_interactive_serial_console_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_evict_lun_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_evict_lun_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_evict_volume_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_evict_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_instance_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_instance_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_lun_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_lun_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_lun_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_lun_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_network_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_network_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_network_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_nfs_share_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_nfs_share_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_nfs_share_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_nfs_share_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_provisioning_config_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_provisioning_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_provisioning_config_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_provisioning_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_snapshot_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_snapshot_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_get_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_instances_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_instances_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_luns_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_luns_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_luns_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_luns_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_network_usage_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_network_usage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_network_usage_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_network_usage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_networks_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_networks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_networks_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_networks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_nfs_shares_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_nfs_shares_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_nfs_shares_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_nfs_shares_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_os_images_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_os_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_os_images_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_os_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_provisioning_quotas_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_provisioning_quotas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_provisioning_quotas_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_provisioning_quotas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_ssh_keys_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_ssh_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_ssh_keys_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_ssh_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volume_snapshots_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volume_snapshots_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volume_snapshots_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volume_snapshots_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volumes_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volumes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volumes_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_list_volumes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_instance_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_instance_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_network_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_network_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_network_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_nfs_share_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_nfs_share_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_nfs_share_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_nfs_share_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_volume_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_volume_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_volume_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_rename_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_reset_instance_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_reset_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_resize_volume_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_resize_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_restore_volume_snapshot_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_restore_volume_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_start_instance_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_start_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_stop_instance_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_stop_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_submit_provisioning_config_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_submit_provisioning_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_submit_provisioning_config_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_submit_provisioning_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_instance_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_network_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_nfs_share_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_nfs_share_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_provisioning_config_async.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_provisioning_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_provisioning_config_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_provisioning_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_volume_sync.py
+++ b/packages/google-cloud-bare-metal-solution/samples/generated_samples/baremetalsolution_v2_generated_bare_metal_solution_update_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/tests/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/tests/unit/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bare-metal-solution/tests/unit/gapic/bare_metal_solution_v2/__init__.py
+++ b/packages/google-cloud-bare-metal-solution/tests/unit/gapic/bare_metal_solution_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/.flake8
+++ b/packages/google-cloud-batch/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/MANIFEST.in
+++ b/packages/google-cloud-batch/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch/gapic_version.py
+++ b/packages/google-cloud-batch/google/cloud/batch/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/gapic_version.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/client.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/pagers.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/base.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/grpc.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/rest.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/rest_base.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/services/batch_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/types/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/types/batch.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/types/batch.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/types/job.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/types/task.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/types/task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1/types/volume.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1/types/volume.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/gapic_version.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/client.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/pagers.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/base.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/grpc.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/rest.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/rest_base.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/services/batch_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/__init__.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/batch.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/batch.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/job.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/notification.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/notification.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/resource_allowance.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/resource_allowance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/task.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/volume.py
+++ b/packages/google-cloud-batch/google/cloud/batch_v1alpha/types/volume.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_cancel_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_cancel_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_create_job_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_create_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_delete_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_job_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_task_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_task_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_jobs_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_jobs_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_tasks_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_tasks_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1_generated_batch_service_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_cancel_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_cancel_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_job_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_resource_allowance_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_resource_allowance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_resource_allowance_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_create_resource_allowance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_delete_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_delete_resource_allowance_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_delete_resource_allowance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_job_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_resource_allowance_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_resource_allowance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_resource_allowance_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_resource_allowance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_task_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_task_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_jobs_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_jobs_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_resource_allowances_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_resource_allowances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_resource_allowances_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_resource_allowances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_tasks_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_tasks_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_job_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_job_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_resource_allowance_async.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_resource_allowance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_resource_allowance_sync.py
+++ b/packages/google-cloud-batch/samples/generated_samples/batch_v1alpha_generated_batch_service_update_resource_allowance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/tests/__init__.py
+++ b/packages/google-cloud-batch/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/tests/unit/__init__.py
+++ b/packages/google-cloud-batch/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-batch/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/tests/unit/gapic/batch_v1/__init__.py
+++ b/packages/google-cloud-batch/tests/unit/gapic/batch_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-batch/tests/unit/gapic/batch_v1alpha/__init__.py
+++ b/packages/google-cloud-batch/tests/unit/gapic/batch_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/.flake8
+++ b/packages/google-cloud-beyondcorp-appconnections/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/MANIFEST.in
+++ b/packages/google-cloud-beyondcorp-appconnections/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/client.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/pagers.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/base.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/grpc.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/rest.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/rest_base.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/services/app_connections_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/types/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/types/app_connections_service.py
+++ b/packages/google-cloud-beyondcorp-appconnections/google/cloud/beyondcorp_appconnections_v1/types/app_connections_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_create_app_connection_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_create_app_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_delete_app_connection_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_delete_app_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_get_app_connection_async.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_get_app_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_get_app_connection_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_get_app_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_list_app_connections_async.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_list_app_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_list_app_connections_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_list_app_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_resolve_app_connections_async.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_resolve_app_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_resolve_app_connections_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_resolve_app_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_update_app_connection_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnections/samples/generated_samples/beyondcorp_v1_generated_app_connections_service_update_app_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/tests/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/tests/unit/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnections/tests/unit/gapic/beyondcorp_appconnections_v1/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnections/tests/unit/gapic/beyondcorp_appconnections_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/.flake8
+++ b/packages/google-cloud-beyondcorp-appconnectors/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/MANIFEST.in
+++ b/packages/google-cloud-beyondcorp-appconnectors/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/client.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/pagers.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/base.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/grpc.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/rest.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/rest_base.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/services/app_connectors_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/app_connector_instance_config.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/app_connector_instance_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/app_connectors_service.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/app_connectors_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/resource_info.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/google/cloud/beyondcorp_appconnectors_v1/types/resource_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_create_app_connector_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_create_app_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_delete_app_connector_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_delete_app_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_get_app_connector_async.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_get_app_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_get_app_connector_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_get_app_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_list_app_connectors_async.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_list_app_connectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_list_app_connectors_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_list_app_connectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_report_status_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_report_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_update_app_connector_sync.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/samples/generated_samples/beyondcorp_v1_generated_app_connectors_service_update_app_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/tests/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/tests/unit/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appconnectors/tests/unit/gapic/beyondcorp_appconnectors_v1/__init__.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/tests/unit/gapic/beyondcorp_appconnectors_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/.flake8
+++ b/packages/google-cloud-beyondcorp-appgateways/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/MANIFEST.in
+++ b/packages/google-cloud-beyondcorp-appgateways/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/client.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/pagers.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/base.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/grpc.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/rest.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/rest_base.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/services/app_gateways_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/types/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/types/app_gateways_service.py
+++ b/packages/google-cloud-beyondcorp-appgateways/google/cloud/beyondcorp_appgateways_v1/types/app_gateways_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_create_app_gateway_sync.py
+++ b/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_create_app_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_delete_app_gateway_sync.py
+++ b/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_delete_app_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_get_app_gateway_async.py
+++ b/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_get_app_gateway_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_get_app_gateway_sync.py
+++ b/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_get_app_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_list_app_gateways_async.py
+++ b/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_list_app_gateways_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_list_app_gateways_sync.py
+++ b/packages/google-cloud-beyondcorp-appgateways/samples/generated_samples/beyondcorp_v1_generated_app_gateways_service_list_app_gateways_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/tests/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/tests/unit/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-appgateways/tests/unit/gapic/beyondcorp_appgateways_v1/__init__.py
+++ b/packages/google-cloud-beyondcorp-appgateways/tests/unit/gapic/beyondcorp_appgateways_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/.flake8
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/MANIFEST.in
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/client.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/pagers.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/base.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/grpc.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/rest.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/rest_base.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/services/client_connector_services_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/types/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/types/client_connector_services_service.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/google/cloud/beyondcorp_clientconnectorservices_v1/types/client_connector_services_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_create_client_connector_service_sync.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_create_client_connector_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_delete_client_connector_service_sync.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_delete_client_connector_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_get_client_connector_service_async.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_get_client_connector_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_get_client_connector_service_sync.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_get_client_connector_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_list_client_connector_services_async.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_list_client_connector_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_list_client_connector_services_sync.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_list_client_connector_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_update_client_connector_service_sync.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/samples/generated_samples/beyondcorp_v1_generated_client_connector_services_service_update_client_connector_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/tests/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/tests/unit/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/tests/unit/gapic/beyondcorp_clientconnectorservices_v1/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/tests/unit/gapic/beyondcorp_clientconnectorservices_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/.flake8
+++ b/packages/google-cloud-beyondcorp-clientgateways/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/MANIFEST.in
+++ b/packages/google-cloud-beyondcorp-clientgateways/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/gapic_version.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/client.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/pagers.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/base.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/grpc.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/rest.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/rest_base.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/services/client_gateways_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/types/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/types/client_gateways_service.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/google/cloud/beyondcorp_clientgateways_v1/types/client_gateways_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_create_client_gateway_sync.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_create_client_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_delete_client_gateway_sync.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_delete_client_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_get_client_gateway_async.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_get_client_gateway_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_get_client_gateway_sync.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_get_client_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_list_client_gateways_async.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_list_client_gateways_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_list_client_gateways_sync.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/samples/generated_samples/beyondcorp_v1_generated_client_gateways_service_list_client_gateways_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/tests/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/tests/unit/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-beyondcorp-clientgateways/tests/unit/gapic/beyondcorp_clientgateways_v1/__init__.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/tests/unit/gapic/beyondcorp_clientgateways_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/.flake8
+++ b/packages/google-cloud-biglake-hive/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/MANIFEST.in
+++ b/packages/google-cloud-biglake-hive/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive/__init__.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive/gapic_version.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/gapic_version.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/__init__.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/__init__.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/async_client.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/client.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/pagers.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/__init__.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/base.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/grpc.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/rest.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/rest_base.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/services/hive_metastore_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/types/__init__.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/types/hive_metastore.py
+++ b/packages/google-cloud-biglake-hive/google/cloud/biglake_hive_v1beta/types/hive_metastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_create_partitions_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_create_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_create_partitions_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_create_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_delete_partitions_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_delete_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_delete_partitions_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_delete_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_update_partitions_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_update_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_update_partitions_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_batch_update_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_catalog_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_catalog_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_database_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_database_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_table_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_table_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_create_hive_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_catalog_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_catalog_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_database_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_database_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_table_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_table_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_delete_hive_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_catalog_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_catalog_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_database_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_database_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_table_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_table_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_get_hive_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_catalogs_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_catalogs_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_databases_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_databases_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_tables_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_tables_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_hive_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_partitions_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_partitions_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_list_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_catalog_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_catalog_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_database_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_database_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_table_async.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_table_sync.py
+++ b/packages/google-cloud-biglake-hive/samples/generated_samples/biglake_v1beta_generated_hive_metastore_service_update_hive_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/tests/__init__.py
+++ b/packages/google-cloud-biglake-hive/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/tests/unit/__init__.py
+++ b/packages/google-cloud-biglake-hive/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-biglake-hive/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake-hive/tests/unit/gapic/biglake_hive_v1beta/__init__.py
+++ b/packages/google-cloud-biglake-hive/tests/unit/gapic/biglake_hive_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/.flake8
+++ b/packages/google-cloud-biglake/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/MANIFEST.in
+++ b/packages/google-cloud-biglake/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake/__init__.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake/gapic_version.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/gapic_version.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/__init__.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/__init__.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/async_client.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/client.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/pagers.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/__init__.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/base.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/grpc.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/rest.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/rest_base.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/services/iceberg_catalog_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/types/__init__.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/types/iceberg_rest_catalog.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/types/iceberg_rest_catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_create_iceberg_catalog_async.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_create_iceberg_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_create_iceberg_catalog_sync.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_create_iceberg_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_failover_iceberg_catalog_async.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_failover_iceberg_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_failover_iceberg_catalog_sync.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_failover_iceberg_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_get_iceberg_catalog_async.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_get_iceberg_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_get_iceberg_catalog_sync.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_get_iceberg_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_list_iceberg_catalogs_async.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_list_iceberg_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_list_iceberg_catalogs_sync.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_list_iceberg_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_update_iceberg_catalog_async.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_update_iceberg_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_update_iceberg_catalog_sync.py
+++ b/packages/google-cloud-biglake/samples/generated_samples/biglake_v1_generated_iceberg_catalog_service_update_iceberg_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/tests/__init__.py
+++ b/packages/google-cloud-biglake/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/tests/unit/__init__.py
+++ b/packages/google-cloud-biglake/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-biglake/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-biglake/tests/unit/gapic/biglake_v1/__init__.py
+++ b/packages/google-cloud-biglake/tests/unit/gapic/biglake_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/.flake8
+++ b/packages/google-cloud-bigquery-analyticshub/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/MANIFEST.in
+++ b/packages/google-cloud-bigquery-analyticshub/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub/gapic_version.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/client.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/pagers.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/base.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/services/analytics_hub_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/types/analyticshub.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/types/analyticshub.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/types/pubsub.py
+++ b/packages/google-cloud-bigquery-analyticshub/google/cloud/bigquery_analyticshub_v1/types/pubsub.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_approve_query_template_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_approve_query_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_approve_query_template_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_approve_query_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_listing_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_listing_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_query_template_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_query_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_query_template_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_create_query_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_listing_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_listing_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_query_template_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_query_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_query_template_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_query_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_subscription_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_delete_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_listing_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_listing_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_query_template_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_query_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_query_template_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_query_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_subscription_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_subscription_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_get_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_data_exchanges_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_data_exchanges_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_data_exchanges_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_data_exchanges_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_listings_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_listings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_listings_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_listings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_org_data_exchanges_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_org_data_exchanges_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_org_data_exchanges_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_org_data_exchanges_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_query_templates_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_query_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_query_templates_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_query_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_shared_resource_subscriptions_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_shared_resource_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_shared_resource_subscriptions_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_shared_resource_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_subscriptions_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_subscriptions_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_list_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_refresh_subscription_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_refresh_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_revoke_subscription_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_revoke_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_revoke_subscription_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_revoke_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_submit_query_template_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_submit_query_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_submit_query_template_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_submit_query_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_subscribe_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_subscribe_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_subscribe_listing_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_subscribe_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_subscribe_listing_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_subscribe_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_listing_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_listing_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_query_template_async.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_query_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_query_template_sync.py
+++ b/packages/google-cloud-bigquery-analyticshub/samples/generated_samples/analyticshub_v1_generated_analytics_hub_service_update_query_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/tests/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-analyticshub/tests/unit/gapic/bigquery_analyticshub_v1/__init__.py
+++ b/packages/google-cloud-bigquery-analyticshub/tests/unit/gapic/bigquery_analyticshub_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/.flake8
+++ b/packages/google-cloud-bigquery-biglake/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/MANIFEST.in
+++ b/packages/google-cloud-bigquery-biglake/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake/gapic_version.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/async_client.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/client.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/pagers.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/base.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/services/metastore_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/types/metastore.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1/types/metastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/async_client.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/client.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/pagers.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/base.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/services/metastore_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/types/metastore.py
+++ b/packages/google-cloud-bigquery-biglake/google/cloud/bigquery_biglake_v1alpha1/types/metastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_catalog_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_catalog_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_create_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_catalog_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_catalog_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_delete_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_catalog_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_catalog_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_get_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_catalogs_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_catalogs_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_databases_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_databases_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_tables_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_tables_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_list_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_rename_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_rename_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_rename_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_rename_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1_generated_metastore_service_update_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_check_lock_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_check_lock_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_check_lock_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_check_lock_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_catalog_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_catalog_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_lock_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_lock_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_lock_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_lock_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_create_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_catalog_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_catalog_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_lock_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_lock_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_lock_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_lock_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_delete_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_catalog_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_catalog_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_get_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_catalogs_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_catalogs_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_databases_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_databases_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_locks_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_locks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_locks_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_locks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_tables_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_tables_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_list_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_rename_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_rename_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_rename_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_rename_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_database_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_database_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_table_async.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_table_sync.py
+++ b/packages/google-cloud-bigquery-biglake/samples/generated_samples/biglake_v1alpha1_generated_metastore_service_update_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/tests/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/tests/unit/gapic/bigquery_biglake_v1/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/tests/unit/gapic/bigquery_biglake_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-biglake/tests/unit/gapic/bigquery_biglake_v1alpha1/__init__.py
+++ b/packages/google-cloud-bigquery-biglake/tests/unit/gapic/bigquery_biglake_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/.flake8
+++ b/packages/google-cloud-bigquery-connection/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/MANIFEST.in
+++ b/packages/google-cloud-bigquery-connection/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection/__init__.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection/gapic_version.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/__init__.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/async_client.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/client.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/pagers.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/base.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/services/connection_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/types/connection.py
+++ b/packages/google-cloud-bigquery-connection/google/cloud/bigquery_connection_v1/types/connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_create_connection_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_create_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_create_connection_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_create_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_delete_connection_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_delete_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_delete_connection_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_delete_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_connection_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_connection_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_list_connections_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_list_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_list_connections_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_list_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_update_connection_async.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_update_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_update_connection_sync.py
+++ b/packages/google-cloud-bigquery-connection/samples/generated_samples/bigqueryconnection_v1_generated_connection_service_update_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/tests/__init__.py
+++ b/packages/google-cloud-bigquery-connection/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-connection/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-connection/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-connection/tests/unit/gapic/bigquery_connection_v1/__init__.py
+++ b/packages/google-cloud-bigquery-connection/tests/unit/gapic/bigquery_connection_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/.flake8
+++ b/packages/google-cloud-bigquery-data-exchange/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/MANIFEST.in
+++ b/packages/google-cloud-bigquery-data-exchange/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange/gapic_version.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/gapic_version.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/async_client.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/client.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/pagers.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/base.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/services/analytics_hub_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/types/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/types/dataexchange.py
+++ b/packages/google-cloud-bigquery-data-exchange/google/cloud/bigquery_data_exchange_v1beta1/types/dataexchange.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_listing_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_listing_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_create_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_listing_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_listing_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_delete_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_listing_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_listing_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_get_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_data_exchanges_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_data_exchanges_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_data_exchanges_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_data_exchanges_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_listings_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_listings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_listings_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_listings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_org_data_exchanges_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_org_data_exchanges_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_org_data_exchanges_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_list_org_data_exchanges_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_subscribe_listing_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_subscribe_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_subscribe_listing_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_subscribe_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_data_exchange_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_data_exchange_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_data_exchange_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_data_exchange_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_listing_async.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_listing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_listing_sync.py
+++ b/packages/google-cloud-bigquery-data-exchange/samples/generated_samples/analyticshub_v1beta1_generated_analytics_hub_service_update_listing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/tests/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-data-exchange/tests/unit/gapic/bigquery_data_exchange_v1beta1/__init__.py
+++ b/packages/google-cloud-bigquery-data-exchange/tests/unit/gapic/bigquery_data_exchange_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/.flake8
+++ b/packages/google-cloud-bigquery-datapolicies/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/MANIFEST.in
+++ b/packages/google-cloud-bigquery-datapolicies/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies/gapic_version.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/async_client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/pagers.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/services/data_policy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/types/datapolicy.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1/types/datapolicy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/gapic_version.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/async_client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/pagers.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/services/data_policy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/types/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/types/datapolicy.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v1beta1/types/datapolicy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/gapic_version.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/async_client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/pagers.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/services/data_policy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/types/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/types/datapolicy.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2/types/datapolicy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/gapic_version.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/async_client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/client.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/pagers.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/services/data_policy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/types/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/types/datapolicy.py
+++ b/packages/google-cloud-bigquery-datapolicies/google/cloud/bigquery_datapolicies_v2beta1/types/datapolicy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_create_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_create_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_create_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_create_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_delete_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_delete_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_delete_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_delete_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_list_data_policies_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_list_data_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_list_data_policies_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_list_data_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_rename_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_rename_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_rename_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_rename_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_update_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_update_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_update_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1_generated_data_policy_service_update_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_create_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_create_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_create_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_create_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_delete_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_delete_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_delete_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_delete_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_list_data_policies_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_list_data_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_list_data_policies_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_list_data_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_update_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_update_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_update_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v1beta1_generated_data_policy_service_update_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_add_grantees_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_add_grantees_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_add_grantees_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_add_grantees_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_create_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_create_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_create_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_create_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_delete_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_delete_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_delete_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_delete_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_list_data_policies_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_list_data_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_list_data_policies_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_list_data_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_remove_grantees_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_remove_grantees_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_remove_grantees_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_remove_grantees_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_update_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_update_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_update_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2_generated_data_policy_service_update_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_add_grantees_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_add_grantees_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_add_grantees_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_add_grantees_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_create_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_create_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_create_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_create_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_delete_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_delete_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_delete_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_delete_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_list_data_policies_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_list_data_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_list_data_policies_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_list_data_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_remove_grantees_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_remove_grantees_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_remove_grantees_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_remove_grantees_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_update_data_policy_async.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_update_data_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_update_data_policy_sync.py
+++ b/packages/google-cloud-bigquery-datapolicies/samples/generated_samples/bigquerydatapolicy_v2beta1_generated_data_policy_service_update_data_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v1/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v1beta1/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v2/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v2beta1/__init__.py
+++ b/packages/google-cloud-bigquery-datapolicies/tests/unit/gapic/bigquery_datapolicies_v2beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/.flake8
+++ b/packages/google-cloud-bigquery-datatransfer/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/MANIFEST.in
+++ b/packages/google-cloud-bigquery-datatransfer/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer/gapic_version.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/async_client.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/client.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/pagers.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/base.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/types/datatransfer.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/types/datatransfer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/types/transfer.py
+++ b/packages/google-cloud-bigquery-datatransfer/google/cloud/bigquery_datatransfer_v1/types/transfer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_check_valid_creds_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_check_valid_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_check_valid_creds_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_check_valid_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_create_transfer_config_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_create_transfer_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_create_transfer_config_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_create_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_config_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_config_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_run_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_run_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_delete_transfer_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_enroll_data_sources_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_enroll_data_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_enroll_data_sources_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_enroll_data_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_data_source_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_data_source_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_config_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_config_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_run_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_run_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_get_transfer_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_data_sources_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_data_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_data_sources_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_data_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_configs_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_configs_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_logs_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_logs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_logs_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_logs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_runs_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_runs_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_list_transfer_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_schedule_transfer_runs_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_schedule_transfer_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_schedule_transfer_runs_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_schedule_transfer_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_start_manual_transfer_runs_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_start_manual_transfer_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_start_manual_transfer_runs_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_start_manual_transfer_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_unenroll_data_sources_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_unenroll_data_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_unenroll_data_sources_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_unenroll_data_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_update_transfer_config_async.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_update_transfer_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_update_transfer_config_sync.py
+++ b/packages/google-cloud-bigquery-datatransfer/samples/generated_samples/bigquerydatatransfer_v1_generated_data_transfer_service_update_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/tests/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-datatransfer/tests/unit/gapic/bigquery_datatransfer_v1/__init__.py
+++ b/packages/google-cloud-bigquery-datatransfer/tests/unit/gapic/bigquery_datatransfer_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/.flake8
+++ b/packages/google-cloud-bigquery-logging/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/MANIFEST.in
+++ b/packages/google-cloud-bigquery-logging/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging/__init__.py
+++ b/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging/gapic_version.py
+++ b/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/types/audit_data.py
+++ b/packages/google-cloud-bigquery-logging/google/cloud/bigquery_logging_v1/types/audit_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/tests/__init__.py
+++ b/packages/google-cloud-bigquery-logging/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-logging/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-logging/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-logging/tests/unit/gapic/bigquery_logging_v1/__init__.py
+++ b/packages/google-cloud-bigquery-logging/tests/unit/gapic/bigquery_logging_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/.flake8
+++ b/packages/google-cloud-bigquery-migration/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/MANIFEST.in
+++ b/packages/google-cloud-bigquery-migration/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration/gapic_version.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/gapic_version.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/async_client.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/client.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/pagers.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/base.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/services/migration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_entities.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_entities.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_error_details.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_error_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_metrics.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_metrics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_service.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/migration_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_config.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_details.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_suggestion.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_suggestion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_usability.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2/types/translation_usability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/gapic_version.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/async_client.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/client.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/pagers.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/base.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/migration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/async_client.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/client.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/base.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/services/sql_translation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/__init__.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/assessment_task.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/assessment_task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_entities.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_entities.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_error_details.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_error_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_metrics.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_metrics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_service.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/migration_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/translation_service.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/translation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/translation_task.py
+++ b/packages/google-cloud-bigquery-migration/google/cloud/bigquery_migration_v2alpha/types/translation_task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_create_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_create_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_create_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_create_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_delete_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_delete_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_delete_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_delete_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_subtask_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_subtask_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_subtask_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_subtask_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_get_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_subtasks_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_subtasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_subtasks_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_subtasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_workflows_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_workflows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_workflows_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_list_migration_workflows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_start_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_start_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_start_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2_generated_migration_service_start_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_create_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_create_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_create_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_create_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_delete_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_delete_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_delete_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_delete_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_subtask_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_subtask_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_subtask_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_subtask_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_get_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_subtasks_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_subtasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_subtasks_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_subtasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_workflows_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_workflows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_workflows_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_list_migration_workflows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_start_migration_workflow_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_start_migration_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_start_migration_workflow_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_migration_service_start_migration_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_sql_translation_service_translate_query_async.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_sql_translation_service_translate_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_sql_translation_service_translate_query_sync.py
+++ b/packages/google-cloud-bigquery-migration/samples/generated_samples/bigquerymigration_v2alpha_generated_sql_translation_service_translate_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/tests/__init__.py
+++ b/packages/google-cloud-bigquery-migration/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-migration/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-migration/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/tests/unit/gapic/bigquery_migration_v2/__init__.py
+++ b/packages/google-cloud-bigquery-migration/tests/unit/gapic/bigquery_migration_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-migration/tests/unit/gapic/bigquery_migration_v2alpha/__init__.py
+++ b/packages/google-cloud-bigquery-migration/tests/unit/gapic/bigquery_migration_v2alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/.flake8
+++ b/packages/google-cloud-bigquery-reservation/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/MANIFEST.in
+++ b/packages/google-cloud-bigquery-reservation/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation/gapic_version.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/async_client.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/client.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/pagers.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/base.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/rest.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/rest_base.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/services/reservation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/types/reservation.py
+++ b/packages/google-cloud-bigquery-reservation/google/cloud/bigquery_reservation_v1/types/reservation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_assignment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_assignment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_assignment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_capacity_commitment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_capacity_commitment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_capacity_commitment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_capacity_commitment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_group_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_group_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_create_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_assignment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_assignment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_assignment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_capacity_commitment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_capacity_commitment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_capacity_commitment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_capacity_commitment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_group_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_group_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_delete_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_failover_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_failover_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_failover_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_failover_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_bi_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_bi_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_bi_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_bi_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_capacity_commitment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_capacity_commitment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_capacity_commitment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_capacity_commitment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_group_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_group_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_get_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_assignments_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_assignments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_assignments_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_assignments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_capacity_commitments_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_capacity_commitments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_capacity_commitments_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_capacity_commitments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservation_groups_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservation_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservation_groups_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservation_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservations_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservations_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_list_reservations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_merge_capacity_commitments_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_merge_capacity_commitments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_merge_capacity_commitments_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_merge_capacity_commitments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_move_assignment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_move_assignment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_move_assignment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_move_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_all_assignments_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_all_assignments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_all_assignments_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_all_assignments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_assignments_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_assignments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_assignments_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_search_assignments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_set_iam_policy_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_split_capacity_commitment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_split_capacity_commitment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_split_capacity_commitment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_split_capacity_commitment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_assignment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_assignment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_assignment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_bi_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_bi_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_bi_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_bi_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_capacity_commitment_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_capacity_commitment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_capacity_commitment_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_capacity_commitment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_reservation_async.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_reservation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_reservation_sync.py
+++ b/packages/google-cloud-bigquery-reservation/samples/generated_samples/bigqueryreservation_v1_generated_reservation_service_update_reservation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/tests/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-reservation/tests/unit/gapic/bigquery_reservation_v1/__init__.py
+++ b/packages/google-cloud-bigquery-reservation/tests/unit/gapic/bigquery_reservation_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/.flake8
+++ b/packages/google-cloud-bigquery-storage/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/MANIFEST.in
+++ b/packages/google-cloud-bigquery-storage/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage/gapic_version.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/gapic_version.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/async_client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/base.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/grpc.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/async_client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/base.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/grpc.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/annotations.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/annotations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/arrow.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/arrow.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/avro.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/avro.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/protobuf.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/protobuf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/storage.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/storage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/stream.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/stream.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/table.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/table.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/gapic_version.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/async_client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/base.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/services/metastore_partition_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/types/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/types/metastore_partition.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/types/metastore_partition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/types/partition.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1alpha/types/partition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/gapic_version.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/async_client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/base.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/grpc.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/services/metastore_partition_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/types/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/types/metastore_partition.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/types/metastore_partition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/types/partition.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta/types/partition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/gapic_version.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/async_client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/base.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/grpc.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_read/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/async_client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/base.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/grpc.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/__init__.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/arrow.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/arrow.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/avro.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/avro.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/protobuf.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/protobuf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/storage.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/storage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/stream.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/stream.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/table.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/types/table.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_create_read_session_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_create_read_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_create_read_session_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_create_read_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_read_rows_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_read_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_read_rows_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_read_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_split_read_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_split_read_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_split_read_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_read_split_read_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_append_rows_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_append_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_append_rows_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_append_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_batch_commit_write_streams_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_batch_commit_write_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_batch_commit_write_streams_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_batch_commit_write_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_create_write_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_create_write_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_create_write_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_create_write_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_finalize_write_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_finalize_write_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_finalize_write_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_finalize_write_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_flush_rows_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_flush_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_flush_rows_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_flush_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_get_write_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_get_write_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_get_write_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1_generated_big_query_write_get_write_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_create_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_create_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_create_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_create_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_delete_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_delete_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_delete_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_delete_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_update_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_update_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_update_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_batch_update_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_list_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_list_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_list_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_list_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_stream_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_stream_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_stream_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1alpha_generated_metastore_partition_service_stream_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_create_read_session_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_create_read_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_create_read_session_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_create_read_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_read_rows_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_read_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_read_rows_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_read_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_split_read_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_split_read_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_split_read_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_read_split_read_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_append_rows_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_append_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_append_rows_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_append_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_batch_commit_write_streams_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_batch_commit_write_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_batch_commit_write_streams_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_batch_commit_write_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_create_write_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_create_write_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_create_write_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_create_write_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_finalize_write_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_finalize_write_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_finalize_write_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_finalize_write_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_flush_rows_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_flush_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_flush_rows_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_flush_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_get_write_stream_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_get_write_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_get_write_stream_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta2_generated_big_query_write_get_write_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_create_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_create_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_create_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_create_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_delete_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_delete_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_delete_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_delete_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_update_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_update_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_update_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_batch_update_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_list_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_list_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_list_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_list_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_stream_metastore_partitions_async.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_stream_metastore_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_stream_metastore_partitions_sync.py
+++ b/packages/google-cloud-bigquery-storage/samples/generated_samples/bigquerystorage_v1beta_generated_metastore_partition_service_stream_metastore_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/unit/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1alpha/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1beta/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1beta2/__init__.py
+++ b/packages/google-cloud-bigquery-storage/tests/unit/gapic/bigquery_storage_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/.flake8
+++ b/packages/google-cloud-billing-budgets/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/MANIFEST.in
+++ b/packages/google-cloud-billing-budgets/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets/gapic_version.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/gapic_version.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/async_client.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/client.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/pagers.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/base.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/grpc.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/rest.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/rest_base.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/services/budget_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/types/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/types/budget_model.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/types/budget_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/types/budget_service.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1/types/budget_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/gapic_version.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/async_client.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/client.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/pagers.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/base.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/grpc.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/services/budget_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/types/__init__.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/types/budget_model.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/types/budget_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/types/budget_service.py
+++ b/packages/google-cloud-billing-budgets/google/cloud/billing/budgets_v1beta1/types/budget_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_create_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_create_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_create_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_create_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_delete_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_delete_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_delete_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_delete_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_get_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_get_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_get_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_get_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_list_budgets_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_list_budgets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_list_budgets_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_list_budgets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_update_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_update_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_update_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1_generated_budget_service_update_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_create_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_create_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_create_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_create_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_delete_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_delete_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_delete_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_delete_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_get_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_get_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_get_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_get_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_list_budgets_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_list_budgets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_list_budgets_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_list_budgets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_update_budget_async.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_update_budget_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_update_budget_sync.py
+++ b/packages/google-cloud-billing-budgets/samples/generated_samples/billingbudgets_v1beta1_generated_budget_service_update_budget_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/tests/__init__.py
+++ b/packages/google-cloud-billing-budgets/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/tests/unit/__init__.py
+++ b/packages/google-cloud-billing-budgets/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-billing-budgets/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/tests/unit/gapic/budgets_v1/__init__.py
+++ b/packages/google-cloud-billing-budgets/tests/unit/gapic/budgets_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing-budgets/tests/unit/gapic/budgets_v1beta1/__init__.py
+++ b/packages/google-cloud-billing-budgets/tests/unit/gapic/budgets_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/.flake8
+++ b/packages/google-cloud-billing/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/MANIFEST.in
+++ b/packages/google-cloud-billing/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing/gapic_version.py
+++ b/packages/google-cloud-billing/google/cloud/billing/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/gapic_version.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/async_client.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/client.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/pagers.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/base.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/grpc.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/grpc_asyncio.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/rest.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/rest_base.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_billing/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/async_client.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/client.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/pagers.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/base.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/grpc.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/grpc_asyncio.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/rest.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/rest_base.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/services/cloud_catalog/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/types/__init__.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/types/cloud_billing.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/types/cloud_billing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/google/cloud/billing_v1/types/cloud_catalog.py
+++ b/packages/google-cloud-billing/google/cloud/billing_v1/types/cloud_catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_create_billing_account_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_create_billing_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_create_billing_account_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_create_billing_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_billing_account_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_billing_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_billing_account_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_billing_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_iam_policy_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_iam_policy_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_project_billing_info_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_project_billing_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_project_billing_info_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_get_project_billing_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_billing_accounts_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_billing_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_billing_accounts_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_billing_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_project_billing_info_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_project_billing_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_project_billing_info_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_list_project_billing_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_move_billing_account_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_move_billing_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_move_billing_account_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_move_billing_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_set_iam_policy_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_set_iam_policy_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_test_iam_permissions_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_test_iam_permissions_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_billing_account_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_billing_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_billing_account_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_billing_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_project_billing_info_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_project_billing_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_project_billing_info_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_billing_update_project_billing_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_services_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_services_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_skus_async.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_skus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_skus_sync.py
+++ b/packages/google-cloud-billing/samples/generated_samples/cloudbilling_v1_generated_cloud_catalog_list_skus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/tests/__init__.py
+++ b/packages/google-cloud-billing/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/tests/unit/__init__.py
+++ b/packages/google-cloud-billing/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-billing/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-billing/tests/unit/gapic/billing_v1/__init__.py
+++ b/packages/google-cloud-billing/tests/unit/gapic/billing_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/.flake8
+++ b/packages/google-cloud-binary-authorization/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/MANIFEST.in
+++ b/packages/google-cloud-binary-authorization/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization/gapic_version.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/gapic_version.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/async_client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/pagers.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/grpc.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/rest.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/rest_base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/binauthz_management_service_v1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/async_client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/grpc.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/rest.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/rest_base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/system_policy_v1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/async_client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/grpc.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/rest.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/rest_base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/services/validation_helper_v1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/resources.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/service.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/gapic_version.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/async_client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/pagers.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/grpc.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/rest.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/rest_base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/binauthz_management_service_v1_beta1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/async_client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/client.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/grpc.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/rest.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/rest_base.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/services/system_policy_v1_beta1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/__init__.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/continuous_validation_logging.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/continuous_validation_logging.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/resources.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/service.py
+++ b/packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_create_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_create_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_create_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_create_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_delete_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_delete_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_delete_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_delete_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_policy_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_policy_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_get_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_list_attestors_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_list_attestors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_list_attestors_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_list_attestors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_policy_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_policy_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_binauthz_management_service_v1_update_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_system_policy_v1_get_system_policy_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_system_policy_v1_get_system_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_system_policy_v1_get_system_policy_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_system_policy_v1_get_system_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_validation_helper_v1_validate_attestation_occurrence_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_validation_helper_v1_validate_attestation_occurrence_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_validation_helper_v1_validate_attestation_occurrence_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1_generated_validation_helper_v1_validate_attestation_occurrence_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_create_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_create_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_create_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_create_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_delete_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_delete_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_delete_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_delete_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_policy_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_policy_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_get_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_list_attestors_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_list_attestors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_list_attestors_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_list_attestors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_attestor_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_attestor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_attestor_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_attestor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_policy_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_policy_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_binauthz_management_service_v1_beta1_update_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_system_policy_v1_beta1_get_system_policy_async.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_system_policy_v1_beta1_get_system_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_system_policy_v1_beta1_get_system_policy_sync.py
+++ b/packages/google-cloud-binary-authorization/samples/generated_samples/binaryauthorization_v1beta1_generated_system_policy_v1_beta1_get_system_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/tests/__init__.py
+++ b/packages/google-cloud-binary-authorization/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/tests/unit/__init__.py
+++ b/packages/google-cloud-binary-authorization/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-binary-authorization/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/tests/unit/gapic/binaryauthorization_v1/__init__.py
+++ b/packages/google-cloud-binary-authorization/tests/unit/gapic/binaryauthorization_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-binary-authorization/tests/unit/gapic/binaryauthorization_v1beta1/__init__.py
+++ b/packages/google-cloud-binary-authorization/tests/unit/gapic/binaryauthorization_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/.flake8
+++ b/packages/google-cloud-build/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/MANIFEST.in
+++ b/packages/google-cloud-build/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild/gapic_version.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/gapic_version.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/client.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/pagers.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/base.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/grpc.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/grpc_asyncio.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/rest.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/rest_base.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/services/cloud_build/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/types/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/types/cloudbuild.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v1/types/cloudbuild.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/gapic_version.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/client.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/pagers.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/base.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/grpc.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/rest.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/rest_base.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/services/repository_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/types/__init__.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/types/cloudbuild.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/types/cloudbuild.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/types/repositories.py
+++ b/packages/google-cloud-build/google/cloud/devtools/cloudbuild_v2/types/repositories.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_approve_build_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_approve_build_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_cancel_build_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_cancel_build_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_cancel_build_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_cancel_build_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_build_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_build_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_build_trigger_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_build_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_build_trigger_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_build_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_worker_pool_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_create_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_delete_build_trigger_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_delete_build_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_delete_build_trigger_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_delete_build_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_delete_worker_pool_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_delete_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_trigger_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_trigger_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_build_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_default_service_account_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_default_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_default_service_account_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_default_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_worker_pool_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_worker_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_worker_pool_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_get_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_build_triggers_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_build_triggers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_build_triggers_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_build_triggers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_builds_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_builds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_builds_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_builds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_worker_pools_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_worker_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_worker_pools_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_list_worker_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_receive_trigger_webhook_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_receive_trigger_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_receive_trigger_webhook_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_receive_trigger_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_retry_build_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_retry_build_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_run_build_trigger_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_run_build_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_update_build_trigger_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_update_build_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_update_build_trigger_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_update_build_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_update_worker_pool_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v1_generated_cloud_build_update_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_batch_create_repositories_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_batch_create_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_create_connection_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_create_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_create_repository_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_create_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_delete_connection_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_delete_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_delete_repository_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_delete_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_git_refs_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_git_refs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_git_refs_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_git_refs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_linkable_repositories_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_linkable_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_linkable_repositories_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_linkable_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_token_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_token_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_write_token_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_write_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_write_token_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_fetch_read_write_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_connection_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_connection_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_repository_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_repository_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_get_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_connections_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_connections_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_repositories_async.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_repositories_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_list_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_update_connection_sync.py
+++ b/packages/google-cloud-build/samples/generated_samples/cloudbuild_v2_generated_repository_manager_update_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/tests/__init__.py
+++ b/packages/google-cloud-build/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/tests/unit/__init__.py
+++ b/packages/google-cloud-build/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-build/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/tests/unit/gapic/cloudbuild_v1/__init__.py
+++ b/packages/google-cloud-build/tests/unit/gapic/cloudbuild_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-build/tests/unit/gapic/cloudbuild_v2/__init__.py
+++ b/packages/google-cloud-build/tests/unit/gapic/cloudbuild_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/.flake8
+++ b/packages/google-cloud-capacityplanner/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/MANIFEST.in
+++ b/packages/google-cloud-capacityplanner/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner/__init__.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner/gapic_version.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/gapic_version.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/__init__.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/__init__.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/client.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/__init__.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/base.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/grpc.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/rest.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/rest_base.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/services/usage_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/__init__.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/allocation.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/allocation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/future_reservation.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/future_reservation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/location.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/location.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/resource.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_export_forecasts_sync.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_export_forecasts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_export_reservations_usage_sync.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_export_reservations_usage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_export_usage_histories_sync.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_export_usage_histories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_forecasts_async.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_forecasts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_forecasts_sync.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_forecasts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_reservations_async.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_reservations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_reservations_sync.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_reservations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_usage_histories_async.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_usage_histories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_usage_histories_sync.py
+++ b/packages/google-cloud-capacityplanner/samples/generated_samples/capacityplanner_v1beta_generated_usage_service_query_usage_histories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/tests/__init__.py
+++ b/packages/google-cloud-capacityplanner/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/tests/unit/__init__.py
+++ b/packages/google-cloud-capacityplanner/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-capacityplanner/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-capacityplanner/tests/unit/gapic/capacityplanner_v1beta/__init__.py
+++ b/packages/google-cloud-capacityplanner/tests/unit/gapic/capacityplanner_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/.flake8
+++ b/packages/google-cloud-certificate-manager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/MANIFEST.in
+++ b/packages/google-cloud-certificate-manager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager/__init__.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager/gapic_version.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/gapic_version.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/__init__.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/__init__.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/client.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/pagers.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/__init__.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/base.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/grpc.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/rest.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/rest_base.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/services/certificate_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/__init__.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/certificate_issuance_config.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/certificate_issuance_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/certificate_manager.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/certificate_manager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/trust_config.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/trust_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_issuance_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_issuance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_map_entry_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_map_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_map_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_dns_authorization_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_dns_authorization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_trust_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_create_trust_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_issuance_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_issuance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_map_entry_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_map_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_map_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_dns_authorization_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_dns_authorization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_trust_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_delete_trust_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_issuance_config_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_issuance_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_issuance_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_issuance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_entry_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_entry_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_dns_authorization_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_dns_authorization_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_dns_authorization_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_dns_authorization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_trust_config_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_trust_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_trust_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_get_trust_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_issuance_configs_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_issuance_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_issuance_configs_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_issuance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_map_entries_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_map_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_map_entries_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_map_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_maps_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_maps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_maps_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificate_maps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificates_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificates_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_dns_authorizations_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_dns_authorizations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_dns_authorizations_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_dns_authorizations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_trust_configs_async.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_trust_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_trust_configs_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_list_trust_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_certificate_map_entry_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_certificate_map_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_certificate_map_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_certificate_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_dns_authorization_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_dns_authorization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_trust_config_sync.py
+++ b/packages/google-cloud-certificate-manager/samples/generated_samples/certificatemanager_v1_generated_certificate_manager_update_trust_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/tests/__init__.py
+++ b/packages/google-cloud-certificate-manager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/tests/unit/__init__.py
+++ b/packages/google-cloud-certificate-manager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-certificate-manager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-certificate-manager/tests/unit/gapic/certificate_manager_v1/__init__.py
+++ b/packages/google-cloud-certificate-manager/tests/unit/gapic/certificate_manager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/.flake8
+++ b/packages/google-cloud-ces/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/MANIFEST.in
+++ b/packages/google-cloud-ces/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces/gapic_version.py
+++ b/packages/google-cloud-ces/google/cloud/ces/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/gapic_version.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/pagers.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/agent_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/async_client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/session_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/async_client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/tool_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/async_client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/services/widget_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/agent.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/agent_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/agent_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/agent_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/agent_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/agent_transfers.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/agent_transfers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/app.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/app.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/app_version.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/app_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/auth.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/auth.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/bigquery_export.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/bigquery_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/changelog.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/changelog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/client_function.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/client_function.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/common.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/connector_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/connector_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/connector_toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/connector_toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/conversation.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/data_store.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/data_store.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/data_store_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/data_store_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/deployment.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/deployment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/example.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/example.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/fakes.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/fakes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/file_search_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/file_search_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/google_search_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/google_search_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/guardrail.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/guardrail.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/mcp_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/mcp_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/mcp_toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/mcp_toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/omnichannel.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/omnichannel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/omnichannel_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/omnichannel_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/open_api_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/open_api_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/open_api_toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/open_api_toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/python_function.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/python_function.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/schema.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/search_suggestions.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/search_suggestions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/security_settings.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/security_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/session_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/session_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/system_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/system_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/tool_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/tool_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/toolset_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/toolset_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/widget_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/widget_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1/types/widget_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1/types/widget_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/gapic_version.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/pagers.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/agent_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/pagers.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/evaluation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/async_client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/session_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/async_client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/tool_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/async_client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/client.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/grpc.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/rest.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/rest_base.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/services/widget_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/__init__.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent_transfers.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/agent_transfers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/app.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/app.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/app_version.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/app_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/auth.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/auth.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/bigquery_export.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/bigquery_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/changelog.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/changelog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/client_function.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/client_function.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/common.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/connector_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/connector_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/connector_toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/connector_toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/conversation.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/data_store.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/data_store.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/data_store_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/data_store_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/deployment.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/deployment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/evaluation.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/evaluation_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/evaluation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/example.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/example.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/fakes.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/fakes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/file_context.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/file_context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/file_search_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/file_search_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/golden_run.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/golden_run.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/google_search_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/google_search_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/guardrail.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/guardrail.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/mcp_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/mcp_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/mcp_toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/mcp_toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/mocks.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/mocks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/omnichannel.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/omnichannel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/omnichannel_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/omnichannel_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/open_api_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/open_api_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/open_api_toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/open_api_toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/python_function.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/python_function.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/schema.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/search_suggestions.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/search_suggestions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/security_settings.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/security_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/session_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/session_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/system_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/system_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/tool_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/tool_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/toolset.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/toolset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/toolset_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/toolset_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/widget_service.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/widget_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/google/cloud/ces_v1beta/types/widget_tool.py
+++ b/packages/google-cloud-ces/google/cloud/ces_v1beta/types/widget_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_batch_delete_conversations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_batch_delete_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_app_version_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_app_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_create_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_app_version_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_app_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_conversation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_conversation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_delete_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_export_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_export_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_version_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_changelog_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_changelog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_changelog_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_changelog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_conversation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_conversation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_get_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_import_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_import_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_agents_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_agents_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_app_versions_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_app_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_app_versions_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_app_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_apps_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_apps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_apps_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_apps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_changelogs_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_changelogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_changelogs_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_changelogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_conversations_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_conversations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_deployments_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_deployments_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_examples_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_examples_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_examples_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_guardrails_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_guardrails_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_guardrails_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_guardrails_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_tools_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_tools_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_toolsets_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_toolsets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_toolsets_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_list_toolsets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_restore_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_restore_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_app_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_app_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_agent_service_update_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_bidi_run_session_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_bidi_run_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_bidi_run_session_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_bidi_run_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_run_session_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_run_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_run_session_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_run_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_stream_run_session_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_stream_run_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_stream_run_session_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_session_service_stream_run_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_execute_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_execute_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_execute_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_execute_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tool_schema_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tool_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tool_schema_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tool_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tools_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tools_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_tool_service_retrieve_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_widget_service_generate_chat_token_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_widget_service_generate_chat_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_widget_service_generate_chat_token_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1_generated_widget_service_generate_chat_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_batch_delete_conversations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_batch_delete_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_app_version_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_app_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_create_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_app_version_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_app_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_conversation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_conversation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_delete_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_export_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_export_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_generate_app_resource_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_generate_app_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_version_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_changelog_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_changelog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_changelog_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_changelog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_conversation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_conversation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_security_settings_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_security_settings_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_get_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_import_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_import_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_agents_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_agents_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_app_versions_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_app_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_app_versions_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_app_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_apps_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_apps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_apps_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_apps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_changelogs_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_changelogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_changelogs_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_changelogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_conversations_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_conversations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_deployments_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_deployments_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_examples_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_examples_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_examples_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_guardrails_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_guardrails_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_guardrails_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_guardrails_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_tools_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_tools_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_toolsets_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_toolsets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_toolsets_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_list_toolsets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_restore_app_version_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_restore_app_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_agent_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_agent_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_app_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_app_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_app_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_app_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_deployment_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_deployment_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_example_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_example_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_guardrail_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_guardrail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_guardrail_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_guardrail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_security_settings_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_security_settings_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_toolset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_toolset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_toolset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_agent_service_update_toolset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_dataset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_dataset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_expectation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_expectation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_expectation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_expectation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_scheduled_evaluation_run_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_scheduled_evaluation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_scheduled_evaluation_run_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_create_scheduled_evaluation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_dataset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_dataset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_expectation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_expectation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_expectation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_expectation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_result_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_result_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_run_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_scheduled_evaluation_run_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_scheduled_evaluation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_scheduled_evaluation_run_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_delete_scheduled_evaluation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_export_evaluations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_export_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_generate_evaluation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_generate_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_dataset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_dataset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_expectation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_expectation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_expectation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_expectation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_result_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_result_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_run_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_run_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_scheduled_evaluation_run_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_scheduled_evaluation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_scheduled_evaluation_run_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_get_scheduled_evaluation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_import_evaluations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_import_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_datasets_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_datasets_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_expectations_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_expectations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_expectations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_expectations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_results_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_results_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_runs_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_runs_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluation_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluations_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluations_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_scheduled_evaluation_runs_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_scheduled_evaluation_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_scheduled_evaluation_runs_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_list_scheduled_evaluation_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_run_evaluation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_run_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_test_persona_voice_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_test_persona_voice_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_test_persona_voice_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_test_persona_voice_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_dataset_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_dataset_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_expectation_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_expectation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_expectation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_expectation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_scheduled_evaluation_run_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_scheduled_evaluation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_scheduled_evaluation_run_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_update_scheduled_evaluation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_upload_evaluation_audio_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_upload_evaluation_audio_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_upload_evaluation_audio_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_evaluation_service_upload_evaluation_audio_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_bidi_run_session_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_bidi_run_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_bidi_run_session_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_bidi_run_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_run_session_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_run_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_run_session_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_run_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_stream_run_session_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_stream_run_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_stream_run_session_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_session_service_stream_run_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_execute_tool_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_execute_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_execute_tool_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_execute_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tool_schema_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tool_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tool_schema_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tool_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tools_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tools_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_tool_service_retrieve_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_widget_service_generate_chat_token_async.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_widget_service_generate_chat_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_widget_service_generate_chat_token_sync.py
+++ b/packages/google-cloud-ces/samples/generated_samples/ces_v1beta_generated_widget_service_generate_chat_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/tests/__init__.py
+++ b/packages/google-cloud-ces/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/tests/unit/__init__.py
+++ b/packages/google-cloud-ces/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-ces/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/tests/unit/gapic/ces_v1/__init__.py
+++ b/packages/google-cloud-ces/tests/unit/gapic/ces_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ces/tests/unit/gapic/ces_v1beta/__init__.py
+++ b/packages/google-cloud-ces/tests/unit/gapic/ces_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/.flake8
+++ b/packages/google-cloud-channel/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/MANIFEST.in
+++ b/packages/google-cloud-channel/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel/gapic_version.py
+++ b/packages/google-cloud-channel/google/cloud/channel/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/gapic_version.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/client.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/pagers.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/base.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/grpc.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_reports_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/client.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/pagers.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/base.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/grpc.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/services/cloud_channel_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/__init__.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/billing_accounts.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/billing_accounts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/channel_partner_links.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/channel_partner_links.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/common.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/customers.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/customers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/entitlement_changes.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/entitlement_changes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/entitlements.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/entitlements.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/offers.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/offers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/operations.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/products.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/products.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/reports_service.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/reports_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/repricing.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/repricing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/service.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/google/cloud/channel_v1/types/subscriber_event.py
+++ b/packages/google-cloud-channel/google/cloud/channel_v1/types/subscriber_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_fetch_report_results_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_fetch_report_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_fetch_report_results_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_fetch_report_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_list_reports_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_list_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_list_reports_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_list_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_run_report_job_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_reports_service_run_report_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_activate_entitlement_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_activate_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_cancel_entitlement_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_cancel_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_change_offer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_change_offer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_change_parameters_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_change_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_change_renewal_settings_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_change_renewal_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_check_cloud_identity_accounts_exist_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_check_cloud_identity_accounts_exist_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_check_cloud_identity_accounts_exist_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_check_cloud_identity_accounts_exist_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_link_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_link_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_channel_partner_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_entitlement_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_create_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_channel_partner_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_channel_partner_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_channel_partner_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_channel_partner_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_delete_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_link_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_link_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_channel_partner_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_entitlement_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_entitlement_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_entitlement_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_get_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_import_customer_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_import_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_import_customer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_import_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_links_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_links_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_repricing_configs_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_repricing_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_repricing_configs_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_channel_partner_repricing_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customer_repricing_configs_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customer_repricing_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customer_repricing_configs_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customer_repricing_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customers_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customers_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_customers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlement_changes_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlement_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlement_changes_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlement_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlements_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlements_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_entitlements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_offers_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_offers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_offers_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_offers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_products_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_products_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_offers_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_offers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_offers_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_offers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_skus_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_skus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_skus_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_purchasable_skus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_group_billable_skus_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_group_billable_skus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_group_billable_skus_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_group_billable_skus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_groups_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_groups_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_sku_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_skus_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_skus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_skus_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_skus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_subscribers_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_subscribers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_subscribers_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_subscribers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_offers_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_offers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_offers_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_offers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_skus_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_skus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_skus_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_list_transferable_skus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_lookup_offer_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_lookup_offer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_lookup_offer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_lookup_offer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_provision_cloud_identity_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_provision_cloud_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_query_eligible_billing_accounts_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_query_eligible_billing_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_query_eligible_billing_accounts_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_query_eligible_billing_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_register_subscriber_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_register_subscriber_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_register_subscriber_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_register_subscriber_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_start_paid_service_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_start_paid_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_suspend_entitlement_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_suspend_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_transfer_entitlements_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_transfer_entitlements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_transfer_entitlements_to_google_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_transfer_entitlements_to_google_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_unregister_subscriber_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_unregister_subscriber_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_unregister_subscriber_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_unregister_subscriber_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_link_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_link_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_channel_partner_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_repricing_config_async.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_repricing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_repricing_config_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_repricing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_sync.py
+++ b/packages/google-cloud-channel/samples/generated_samples/cloudchannel_v1_generated_cloud_channel_service_update_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/tests/__init__.py
+++ b/packages/google-cloud-channel/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/tests/unit/__init__.py
+++ b/packages/google-cloud-channel/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-channel/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-channel/tests/unit/gapic/channel_v1/__init__.py
+++ b/packages/google-cloud-channel/tests/unit/gapic/channel_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/.flake8
+++ b/packages/google-cloud-chronicle/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/MANIFEST.in
+++ b/packages/google-cloud-chronicle/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle/gapic_version.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/gapic_version.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/pagers.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/grpc.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/rest.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/rest_base.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/__init__.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/big_query_export.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/big_query_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/dashboard_chart.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/dashboard_chart.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/dashboard_query.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/dashboard_query.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/data_access_control.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/data_access_control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/data_table.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/data_table.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/entity.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/entity.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/featured_content_metadata.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/featured_content_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/featured_content_native_dashboard.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/featured_content_native_dashboard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/instance.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/native_dashboard.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/native_dashboard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/reference_list.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/reference_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/rule.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/types/rule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_get_big_query_export_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_get_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_get_big_query_export_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_get_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_provision_big_query_export_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_provision_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_provision_big_query_export_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_provision_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_update_big_query_export_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_update_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_update_big_query_export_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_big_query_export_service_update_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_batch_get_dashboard_charts_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_batch_get_dashboard_charts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_batch_get_dashboard_charts_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_batch_get_dashboard_charts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_get_dashboard_chart_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_get_dashboard_chart_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_get_dashboard_chart_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_chart_service_get_dashboard_chart_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_execute_dashboard_query_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_execute_dashboard_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_execute_dashboard_query_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_execute_dashboard_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_get_dashboard_query_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_get_dashboard_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_get_dashboard_query_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_dashboard_query_service_get_dashboard_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_label_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_label_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_scope_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_scope_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_scope_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_create_data_access_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_label_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_label_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_scope_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_scope_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_scope_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_delete_data_access_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_label_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_label_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_scope_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_scope_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_scope_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_get_data_access_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_labels_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_labels_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_scopes_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_scopes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_scopes_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_list_data_access_scopes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_label_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_label_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_scope_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_scope_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_scope_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_access_control_service_update_data_access_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_create_data_table_rows_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_create_data_table_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_create_data_table_rows_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_create_data_table_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_get_data_table_rows_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_get_data_table_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_get_data_table_rows_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_get_data_table_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_replace_data_table_rows_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_replace_data_table_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_replace_data_table_rows_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_replace_data_table_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_update_data_table_rows_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_update_data_table_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_update_data_table_rows_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_bulk_update_data_table_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_row_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_row_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_create_data_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_row_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_row_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_delete_data_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_operation_errors_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_operation_errors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_operation_errors_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_operation_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_row_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_row_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_get_data_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_table_rows_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_table_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_table_rows_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_table_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_tables_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_tables_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_list_data_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_row_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_row_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_data_table_service_update_data_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_create_watchlist_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_create_watchlist_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_create_watchlist_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_create_watchlist_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_delete_watchlist_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_delete_watchlist_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_delete_watchlist_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_delete_watchlist_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_get_watchlist_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_get_watchlist_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_get_watchlist_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_get_watchlist_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_list_watchlists_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_list_watchlists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_list_watchlists_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_list_watchlists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_update_watchlist_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_update_watchlist_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_update_watchlist_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_entity_service_update_watchlist_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_get_featured_content_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_get_featured_content_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_get_featured_content_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_get_featured_content_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_install_featured_content_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_install_featured_content_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_install_featured_content_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_install_featured_content_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_list_featured_content_native_dashboards_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_list_featured_content_native_dashboards_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_list_featured_content_native_dashboards_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_featured_content_native_dashboard_service_list_featured_content_native_dashboards_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_instance_service_get_instance_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_instance_service_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_instance_service_get_instance_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_instance_service_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_add_chart_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_add_chart_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_add_chart_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_add_chart_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_create_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_create_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_create_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_create_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_delete_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_delete_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_delete_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_delete_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_chart_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_chart_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_chart_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_chart_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_duplicate_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_edit_chart_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_edit_chart_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_edit_chart_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_edit_chart_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_export_native_dashboards_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_export_native_dashboards_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_export_native_dashboards_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_export_native_dashboards_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_get_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_get_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_get_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_get_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_import_native_dashboards_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_import_native_dashboards_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_import_native_dashboards_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_import_native_dashboards_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_list_native_dashboards_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_list_native_dashboards_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_list_native_dashboards_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_list_native_dashboards_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_remove_chart_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_remove_chart_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_remove_chart_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_remove_chart_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_update_native_dashboard_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_update_native_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_update_native_dashboard_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_native_dashboard_service_update_native_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_create_reference_list_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_create_reference_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_create_reference_list_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_create_reference_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_get_reference_list_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_get_reference_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_get_reference_list_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_get_reference_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_list_reference_lists_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_list_reference_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_list_reference_lists_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_list_reference_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_update_reference_list_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_update_reference_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_update_reference_list_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_reference_list_service_update_reference_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_create_retrohunt_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_create_retrohunt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_create_rule_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_create_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_create_rule_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_create_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_delete_rule_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_delete_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_delete_rule_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_delete_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_retrohunt_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_retrohunt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_retrohunt_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_retrohunt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_deployment_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_deployment_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_retrohunts_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_retrohunts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_retrohunts_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_retrohunts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_deployments_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_deployments_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_revisions_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_revisions_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rule_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rules_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rules_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_list_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_deployment_async.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_deployment_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_sync.py
+++ b/packages/google-cloud-chronicle/samples/generated_samples/chronicle_v1_generated_rule_service_update_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/tests/__init__.py
+++ b/packages/google-cloud-chronicle/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/tests/unit/__init__.py
+++ b/packages/google-cloud-chronicle/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/__init__.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/.flake8
+++ b/packages/google-cloud-cloudcontrolspartner/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/MANIFEST.in
+++ b/packages/google-cloud-cloudcontrolspartner/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner/gapic_version.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/gapic_version.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/async_client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/pagers.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/grpc.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/rest.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/rest_base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_core/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/async_client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/pagers.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/grpc.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/rest.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/rest_base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/services/cloud_controls_partner_monitoring/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/access_approval_requests.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/access_approval_requests.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/completion_state.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/completion_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/core.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/customer_workloads.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/customer_workloads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/customers.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/customers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/ekm_connections.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/ekm_connections.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/monitoring.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/monitoring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/partner_permissions.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/partner_permissions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/partners.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/partners.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/violations.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1/types/violations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/gapic_version.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/async_client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/pagers.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/grpc.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/rest.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/rest_base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_core/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/async_client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/client.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/pagers.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/grpc.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/rest.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/rest_base.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/services/cloud_controls_partner_monitoring/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/access_approval_requests.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/access_approval_requests.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/completion_state.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/completion_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/core.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/customer_workloads.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/customer_workloads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/customers.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/customers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/ekm_connections.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/ekm_connections.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/monitoring.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/monitoring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/partner_permissions.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/partner_permissions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/partners.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/partners.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/violations.py
+++ b/packages/google-cloud-cloudcontrolspartner/google/cloud/cloudcontrolspartner_v1beta/types/violations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_create_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_create_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_create_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_create_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_delete_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_delete_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_delete_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_delete_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_ekm_connections_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_ekm_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_ekm_connections_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_ekm_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_permissions_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_permissions_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_partner_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_workload_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_workload_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_get_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_access_approval_requests_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_access_approval_requests_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_access_approval_requests_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_access_approval_requests_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_customers_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_customers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_customers_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_customers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_workloads_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_workloads_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_update_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_update_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_update_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_core_update_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_get_violation_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_get_violation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_get_violation_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_get_violation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_list_violations_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_list_violations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_list_violations_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1_generated_cloud_controls_partner_monitoring_list_violations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_create_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_create_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_create_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_create_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_delete_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_delete_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_delete_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_delete_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_ekm_connections_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_ekm_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_ekm_connections_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_ekm_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_permissions_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_permissions_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_partner_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_workload_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_workload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_workload_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_get_workload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_access_approval_requests_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_access_approval_requests_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_access_approval_requests_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_access_approval_requests_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_customers_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_customers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_customers_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_customers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_workloads_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_workloads_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_update_customer_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_update_customer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_update_customer_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_core_update_customer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_get_violation_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_get_violation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_get_violation_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_get_violation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_list_violations_async.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_list_violations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_list_violations_sync.py
+++ b/packages/google-cloud-cloudcontrolspartner/samples/generated_samples/cloudcontrolspartner_v1beta_generated_cloud_controls_partner_monitoring_list_violations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/tests/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/tests/unit/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/tests/unit/gapic/cloudcontrolspartner_v1/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/tests/unit/gapic/cloudcontrolspartner_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudcontrolspartner/tests/unit/gapic/cloudcontrolspartner_v1beta/__init__.py
+++ b/packages/google-cloud-cloudcontrolspartner/tests/unit/gapic/cloudcontrolspartner_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/.flake8
+++ b/packages/google-cloud-cloudsecuritycompliance/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/MANIFEST.in
+++ b/packages/google-cloud-cloudsecuritycompliance/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance/gapic_version.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/gapic_version.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/pagers.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/grpc.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/rest.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/rest_base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/audit/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/async_client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/grpc.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/rest.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/rest_base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/cm_enrollment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/async_client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/pagers.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/grpc.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/rest.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/rest_base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/config/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/pagers.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/grpc.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/rest.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/rest_base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/deployment/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/async_client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/client.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/pagers.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/grpc.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/grpc_asyncio.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/rest.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/rest_base.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/services/monitoring/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/audit.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/audit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/cm_enrollment_service.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/cm_enrollment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/common.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/config.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/deployment.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/deployment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/monitoring.py
+++ b/packages/google-cloud-cloudsecuritycompliance/google/cloud/cloudsecuritycompliance_v1/types/monitoring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_create_framework_audit_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_create_framework_audit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_generate_framework_audit_scope_report_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_generate_framework_audit_scope_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_generate_framework_audit_scope_report_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_generate_framework_audit_scope_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_get_framework_audit_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_get_framework_audit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_get_framework_audit_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_get_framework_audit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_list_framework_audits_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_list_framework_audits_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_list_framework_audits_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_audit_list_framework_audits_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_calculate_effective_cm_enrollment_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_calculate_effective_cm_enrollment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_calculate_effective_cm_enrollment_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_calculate_effective_cm_enrollment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_update_cm_enrollment_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_update_cm_enrollment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_update_cm_enrollment_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_cm_enrollment_service_update_cm_enrollment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_cloud_control_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_cloud_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_cloud_control_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_cloud_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_framework_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_framework_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_framework_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_create_framework_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_cloud_control_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_cloud_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_cloud_control_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_cloud_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_framework_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_framework_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_framework_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_delete_framework_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_cloud_control_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_cloud_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_cloud_control_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_cloud_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_framework_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_framework_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_framework_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_get_framework_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_cloud_controls_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_cloud_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_cloud_controls_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_cloud_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_frameworks_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_frameworks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_frameworks_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_list_frameworks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_cloud_control_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_cloud_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_cloud_control_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_cloud_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_framework_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_framework_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_framework_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_config_update_framework_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_create_framework_deployment_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_create_framework_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_delete_framework_deployment_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_delete_framework_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_cloud_control_deployment_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_cloud_control_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_cloud_control_deployment_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_cloud_control_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_framework_deployment_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_framework_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_framework_deployment_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_get_framework_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_cloud_control_deployments_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_cloud_control_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_cloud_control_deployments_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_cloud_control_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_framework_deployments_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_framework_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_framework_deployments_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_deployment_list_framework_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_aggregate_framework_compliance_report_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_aggregate_framework_compliance_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_aggregate_framework_compliance_report_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_aggregate_framework_compliance_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_fetch_framework_compliance_report_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_fetch_framework_compliance_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_fetch_framework_compliance_report_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_fetch_framework_compliance_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_control_compliance_summaries_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_control_compliance_summaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_control_compliance_summaries_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_control_compliance_summaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_finding_summaries_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_finding_summaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_finding_summaries_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_finding_summaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_framework_compliance_summaries_async.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_framework_compliance_summaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_framework_compliance_summaries_sync.py
+++ b/packages/google-cloud-cloudsecuritycompliance/samples/generated_samples/cloudsecuritycompliance_v1_generated_monitoring_list_framework_compliance_summaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/tests/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/tests/unit/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-cloudsecuritycompliance/tests/unit/gapic/cloudsecuritycompliance_v1/__init__.py
+++ b/packages/google-cloud-cloudsecuritycompliance/tests/unit/gapic/cloudsecuritycompliance_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/.flake8
+++ b/packages/google-cloud-commerce-consumer-procurement/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/MANIFEST.in
+++ b/packages/google-cloud-commerce-consumer-procurement/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement/gapic_version.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/gapic_version.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/client.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/pagers.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/base.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/grpc.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/rest.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/rest_base.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/consumer_procurement_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/async_client.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/client.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/pagers.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/base.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/grpc.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/rest.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/rest_base.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/services/license_management_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/license_management_service.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/license_management_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/order.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/order.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/procurement_service.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1/types/procurement_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/client.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/pagers.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/base.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/grpc.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/rest.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/rest_base.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/services/consumer_procurement_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/types/order.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/types/order.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/types/procurement_service.py
+++ b/packages/google-cloud-commerce-consumer-procurement/google/cloud/commerce_consumer_procurement_v1alpha1/types/procurement_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_cancel_order_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_cancel_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_get_order_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_get_order_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_get_order_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_get_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_list_orders_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_list_orders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_list_orders_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_list_orders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_modify_order_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_modify_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_place_order_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_consumer_procurement_service_place_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_assign_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_assign_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_assign_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_assign_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_enumerate_licensed_users_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_enumerate_licensed_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_enumerate_licensed_users_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_enumerate_licensed_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_get_license_pool_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_get_license_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_get_license_pool_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_get_license_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_unassign_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_unassign_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_unassign_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_unassign_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_update_license_pool_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_update_license_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_update_license_pool_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1_generated_license_management_service_update_license_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_get_order_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_get_order_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_get_order_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_get_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_list_orders_async.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_list_orders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_list_orders_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_list_orders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_place_order_sync.py
+++ b/packages/google-cloud-commerce-consumer-procurement/samples/generated_samples/cloudcommerceconsumerprocurement_v1alpha1_generated_consumer_procurement_service_place_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/tests/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/tests/unit/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/tests/unit/gapic/commerce_consumer_procurement_v1/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/tests/unit/gapic/commerce_consumer_procurement_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-commerce-consumer-procurement/tests/unit/gapic/commerce_consumer_procurement_v1alpha1/__init__.py
+++ b/packages/google-cloud-commerce-consumer-procurement/tests/unit/gapic/commerce_consumer_procurement_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/.flake8
+++ b/packages/google-cloud-common/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/MANIFEST.in
+++ b/packages/google-cloud-common/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/google/cloud/common/gapic_version.py
+++ b/packages/google-cloud-common/google/cloud/common/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/google/cloud/common/services/__init__.py
+++ b/packages/google-cloud-common/google/cloud/common/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/google/cloud/common/types/__init__.py
+++ b/packages/google-cloud-common/google/cloud/common/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/google/cloud/common/types/operation_metadata.py
+++ b/packages/google-cloud-common/google/cloud/common/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/tests/__init__.py
+++ b/packages/google-cloud-common/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/tests/unit/__init__.py
+++ b/packages/google-cloud-common/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-common/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-common/tests/unit/gapic/common/__init__.py
+++ b/packages/google-cloud-common/tests/unit/gapic/common/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/.flake8
+++ b/packages/google-cloud-compute-v1beta/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/MANIFEST.in
+++ b/packages/google-cloud-compute-v1beta/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/gapic_version.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/accelerator_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/addresses/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/advice/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/autoscalers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_buckets/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/backend_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/cross_site_networks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disk_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/disks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/external_vpn_gateways/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewall_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/firewalls/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/forwarding_rules/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/future_reservations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_addresses/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_forwarding_rules/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_network_endpoint_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_organization_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_public_delegated_prefixes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/global_vm_extension_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/health_checks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/image_family_views/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/images/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_manager_resize_requests/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_group_managers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instance_templates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshot_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/instant_snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachment_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_attachments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_locations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnect_remote_locations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/interconnects/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/license_codes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/licenses/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_images/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/machine_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_attachments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_edge_security_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_endpoint_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_firewall_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/network_profiles/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/networks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_templates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/node_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/organization_security_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/packet_mirrorings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/preview_features/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/projects/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_advertised_prefixes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/public_delegated_prefixes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_autoscalers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_buckets/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_backend_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_commitments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_composite_health_checks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_settings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disk_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_disks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_aggregation_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_check_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_checks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_health_sources/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_manager_resize_requests/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_group_managers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instance_templates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshot_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_instant_snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_mig_members/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_multi_migs/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_endpoint_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_firewall_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_network_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_notification_endpoints/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_security_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshot_settings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_certificates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_ssl_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_http_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_https_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_target_tcp_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_url_maps/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/region_zones/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/regions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_blocks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_slots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservation_sub_blocks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/reservations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/resource_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollout_plans/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/rollouts/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/routes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/security_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/service_attachments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshot_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_certificates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/ssl_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pool_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/storage_pools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/subnetworks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_grpc_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_http_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_https_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_pools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_ssl_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_tcp_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/target_vpn_gateways/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/url_maps/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_gateways/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/vpn_tunnels/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/wire_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zone_vm_extension_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/client.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/pagers.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/rest.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/rest_base.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/services/zones/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/types/__init__.py
+++ b/packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_accelerator_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_accelerator_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_accelerator_types_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_accelerator_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_accelerator_types_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_accelerator_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_move_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_addresses_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_advice_calendar_mode_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_advice_calendar_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_autoscalers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_add_signed_url_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_add_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_delete_signed_url_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_delete_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_list_usable_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_set_edge_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_set_edge_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_buckets_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_add_signed_url_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_add_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_delete_signed_url_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_delete_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_effective_security_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_effective_security_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_health_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_list_usable_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_set_edge_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_set_edge_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_set_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_backend_services_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_cross_site_networks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_settings_service_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_settings_service_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_settings_service_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_settings_service_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_types_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_types_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disk_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_add_resource_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_add_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_bulk_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_bulk_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_bulk_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_create_snapshot_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_remove_resource_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_remove_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_resize_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_start_async_replication_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_start_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_stop_async_replication_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_stop_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_stop_group_async_replication_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_stop_group_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_update_kms_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_disks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_external_vpn_gateways_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_add_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_add_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_add_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_clone_rules_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_clone_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_list_associations_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_list_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_move_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_patch_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_patch_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_remove_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_remove_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewall_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_firewalls_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_set_target_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_set_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_forwarding_rules_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_cancel_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_future_reservations_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_move_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_addresses_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_set_target_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_set_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_forwarding_rules_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_attach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_attach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_detach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_detach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_list_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_list_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_network_endpoint_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_wait_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_operations_wait_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_organization_operations_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_organization_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_organization_operations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_organization_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_organization_operations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_organization_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_public_delegated_prefixes_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_global_vm_extension_policies_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_health_checks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_image_family_views_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_image_family_views_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_deprecate_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_deprecate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_get_from_family_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_get_from_family_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_images_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_cancel_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_manager_resize_requests_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_abandon_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_abandon_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_apply_updates_to_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_apply_updates_to_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_configure_accelerator_topologies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_configure_accelerator_topologies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_create_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_delete_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_delete_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_delete_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_delete_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_get_available_accelerator_topologies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_get_available_accelerator_topologies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_errors_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_managed_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_managed_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_patch_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_patch_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_recreate_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_recreate_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_resize_advanced_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_resize_advanced_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_resize_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_resume_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_resume_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_set_auto_healing_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_set_auto_healing_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_set_instance_template_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_set_instance_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_set_target_pools_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_set_target_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_start_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_start_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_stop_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_stop_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_suspend_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_suspend_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_update_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_update_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_group_managers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_add_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_add_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_list_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_remove_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_remove_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_set_named_ports_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_set_named_ports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_settings_service_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_settings_service_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_settings_service_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_settings_service_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instance_templates_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_add_access_config_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_add_access_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_add_network_interface_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_add_network_interface_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_add_resource_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_add_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_attach_disk_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_attach_disk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_bulk_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_delete_access_config_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_delete_access_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_delete_network_interface_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_delete_network_interface_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_detach_disk_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_detach_disk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_effective_firewalls_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_effective_firewalls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_guest_attributes_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_guest_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_partner_metadata_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_partner_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_screenshot_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_screenshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_serial_port_output_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_serial_port_output_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_shielded_instance_identity_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_shielded_instance_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_shielded_vm_identity_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_shielded_vm_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_list_referrers_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_list_referrers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_patch_partner_metadata_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_patch_partner_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_remove_resource_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_remove_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_report_host_as_faulty_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_report_host_as_faulty_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_reset_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_reset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_resume_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_resume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_send_diagnostic_interrupt_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_send_diagnostic_interrupt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_deletion_protection_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_deletion_protection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_disk_auto_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_disk_auto_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_machine_resources_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_machine_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_machine_type_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_machine_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_metadata_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_min_cpu_platform_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_min_cpu_platform_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_name_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_name_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_scheduling_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_scheduling_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_service_account_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_shielded_instance_integrity_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_shielded_instance_integrity_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_shielded_vm_integrity_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_shielded_vm_integrity_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_tags_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_set_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_simulate_maintenance_event_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_simulate_maintenance_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_start_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_start_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_start_with_encryption_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_start_with_encryption_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_stop_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_stop_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_suspend_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_suspend_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_access_config_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_access_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_display_device_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_display_device_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_network_interface_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_network_interface_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_shielded_instance_config_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_shielded_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_shielded_vm_config_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_shielded_vm_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instances_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshot_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_instant_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_get_operational_status_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_get_operational_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachment_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_attachments_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_create_members_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_create_members_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_get_operational_status_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_get_operational_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_locations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_locations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_locations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_locations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_remote_locations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_remote_locations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_remote_locations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnect_remote_locations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_get_diagnostics_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_get_diagnostics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_get_macsec_config_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_get_macsec_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_interconnects_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_license_codes_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_license_codes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_license_codes_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_license_codes_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_licenses_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_images_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_types_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_types_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_machine_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_attachments_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_edge_security_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_attach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_attach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_detach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_detach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_list_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_list_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_endpoint_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_add_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_add_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_add_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_clone_rules_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_clone_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_patch_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_patch_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_remove_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_remove_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_firewall_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_profiles_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_profiles_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_profiles_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_network_profiles_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_add_peering_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_add_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_cancel_request_remove_peering_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_cancel_request_remove_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_get_effective_firewalls_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_get_effective_firewalls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_list_peering_routes_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_list_peering_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_remove_peering_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_remove_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_request_remove_peering_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_request_remove_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_switch_to_custom_mode_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_switch_to_custom_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_update_peering_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_networks_update_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_add_nodes_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_add_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_delete_nodes_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_delete_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_list_nodes_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_list_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_set_node_template_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_set_node_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_simulate_maintenance_event_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_simulate_maintenance_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_templates_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_types_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_types_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_node_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_add_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_copy_rules_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_copy_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_get_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_list_associations_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_list_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_list_preconfigured_expression_sets_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_list_preconfigured_expression_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_move_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_organization_security_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_packet_mirrorings_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_preview_features_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_preview_features_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_preview_features_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_preview_features_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_preview_features_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_preview_features_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_disable_xpn_host_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_disable_xpn_host_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_disable_xpn_resource_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_disable_xpn_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_enable_xpn_host_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_enable_xpn_host_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_enable_xpn_resource_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_enable_xpn_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_get_xpn_host_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_get_xpn_host_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_get_xpn_resources_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_get_xpn_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_list_xpn_hosts_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_list_xpn_hosts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_move_disk_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_move_disk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_move_instance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_move_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_cloud_armor_tier_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_cloud_armor_tier_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_common_instance_metadata_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_common_instance_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_default_network_tier_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_default_network_tier_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_managed_protection_tier_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_managed_protection_tier_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_usage_export_bucket_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_projects_set_usage_export_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_announce_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_announce_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_withdraw_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_advertised_prefixes_withdraw_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_announce_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_announce_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_withdraw_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_public_delegated_prefixes_withdraw_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_autoscalers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_list_usable_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_buckets_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_get_health_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_list_usable_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_set_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_backend_services_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_update_reservations_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_update_reservations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_commitments_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_get_health_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_composite_health_checks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_settings_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_settings_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_settings_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_settings_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_types_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_types_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disk_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_add_resource_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_add_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_bulk_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_create_snapshot_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_remove_resource_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_remove_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_resize_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_start_async_replication_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_start_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_stop_async_replication_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_stop_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_stop_group_async_replication_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_stop_group_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_update_kms_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_disks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_aggregation_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_check_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_checks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_get_health_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_health_sources_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_cancel_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_manager_resize_requests_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_abandon_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_abandon_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_adopt_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_adopt_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_apply_updates_to_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_apply_updates_to_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_create_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_delete_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_delete_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_delete_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_delete_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_errors_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_managed_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_managed_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_patch_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_patch_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_recreate_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_recreate_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_resize_advanced_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_resize_advanced_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_resize_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_resume_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_resume_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_set_auto_healing_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_set_auto_healing_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_set_instance_template_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_set_instance_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_set_target_pools_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_set_target_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_start_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_start_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_stop_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_stop_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_suspend_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_suspend_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_update_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_update_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_group_managers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_list_instances_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_set_named_ports_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_set_named_ports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instance_templates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instances_bulk_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instances_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshot_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_instant_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_mig_members_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_mig_members_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_mig_members_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_mig_members_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_multi_migs_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_attach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_attach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_detach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_detach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_list_network_endpoints_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_list_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_endpoint_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_add_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_clone_rules_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_clone_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_effective_firewalls_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_effective_firewalls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_patch_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_patch_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_firewall_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_add_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_add_traffic_classification_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_add_traffic_classification_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_get_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_get_traffic_classification_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_get_traffic_classification_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_patch_traffic_classification_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_patch_traffic_classification_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_remove_traffic_classification_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_network_policies_remove_traffic_classification_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_notification_endpoints_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_wait_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_operations_wait_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_security_policies_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshot_settings_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshot_settings_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshot_settings_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshot_settings_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_update_kms_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_snapshots_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_certificates_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_list_available_features_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_list_available_features_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_ssl_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_http_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_set_ssl_certificates_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_set_ssl_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_https_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_target_tcp_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_invalidate_cache_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_invalidate_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_validate_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_url_maps_validate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_zones_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_region_zones_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_regions_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_regions_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_regions_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_regions_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_blocks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_get_version_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_slots_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_get_version_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_report_faulty_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_report_faulty_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservation_sub_blocks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_resize_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_reservations_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_resource_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollout_plans_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_cancel_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_rollouts_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_delete_named_set_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_delete_named_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_delete_route_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_delete_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_named_set_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_named_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_nat_ip_info_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_nat_ip_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_nat_mapping_info_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_nat_mapping_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_route_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_router_status_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_router_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_bgp_routes_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_bgp_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_named_sets_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_named_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_route_policies_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_route_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_patch_named_set_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_patch_named_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_patch_route_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_patch_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_preview_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_update_named_set_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_update_named_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_update_route_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_update_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_routes_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_list_preconfigured_expression_sets_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_list_preconfigured_expression_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_security_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_service_attachments_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_settings_service_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_settings_service_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_settings_service_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshot_settings_service_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_update_kms_key_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_snapshots_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_certificates_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_list_available_features_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_list_available_features_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_ssl_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pool_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pool_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pool_types_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pool_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pool_types_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pool_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_list_disks_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_list_disks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_storage_pools_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_expand_ip_cidr_range_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_expand_ip_cidr_range_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_list_usable_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_set_private_ip_google_access_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_set_private_ip_google_access_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_subnetworks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_grpc_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_http_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_certificate_map_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_quic_override_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_quic_override_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_ssl_certificates_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_ssl_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_ssl_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_ssl_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_https_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_set_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_instances_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_add_health_check_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_add_health_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_add_instance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_add_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_get_health_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_remove_health_check_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_remove_health_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_remove_instance_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_remove_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_set_backup_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_set_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_set_security_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_pools_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_backend_service_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_backend_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_certificate_map_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_proxy_header_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_proxy_header_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_ssl_certificates_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_ssl_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_ssl_policy_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_set_ssl_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_ssl_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_set_backend_service_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_set_backend_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_set_proxy_header_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_set_proxy_header_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_tcp_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_target_vpn_gateways_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_invalidate_cache_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_invalidate_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_validate_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_url_maps_validate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_get_status_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_get_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_gateways_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_aggregated_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_set_labels_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_vpn_tunnels_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_patch_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_wire_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_wait_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_operations_wait_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_delete_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_insert_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_update_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zone_vm_extension_policies_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zones_get_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zones_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zones_list_sync.py
+++ b/packages/google-cloud-compute-v1beta/samples/generated_samples/compute_v1beta_generated_zones_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/tests/__init__.py
+++ b/packages/google-cloud-compute-v1beta/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/tests/unit/__init__.py
+++ b/packages/google-cloud-compute-v1beta/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-compute-v1beta/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute-v1beta/tests/unit/gapic/compute_v1beta/__init__.py
+++ b/packages/google-cloud-compute-v1beta/tests/unit/gapic/compute_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/.flake8
+++ b/packages/google-cloud-compute/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/MANIFEST.in
+++ b/packages/google-cloud-compute/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute/gapic_version.py
+++ b/packages/google-cloud-compute/google/cloud/compute/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/gapic_version.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/accelerator_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/addresses/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/advice/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/autoscalers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_buckets/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/backend_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/cross_site_networks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disk_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/disks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/external_vpn_gateways/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewall_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/firewalls/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/forwarding_rules/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/future_reservations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_addresses/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_forwarding_rules/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_organization_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/health_checks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/image_family_views/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/images/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_manager_resize_requests/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_group_managers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instance_templates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshot_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/instant_snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachment_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_attachments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_locations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnect_remote_locations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/interconnects/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/license_codes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/licenses/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_images/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/machine_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_attachments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_edge_security_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_endpoint_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_firewall_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/network_profiles/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/networks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_templates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/node_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/organization_security_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/packet_mirrorings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/preview_features/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/projects/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_advertised_prefixes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/public_delegated_prefixes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_autoscalers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_buckets/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_backend_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_commitments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_composite_health_checks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disk_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_disks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_aggregation_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_check_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_checks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_health_sources/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_manager_resize_requests/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_group_managers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instance_templates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshot_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_instant_snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_network_firewall_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_notification_endpoints/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_security_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshot_settings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_certificates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_ssl_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_http_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_https_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_target_tcp_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_url_maps/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/region_zones/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/regions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_blocks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_slots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservation_sub_blocks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/reservations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/resource_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routers/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/routes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/security_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/service_attachments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshot_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/snapshots/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_certificates/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/ssl_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pool_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/storage_pools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/subnetworks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_grpc_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_http_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_https_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_pools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_ssl_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_tcp_proxies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/target_vpn_gateways/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/url_maps/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_gateways/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/vpn_tunnels/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/wire_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zone_vm_extension_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/client.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/pagers.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/rest.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/rest_base.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/services/zones/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/google/cloud/compute_v1/types/__init__.py
+++ b/packages/google-cloud-compute/google/cloud/compute_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_accelerator_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_accelerator_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_accelerator_types_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_accelerator_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_accelerator_types_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_accelerator_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_move_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_addresses_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_advice_calendar_mode_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_advice_calendar_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_autoscalers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_add_signed_url_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_add_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_delete_signed_url_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_delete_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_list_usable_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_set_edge_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_set_edge_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_buckets_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_add_signed_url_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_add_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_delete_signed_url_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_delete_signed_url_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_effective_security_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_effective_security_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_health_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_list_usable_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_set_edge_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_set_edge_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_set_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_backend_services_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_cross_site_networks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disk_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disk_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disk_types_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disk_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disk_types_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disk_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_add_resource_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_add_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_bulk_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_bulk_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_bulk_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_create_snapshot_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_remove_resource_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_remove_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_resize_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_start_async_replication_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_start_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_stop_async_replication_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_stop_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_stop_group_async_replication_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_stop_group_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_update_kms_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_disks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_external_vpn_gateways_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_add_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_clone_rules_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_clone_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_list_associations_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_list_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_move_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewall_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_firewalls_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_set_target_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_forwarding_rules_set_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_cancel_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_future_reservations_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_move_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_addresses_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_set_target_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_forwarding_rules_set_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_attach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_attach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_detach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_detach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_list_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_list_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_network_endpoint_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_wait_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_operations_wait_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_organization_operations_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_organization_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_organization_operations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_organization_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_organization_operations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_organization_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_global_public_delegated_prefixes_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_health_checks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_image_family_views_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_image_family_views_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_deprecate_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_deprecate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_get_from_family_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_get_from_family_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_images_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_cancel_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_manager_resize_requests_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_abandon_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_abandon_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_apply_updates_to_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_apply_updates_to_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_create_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_delete_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_delete_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_delete_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_delete_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_errors_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_managed_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_managed_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_patch_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_patch_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_recreate_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_recreate_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_resize_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_resume_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_resume_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_set_instance_template_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_set_instance_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_set_target_pools_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_set_target_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_start_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_start_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_stop_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_stop_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_suspend_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_suspend_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_update_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_group_managers_update_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_add_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_add_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_list_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_remove_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_remove_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_set_named_ports_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_set_named_ports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_settings_service_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_settings_service_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_settings_service_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_settings_service_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instance_templates_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_add_access_config_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_add_access_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_add_network_interface_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_add_network_interface_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_add_resource_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_add_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_attach_disk_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_attach_disk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_bulk_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_delete_access_config_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_delete_access_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_delete_network_interface_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_delete_network_interface_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_detach_disk_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_detach_disk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_effective_firewalls_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_effective_firewalls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_guest_attributes_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_guest_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_screenshot_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_screenshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_serial_port_output_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_serial_port_output_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_shielded_instance_identity_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_shielded_instance_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_list_referrers_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_list_referrers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_remove_resource_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_remove_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_report_host_as_faulty_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_report_host_as_faulty_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_reset_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_reset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_resume_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_resume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_send_diagnostic_interrupt_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_send_diagnostic_interrupt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_deletion_protection_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_deletion_protection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_disk_auto_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_disk_auto_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_machine_resources_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_machine_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_machine_type_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_machine_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_metadata_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_min_cpu_platform_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_min_cpu_platform_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_name_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_name_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_scheduling_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_scheduling_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_service_account_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_shielded_instance_integrity_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_shielded_instance_integrity_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_tags_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_set_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_simulate_maintenance_event_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_simulate_maintenance_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_start_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_start_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_start_with_encryption_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_start_with_encryption_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_stop_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_stop_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_suspend_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_suspend_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_access_config_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_access_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_display_device_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_display_device_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_network_interface_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_network_interface_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_shielded_instance_config_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_shielded_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instances_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshot_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_instant_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_get_operational_status_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_get_operational_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachment_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_attachments_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_create_members_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_create_members_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_get_operational_status_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_get_operational_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_locations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_locations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_locations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_locations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_remote_locations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_remote_locations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_remote_locations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnect_remote_locations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_get_diagnostics_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_get_diagnostics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_get_macsec_config_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_get_macsec_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_interconnects_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_license_codes_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_license_codes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_license_codes_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_license_codes_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_licenses_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_images_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_types_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_types_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_machine_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_attachments_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_edge_security_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_attach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_attach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_detach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_detach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_list_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_list_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_endpoint_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_add_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_add_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_add_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_clone_rules_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_clone_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_patch_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_patch_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_remove_packet_mirroring_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_remove_packet_mirroring_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_firewall_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_profiles_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_profiles_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_profiles_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_network_profiles_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_add_peering_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_add_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_get_effective_firewalls_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_get_effective_firewalls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_list_peering_routes_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_list_peering_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_remove_peering_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_remove_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_request_remove_peering_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_request_remove_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_switch_to_custom_mode_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_switch_to_custom_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_update_peering_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_networks_update_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_add_nodes_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_add_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_delete_nodes_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_delete_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_list_nodes_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_list_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_set_node_template_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_set_node_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_simulate_maintenance_event_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_simulate_maintenance_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_templates_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_types_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_types_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_node_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_add_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_copy_rules_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_copy_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_get_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_list_associations_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_list_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_list_preconfigured_expression_sets_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_list_preconfigured_expression_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_move_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_move_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_organization_security_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_packet_mirrorings_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_preview_features_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_preview_features_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_preview_features_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_preview_features_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_preview_features_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_preview_features_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_disable_xpn_host_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_disable_xpn_host_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_disable_xpn_resource_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_disable_xpn_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_enable_xpn_host_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_enable_xpn_host_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_enable_xpn_resource_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_enable_xpn_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_get_xpn_host_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_get_xpn_host_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_get_xpn_resources_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_get_xpn_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_list_xpn_hosts_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_list_xpn_hosts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_move_disk_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_move_disk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_move_instance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_move_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_cloud_armor_tier_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_cloud_armor_tier_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_common_instance_metadata_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_common_instance_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_default_network_tier_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_default_network_tier_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_usage_export_bucket_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_projects_set_usage_export_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_announce_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_announce_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_withdraw_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_advertised_prefixes_withdraw_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_announce_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_announce_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_withdraw_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_public_delegated_prefixes_withdraw_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_autoscalers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_list_usable_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_buckets_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_get_health_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_list_usable_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_set_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_backend_services_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_commitments_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_get_health_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_composite_health_checks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disk_types_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disk_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disk_types_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disk_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_add_resource_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_add_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_bulk_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_create_snapshot_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_remove_resource_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_remove_resource_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_resize_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_start_async_replication_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_start_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_stop_async_replication_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_stop_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_stop_group_async_replication_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_stop_group_async_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_update_kms_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_disks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_aggregation_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_check_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_checks_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_get_health_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_health_sources_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_cancel_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_cancel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_manager_resize_requests_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_abandon_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_abandon_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_apply_updates_to_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_apply_updates_to_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_create_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_create_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_delete_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_delete_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_delete_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_delete_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_errors_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_managed_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_managed_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_patch_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_patch_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_recreate_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_recreate_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_resize_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_resume_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_resume_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_set_instance_template_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_set_instance_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_set_target_pools_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_set_target_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_start_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_start_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_stop_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_stop_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_suspend_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_suspend_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_update_per_instance_configs_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_group_managers_update_per_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_list_instances_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_set_named_ports_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_set_named_ports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instance_templates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instances_bulk_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instances_bulk_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshot_groups_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_instant_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_attach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_attach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_detach_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_detach_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_list_network_endpoints_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_list_network_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_endpoint_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_add_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_add_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_clone_rules_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_clone_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_effective_firewalls_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_effective_firewalls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_remove_association_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_remove_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_network_firewall_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_notification_endpoints_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_wait_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_operations_wait_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_security_policies_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshot_settings_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshot_settings_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshot_settings_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshot_settings_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_update_kms_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_snapshots_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_certificates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_list_available_features_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_list_available_features_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_ssl_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_http_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_set_ssl_certificates_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_set_ssl_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_https_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_target_tcp_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_validate_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_url_maps_validate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_zones_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_region_zones_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_regions_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_regions_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_regions_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_regions_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_blocks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_get_version_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_slots_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_get_version_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_report_faulty_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_report_faulty_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservation_sub_blocks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_perform_maintenance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_resize_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_resize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_reservations_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_resource_policies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_delete_route_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_delete_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_nat_ip_info_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_nat_ip_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_nat_mapping_info_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_nat_mapping_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_route_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_router_status_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_router_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_list_bgp_routes_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_list_bgp_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_list_route_policies_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_list_route_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_patch_route_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_patch_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_preview_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_update_route_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_update_route_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routers_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_routes_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_add_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_add_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_get_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_get_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_list_preconfigured_expression_sets_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_list_preconfigured_expression_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_patch_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_patch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_remove_rule_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_remove_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_security_policies_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_service_attachments_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshot_settings_service_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshot_settings_service_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshot_settings_service_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshot_settings_service_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_update_kms_key_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_snapshots_update_kms_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_certificates_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_list_available_features_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_list_available_features_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_ssl_policies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pool_types_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pool_types_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pool_types_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pool_types_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pool_types_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pool_types_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_list_disks_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_list_disks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_storage_pools_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_expand_ip_cidr_range_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_expand_ip_cidr_range_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_get_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_list_usable_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_list_usable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_set_iam_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_set_private_ip_google_access_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_set_private_ip_google_access_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_subnetworks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_grpc_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_http_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_certificate_map_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_quic_override_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_quic_override_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_ssl_certificates_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_ssl_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_ssl_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_ssl_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_url_map_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_https_proxies_set_url_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_set_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_instances_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_add_health_check_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_add_health_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_add_instance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_add_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_get_health_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_get_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_remove_health_check_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_remove_health_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_remove_instance_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_remove_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_set_backup_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_set_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_set_security_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_set_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_pools_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_backend_service_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_backend_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_certificate_map_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_certificate_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_proxy_header_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_proxy_header_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_ssl_certificates_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_ssl_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_ssl_policy_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_set_ssl_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_ssl_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_set_backend_service_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_set_backend_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_set_proxy_header_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_set_proxy_header_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_tcp_proxies_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_target_vpn_gateways_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_invalidate_cache_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_invalidate_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_validate_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_url_maps_validate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_get_status_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_get_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_test_iam_permissions_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_gateways_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_aggregated_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_aggregated_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_set_labels_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_vpn_tunnels_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_patch_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_wire_groups_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_wait_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_operations_wait_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_delete_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_insert_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_insert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_update_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zone_vm_extension_policies_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zones_get_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zones_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zones_list_sync.py
+++ b/packages/google-cloud-compute/samples/generated_samples/compute_v1_generated_zones_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/tests/__init__.py
+++ b/packages/google-cloud-compute/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/tests/unit/__init__.py
+++ b/packages/google-cloud-compute/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-compute/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-compute/tests/unit/gapic/compute_v1/__init__.py
+++ b/packages/google-cloud-compute/tests/unit/gapic/compute_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/.flake8
+++ b/packages/google-cloud-confidentialcomputing/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/MANIFEST.in
+++ b/packages/google-cloud-confidentialcomputing/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing/gapic_version.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/gapic_version.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/async_client.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/client.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/base.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/grpc.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/grpc_asyncio.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/rest.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/rest_base.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/services/confidential_computing/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/types/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/types/service.py
+++ b/packages/google-cloud-confidentialcomputing/google/cloud/confidentialcomputing_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_create_challenge_async.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_create_challenge_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_create_challenge_sync.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_create_challenge_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_attestation_async.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_attestation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_attestation_sync.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_attestation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_gke_async.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_gke_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_gke_sync.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_gke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_space_async.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_space_sync.py
+++ b/packages/google-cloud-confidentialcomputing/samples/generated_samples/confidentialcomputing_v1_generated_confidential_computing_verify_confidential_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/tests/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/tests/unit/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-confidentialcomputing/tests/unit/gapic/confidentialcomputing_v1/__init__.py
+++ b/packages/google-cloud-confidentialcomputing/tests/unit/gapic/confidentialcomputing_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/.flake8
+++ b/packages/google-cloud-config/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/MANIFEST.in
+++ b/packages/google-cloud-config/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config/__init__.py
+++ b/packages/google-cloud-config/google/cloud/config/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config/gapic_version.py
+++ b/packages/google-cloud-config/google/cloud/config/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/gapic_version.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/__init__.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/__init__.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/client.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/pagers.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/__init__.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/base.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/grpc.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/grpc_asyncio.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/rest.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/rest_base.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/types/__init__.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/google/cloud/config_v1/types/config.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/types/config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_create_deployment_group_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_create_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_create_deployment_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_create_preview_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_create_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_deployment_group_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_deployment_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_preview_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_statefile_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_statefile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_statefile_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_delete_statefile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_deprovision_deployment_group_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_deprovision_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_deployment_statefile_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_deployment_statefile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_deployment_statefile_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_deployment_statefile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_lock_info_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_lock_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_lock_info_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_lock_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_preview_result_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_preview_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_preview_result_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_preview_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_revision_statefile_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_revision_statefile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_revision_statefile_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_export_revision_statefile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_auto_migration_config_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_auto_migration_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_auto_migration_config_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_auto_migration_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_revision_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_revision_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_preview_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_preview_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_preview_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_change_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_change_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_change_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_change_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_drift_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_drift_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_drift_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_drift_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_revision_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_revision_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_terraform_version_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_terraform_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_terraform_version_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_get_terraform_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_import_statefile_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_import_statefile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_import_statefile_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_import_statefile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_group_revisions_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_group_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_group_revisions_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_group_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_groups_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_groups_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployment_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployments_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployments_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_previews_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_previews_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_previews_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_previews_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_changes_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_changes_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_drifts_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_drifts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_drifts_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resource_drifts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resources_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resources_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_revisions_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_revisions_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_terraform_versions_async.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_terraform_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_terraform_versions_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_list_terraform_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_lock_deployment_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_lock_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_provision_deployment_group_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_provision_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_unlock_deployment_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_unlock_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_update_auto_migration_config_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_update_auto_migration_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_update_deployment_group_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_update_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_update_deployment_sync.py
+++ b/packages/google-cloud-config/samples/generated_samples/config_v1_generated_config_update_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/tests/__init__.py
+++ b/packages/google-cloud-config/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/tests/unit/__init__.py
+++ b/packages/google-cloud-config/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-config/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-config/tests/unit/gapic/config_v1/__init__.py
+++ b/packages/google-cloud-config/tests/unit/gapic/config_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/.flake8
+++ b/packages/google-cloud-configdelivery/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/MANIFEST.in
+++ b/packages/google-cloud-configdelivery/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery/gapic_version.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/gapic_version.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/client.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/pagers.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/base.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/grpc.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/grpc_asyncio.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/rest.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/rest_base.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/services/config_delivery/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/types/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/types/config_delivery.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1/types/config_delivery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/gapic_version.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/client.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/pagers.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/base.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/grpc.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/grpc_asyncio.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/rest.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/rest_base.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/services/config_delivery/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/types/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/types/config_delivery.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1alpha/types/config_delivery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/gapic_version.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/client.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/pagers.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/base.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/grpc.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/grpc_asyncio.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/rest.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/rest_base.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/services/config_delivery/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/types/__init__.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/types/config_delivery.py
+++ b/packages/google-cloud-configdelivery/google/cloud/configdelivery_v1beta/types/config_delivery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_abort_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_abort_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_create_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_delete_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_fleet_package_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_fleet_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_release_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_resource_bundle_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_resource_bundle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_rollout_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_variant_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_variant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_get_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_fleet_packages_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_fleet_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_fleet_packages_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_fleet_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_releases_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_releases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_releases_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_releases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_resource_bundles_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_resource_bundles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_resource_bundles_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_resource_bundles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_rollouts_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_rollouts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_rollouts_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_rollouts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_variants_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_variants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_variants_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_list_variants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_resume_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_resume_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_suspend_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_suspend_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1_generated_config_delivery_update_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_abort_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_abort_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_create_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_delete_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_fleet_package_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_fleet_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_release_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_resource_bundle_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_resource_bundle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_rollout_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_variant_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_variant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_get_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_fleet_packages_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_fleet_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_fleet_packages_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_fleet_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_releases_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_releases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_releases_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_releases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_resource_bundles_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_resource_bundles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_resource_bundles_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_resource_bundles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_rollouts_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_rollouts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_rollouts_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_rollouts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_variants_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_variants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_variants_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_list_variants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_resume_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_resume_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_suspend_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_suspend_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1alpha_generated_config_delivery_update_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_abort_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_abort_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_create_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_delete_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_fleet_package_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_fleet_package_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_release_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_resource_bundle_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_resource_bundle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_rollout_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_variant_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_variant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_get_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_fleet_packages_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_fleet_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_fleet_packages_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_fleet_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_releases_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_releases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_releases_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_releases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_resource_bundles_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_resource_bundles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_resource_bundles_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_resource_bundles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_rollouts_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_rollouts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_rollouts_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_rollouts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_variants_async.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_variants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_variants_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_list_variants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_resume_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_resume_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_suspend_rollout_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_suspend_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_fleet_package_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_fleet_package_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_release_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_resource_bundle_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_resource_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_variant_sync.py
+++ b/packages/google-cloud-configdelivery/samples/generated_samples/configdelivery_v1beta_generated_config_delivery_update_variant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/tests/__init__.py
+++ b/packages/google-cloud-configdelivery/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/tests/unit/__init__.py
+++ b/packages/google-cloud-configdelivery/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-configdelivery/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/tests/unit/gapic/configdelivery_v1/__init__.py
+++ b/packages/google-cloud-configdelivery/tests/unit/gapic/configdelivery_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/tests/unit/gapic/configdelivery_v1alpha/__init__.py
+++ b/packages/google-cloud-configdelivery/tests/unit/gapic/configdelivery_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-configdelivery/tests/unit/gapic/configdelivery_v1beta/__init__.py
+++ b/packages/google-cloud-configdelivery/tests/unit/gapic/configdelivery_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/.flake8
+++ b/packages/google-cloud-contact-center-insights/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/MANIFEST.in
+++ b/packages/google-cloud-contact-center-insights/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights/__init__.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights/gapic_version.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/gapic_version.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/__init__.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/__init__.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/client.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/pagers.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/__init__.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/base.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/grpc.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/rest.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/rest_base.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/services/contact_center_insights/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/types/__init__.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/types/contact_center_insights.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/types/contact_center_insights.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/types/resources.py
+++ b/packages/google-cloud-contact-center-insights/google/cloud/contact_center_insights_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_analyze_conversations_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_analyze_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_delete_conversations_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_delete_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_download_feedback_labels_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_download_feedback_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_upload_feedback_labels_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_bulk_upload_feedback_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_issue_model_stats_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_issue_model_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_issue_model_stats_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_issue_model_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_stats_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_stats_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_calculate_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_analysis_rule_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_analysis_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_analysis_rule_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_analysis_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_analysis_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_conversation_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_conversation_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_feedback_label_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_feedback_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_feedback_label_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_feedback_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_phrase_matcher_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_phrase_matcher_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_phrase_matcher_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_phrase_matcher_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_question_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_question_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_revision_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_revision_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_qa_scorecard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_view_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_view_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_create_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_rule_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_rule_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_conversation_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_conversation_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_feedback_label_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_feedback_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_feedback_label_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_feedback_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_issue_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_issue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_issue_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_phrase_matcher_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_phrase_matcher_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_phrase_matcher_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_phrase_matcher_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_question_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_question_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_revision_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_revision_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_qa_scorecard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_view_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_view_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_delete_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_deploy_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_deploy_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_deploy_qa_scorecard_revision_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_deploy_qa_scorecard_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_deploy_qa_scorecard_revision_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_deploy_qa_scorecard_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_export_insights_data_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_export_insights_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_export_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_export_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_rule_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_rule_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_conversation_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_conversation_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_encryption_spec_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_encryption_spec_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_encryption_spec_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_encryption_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_feedback_label_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_feedback_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_feedback_label_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_feedback_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_model_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_phrase_matcher_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_phrase_matcher_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_phrase_matcher_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_phrase_matcher_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_question_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_question_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_revision_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_revision_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_qa_scorecard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_settings_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_settings_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_view_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_view_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_get_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_import_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_import_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_ingest_conversations_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_ingest_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_initialize_encryption_spec_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_initialize_encryption_spec_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_all_feedback_labels_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_all_feedback_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_all_feedback_labels_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_all_feedback_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analyses_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analyses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analyses_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analyses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analysis_rules_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analysis_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analysis_rules_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_analysis_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_conversations_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_conversations_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_feedback_labels_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_feedback_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_feedback_labels_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_feedback_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issue_models_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issue_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issue_models_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issue_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issues_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issues_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_phrase_matchers_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_phrase_matchers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_phrase_matchers_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_phrase_matchers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_questions_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_questions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_questions_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_questions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecard_revisions_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecard_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecard_revisions_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecard_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecards_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecards_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecards_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_qa_scorecards_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_views_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_views_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_views_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_list_views_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_query_metrics_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_query_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_tune_qa_scorecard_revision_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_tune_qa_scorecard_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_undeploy_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_undeploy_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_undeploy_qa_scorecard_revision_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_undeploy_qa_scorecard_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_undeploy_qa_scorecard_revision_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_undeploy_qa_scorecard_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_analysis_rule_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_analysis_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_analysis_rule_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_analysis_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_conversation_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_conversation_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_feedback_label_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_feedback_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_feedback_label_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_feedback_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_model_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_model_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_phrase_matcher_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_phrase_matcher_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_phrase_matcher_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_phrase_matcher_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_question_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_question_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_scorecard_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_scorecard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_scorecard_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_qa_scorecard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_settings_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_settings_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_view_async.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_view_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_update_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_upload_conversation_sync.py
+++ b/packages/google-cloud-contact-center-insights/samples/generated_samples/contactcenterinsights_v1_generated_contact_center_insights_upload_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/tests/__init__.py
+++ b/packages/google-cloud-contact-center-insights/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/tests/unit/__init__.py
+++ b/packages/google-cloud-contact-center-insights/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-contact-center-insights/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contact-center-insights/tests/unit/gapic/contact_center_insights_v1/__init__.py
+++ b/packages/google-cloud-contact-center-insights/tests/unit/gapic/contact_center_insights_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/.flake8
+++ b/packages/google-cloud-container/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/MANIFEST.in
+++ b/packages/google-cloud-container/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container/gapic_version.py
+++ b/packages/google-cloud-container/google/cloud/container/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/gapic_version.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/async_client.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/client.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/pagers.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/base.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/grpc.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/rest.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/rest_base.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/services/cluster_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/types/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1/types/cluster_service.py
+++ b/packages/google-cloud-container/google/cloud/container_v1/types/cluster_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/gapic_version.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/async_client.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/client.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/pagers.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/base.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/grpc.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/services/cluster_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/types/__init__.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/google/cloud/container_v1beta1/types/cluster_service.py
+++ b/packages/google-cloud-container/google/cloud/container_v1beta1/types/cluster_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_cancel_operation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_cancel_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_cancel_operation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_cancel_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_check_autopilot_compatibility_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_check_autopilot_compatibility_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_check_autopilot_compatibility_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_check_autopilot_compatibility_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_ip_rotation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_ip_rotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_ip_rotation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_ip_rotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_node_pool_upgrade_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_node_pool_upgrade_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_node_pool_upgrade_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_complete_node_pool_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_create_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_delete_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_cluster_upgrade_info_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_cluster_upgrade_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_cluster_upgrade_info_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_cluster_upgrade_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_node_pool_upgrade_info_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_node_pool_upgrade_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_node_pool_upgrade_info_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_fetch_node_pool_upgrade_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_json_web_keys_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_json_web_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_json_web_keys_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_json_web_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_operation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_operation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_server_config_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_server_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_server_config_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_get_server_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_clusters_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_clusters_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_node_pools_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_node_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_node_pools_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_node_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_operations_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_operations_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_usable_subnetworks_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_usable_subnetworks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_usable_subnetworks_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_list_usable_subnetworks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_rollback_node_pool_upgrade_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_rollback_node_pool_upgrade_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_rollback_node_pool_upgrade_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_rollback_node_pool_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_addons_config_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_addons_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_addons_config_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_addons_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_labels_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_labels_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_legacy_abac_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_legacy_abac_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_legacy_abac_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_legacy_abac_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_locations_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_locations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_locations_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_locations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_logging_service_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_logging_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_logging_service_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_logging_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_maintenance_policy_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_maintenance_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_maintenance_policy_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_maintenance_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_master_auth_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_master_auth_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_master_auth_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_master_auth_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_monitoring_service_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_monitoring_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_monitoring_service_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_monitoring_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_network_policy_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_network_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_network_policy_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_network_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_autoscaling_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_autoscaling_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_autoscaling_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_autoscaling_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_management_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_management_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_management_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_management_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_size_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_size_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_size_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_set_node_pool_size_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_start_ip_rotation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_start_ip_rotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_start_ip_rotation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_start_ip_rotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_master_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_master_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_master_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_master_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1_generated_cluster_manager_update_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_cancel_operation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_cancel_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_cancel_operation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_cancel_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_check_autopilot_compatibility_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_check_autopilot_compatibility_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_check_autopilot_compatibility_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_check_autopilot_compatibility_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_control_plane_upgrade_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_control_plane_upgrade_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_control_plane_upgrade_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_control_plane_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_ip_rotation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_ip_rotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_ip_rotation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_ip_rotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_node_pool_upgrade_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_node_pool_upgrade_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_node_pool_upgrade_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_complete_node_pool_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_create_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_delete_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_cluster_upgrade_info_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_cluster_upgrade_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_cluster_upgrade_info_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_cluster_upgrade_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_node_pool_upgrade_info_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_node_pool_upgrade_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_node_pool_upgrade_info_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_fetch_node_pool_upgrade_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_json_web_keys_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_json_web_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_json_web_keys_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_json_web_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_operation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_operation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_server_config_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_server_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_server_config_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_get_server_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_clusters_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_clusters_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_locations_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_locations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_locations_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_locations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_node_pools_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_node_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_node_pools_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_node_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_operations_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_operations_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_usable_subnetworks_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_usable_subnetworks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_usable_subnetworks_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_list_usable_subnetworks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_rollback_node_pool_upgrade_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_rollback_node_pool_upgrade_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_rollback_node_pool_upgrade_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_rollback_node_pool_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_addons_config_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_addons_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_addons_config_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_addons_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_labels_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_labels_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_legacy_abac_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_legacy_abac_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_legacy_abac_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_legacy_abac_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_locations_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_locations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_locations_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_locations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_logging_service_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_logging_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_logging_service_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_logging_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_maintenance_policy_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_maintenance_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_maintenance_policy_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_maintenance_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_master_auth_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_master_auth_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_master_auth_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_master_auth_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_monitoring_service_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_monitoring_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_monitoring_service_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_monitoring_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_network_policy_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_network_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_network_policy_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_network_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_autoscaling_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_autoscaling_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_autoscaling_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_autoscaling_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_management_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_management_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_management_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_management_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_size_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_size_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_size_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_set_node_pool_size_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_start_ip_rotation_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_start_ip_rotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_start_ip_rotation_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_start_ip_rotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_cluster_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_cluster_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_master_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_master_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_master_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_master_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_node_pool_async.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_node_pool_sync.py
+++ b/packages/google-cloud-container/samples/generated_samples/container_v1beta1_generated_cluster_manager_update_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/tests/__init__.py
+++ b/packages/google-cloud-container/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/tests/unit/__init__.py
+++ b/packages/google-cloud-container/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-container/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/tests/unit/gapic/container_v1/__init__.py
+++ b/packages/google-cloud-container/tests/unit/gapic/container_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-container/tests/unit/gapic/container_v1beta1/__init__.py
+++ b/packages/google-cloud-container/tests/unit/gapic/container_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/.flake8
+++ b/packages/google-cloud-containeranalysis/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/MANIFEST.in
+++ b/packages/google-cloud-containeranalysis/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis/__init__.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis/gapic_version.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/gapic_version.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/__init__.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/__init__.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/async_client.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/client.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/__init__.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/base.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/grpc.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/grpc_asyncio.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/rest.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/rest_base.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/types/__init__.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/types/containeranalysis.py
+++ b/packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/types/containeranalysis.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_export_sbom_async.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_export_sbom_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_export_sbom_sync.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_export_sbom_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_iam_policy_async.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_iam_policy_sync.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_vulnerability_occurrences_summary_async.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_vulnerability_occurrences_summary_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_vulnerability_occurrences_summary_sync.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_get_vulnerability_occurrences_summary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_set_iam_policy_async.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_set_iam_policy_sync.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_test_iam_permissions_async.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_test_iam_permissions_sync.py
+++ b/packages/google-cloud-containeranalysis/samples/generated_samples/containeranalysis_v1_generated_container_analysis_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/tests/__init__.py
+++ b/packages/google-cloud-containeranalysis/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/tests/unit/__init__.py
+++ b/packages/google-cloud-containeranalysis/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-containeranalysis/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-containeranalysis/tests/unit/gapic/containeranalysis_v1/__init__.py
+++ b/packages/google-cloud-containeranalysis/tests/unit/gapic/containeranalysis_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/.flake8
+++ b/packages/google-cloud-contentwarehouse/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/MANIFEST.in
+++ b/packages/google-cloud-contentwarehouse/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse/gapic_version.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/gapic_version.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/async_client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/pagers.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/grpc.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/rest.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/rest_base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_link_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/async_client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/pagers.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/grpc.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/rest.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/rest_base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_schema_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/async_client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/pagers.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/grpc.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/rest.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/rest_base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/document_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/grpc.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/rest.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/rest_base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/pipeline_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/async_client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/pagers.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/grpc.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/rest.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/rest_base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/rule_set_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/async_client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/client.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/pagers.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/grpc.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/rest.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/rest_base.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/services/synonym_set_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/__init__.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/async_document_service_request.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/async_document_service_request.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/common.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_link_service.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_link_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_schema.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_schema_service.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_schema_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_service.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_service_request.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/document_service_request.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/filters.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/filters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/histogram.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/histogram.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/pipeline_service.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/pipeline_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/pipelines.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/pipelines.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/rule_engine.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/rule_engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/ruleset_service.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/ruleset_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/ruleset_service_request.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/ruleset_service_request.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/synonymset.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/synonymset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/synonymset_service.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/synonymset_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/synonymset_service_request.py
+++ b/packages/google-cloud-contentwarehouse/google/cloud/contentwarehouse_v1/types/synonymset_service_request.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_create_document_link_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_create_document_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_create_document_link_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_create_document_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_delete_document_link_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_delete_document_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_delete_document_link_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_delete_document_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_sources_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_sources_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_targets_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_targets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_targets_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_link_service_list_linked_targets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_create_document_schema_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_create_document_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_create_document_schema_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_create_document_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_delete_document_schema_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_delete_document_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_delete_document_schema_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_delete_document_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_get_document_schema_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_get_document_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_get_document_schema_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_get_document_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_list_document_schemas_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_list_document_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_list_document_schemas_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_list_document_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_update_document_schema_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_update_document_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_update_document_schema_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_schema_service_update_document_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_create_document_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_create_document_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_delete_document_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_delete_document_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_fetch_acl_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_fetch_acl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_fetch_acl_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_fetch_acl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_get_document_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_get_document_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_lock_document_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_lock_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_lock_document_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_lock_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_search_documents_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_search_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_search_documents_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_search_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_set_acl_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_set_acl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_set_acl_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_set_acl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_update_document_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_update_document_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_document_service_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_pipeline_service_run_pipeline_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_pipeline_service_run_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_create_rule_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_create_rule_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_create_rule_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_create_rule_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_delete_rule_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_delete_rule_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_delete_rule_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_delete_rule_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_get_rule_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_get_rule_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_get_rule_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_get_rule_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_list_rule_sets_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_list_rule_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_list_rule_sets_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_list_rule_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_update_rule_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_update_rule_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_update_rule_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_rule_set_service_update_rule_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_create_synonym_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_create_synonym_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_create_synonym_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_create_synonym_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_delete_synonym_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_delete_synonym_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_delete_synonym_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_delete_synonym_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_get_synonym_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_get_synonym_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_get_synonym_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_get_synonym_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_list_synonym_sets_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_list_synonym_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_list_synonym_sets_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_list_synonym_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_update_synonym_set_async.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_update_synonym_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_update_synonym_set_sync.py
+++ b/packages/google-cloud-contentwarehouse/samples/generated_samples/contentwarehouse_v1_generated_synonym_set_service_update_synonym_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/tests/__init__.py
+++ b/packages/google-cloud-contentwarehouse/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/tests/unit/__init__.py
+++ b/packages/google-cloud-contentwarehouse/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-contentwarehouse/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-contentwarehouse/tests/unit/gapic/contentwarehouse_v1/__init__.py
+++ b/packages/google-cloud-contentwarehouse/tests/unit/gapic/contentwarehouse_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/.flake8
+++ b/packages/google-cloud-data-fusion/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/MANIFEST.in
+++ b/packages/google-cloud-data-fusion/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion/__init__.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion/gapic_version.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/gapic_version.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/__init__.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/__init__.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/client.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/pagers.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/__init__.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/base.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/grpc.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/grpc_asyncio.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/rest.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/rest_base.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/services/data_fusion/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/types/__init__.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/types/datafusion.py
+++ b/packages/google-cloud-data-fusion/google/cloud/data_fusion_v1/types/datafusion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_create_instance_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_delete_instance_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_get_instance_async.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_get_instance_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_available_versions_async.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_available_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_available_versions_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_available_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_instances_async.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_instances_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_restart_instance_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_restart_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_update_instance_sync.py
+++ b/packages/google-cloud-data-fusion/samples/generated_samples/datafusion_v1_generated_data_fusion_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/tests/__init__.py
+++ b/packages/google-cloud-data-fusion/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/tests/unit/__init__.py
+++ b/packages/google-cloud-data-fusion/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-data-fusion/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-fusion/tests/unit/gapic/data_fusion_v1/__init__.py
+++ b/packages/google-cloud-data-fusion/tests/unit/gapic/data_fusion_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/.flake8
+++ b/packages/google-cloud-data-qna/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/MANIFEST.in
+++ b/packages/google-cloud-data-qna/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna/gapic_version.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/gapic_version.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/async_client.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/client.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/base.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/grpc.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/rest.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/rest_base.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/auto_suggestion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/async_client.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/client.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/base.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/grpc.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/rest.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/rest_base.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/services/question_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/__init__.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/annotated_string.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/annotated_string.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/auto_suggestion_service.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/auto_suggestion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/question.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/question.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/question_service.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/question_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/user_feedback.py
+++ b/packages/google-cloud-data-qna/google/cloud/dataqna_v1alpha/types/user_feedback.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_auto_suggestion_service_suggest_queries_async.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_auto_suggestion_service_suggest_queries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_auto_suggestion_service_suggest_queries_sync.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_auto_suggestion_service_suggest_queries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_create_question_async.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_create_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_create_question_sync.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_create_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_execute_question_async.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_execute_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_execute_question_sync.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_execute_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_question_async.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_question_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_question_sync.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_question_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_user_feedback_async.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_user_feedback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_user_feedback_sync.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_get_user_feedback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_update_user_feedback_async.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_update_user_feedback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_update_user_feedback_sync.py
+++ b/packages/google-cloud-data-qna/samples/generated_samples/dataqna_v1alpha_generated_question_service_update_user_feedback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/tests/__init__.py
+++ b/packages/google-cloud-data-qna/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/tests/unit/__init__.py
+++ b/packages/google-cloud-data-qna/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-data-qna/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-data-qna/tests/unit/gapic/dataqna_v1alpha/__init__.py
+++ b/packages/google-cloud-data-qna/tests/unit/gapic/dataqna_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/.flake8
+++ b/packages/google-cloud-databasecenter/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/MANIFEST.in
+++ b/packages/google-cloud-databasecenter/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter/__init__.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter/gapic_version.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/gapic_version.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/__init__.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/__init__.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/async_client.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/client.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/pagers.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/__init__.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/base.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/grpc.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/grpc_asyncio.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/rest.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/rest_base.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/services/database_center/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/__init__.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/affiliation.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/affiliation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/machine_config.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/machine_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/maintenance.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/maintenance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/metric_data.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/metric_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/operation_error_type.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/operation_error_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/product.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/product.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/service.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/signals.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/signals.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/suspension_reason.py
+++ b/packages/google-cloud-databasecenter/google/cloud/databasecenter_v1beta/types/suspension_reason.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_fleet_async.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_fleet_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_fleet_sync.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_fleet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_issue_stats_async.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_issue_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_issue_stats_sync.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_aggregate_issue_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_database_resource_groups_async.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_database_resource_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_database_resource_groups_sync.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_database_resource_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_issues_async.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_issues_sync.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_products_async.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_products_sync.py
+++ b/packages/google-cloud-databasecenter/samples/generated_samples/databasecenter_v1beta_generated_database_center_query_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/tests/__init__.py
+++ b/packages/google-cloud-databasecenter/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/tests/unit/__init__.py
+++ b/packages/google-cloud-databasecenter/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-databasecenter/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-databasecenter/tests/unit/gapic/databasecenter_v1beta/__init__.py
+++ b/packages/google-cloud-databasecenter/tests/unit/gapic/databasecenter_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/.flake8
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/MANIFEST.in
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement/gapic_version.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/gapic_version.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/async_client.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/client.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/base.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/grpc.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/rest.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/rest_base.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/services/config_management_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/types/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/types/configmanagement.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/google/cloud/datacatalog_lineage_configmanagement_v1/types/configmanagement.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_get_config_async.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_get_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_get_config_sync.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_get_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_update_config_async.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_update_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_update_config_sync.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/samples/generated_samples/datalineage_v1_generated_config_management_service_update_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/tests/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/tests/unit/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/tests/unit/gapic/datacatalog_lineage_configmanagement_v1/__init__.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/tests/unit/gapic/datacatalog_lineage_configmanagement_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/.flake8
+++ b/packages/google-cloud-datacatalog/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/MANIFEST.in
+++ b/packages/google-cloud-datacatalog/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog/gapic_version.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/gapic_version.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/pagers.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/base.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/grpc.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/data_catalog/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/async_client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/pagers.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/base.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/grpc.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/async_client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/base.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/grpc.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/services/policy_tag_manager_serialization/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/bigquery.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/bigquery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/common.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/data_source.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/data_source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/datacatalog.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/datacatalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/dataplex_spec.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/dataplex_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/dump_content.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/dump_content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/gcs_fileset_spec.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/gcs_fileset_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/physical_schema.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/physical_schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/policytagmanager.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/policytagmanager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/policytagmanagerserialization.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/policytagmanagerserialization.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/schema.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/search.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/table_spec.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/table_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/tags.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/tags.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/timestamps.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/timestamps.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/usage.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1/types/usage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/gapic_version.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/async_client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/pagers.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/base.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/grpc.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/data_catalog/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/async_client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/pagers.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/base.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/grpc.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/async_client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/client.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/base.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/grpc.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/services/policy_tag_manager_serialization/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/__init__.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/common.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/datacatalog.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/datacatalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/gcs_fileset_spec.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/gcs_fileset_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/policytagmanager.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/policytagmanager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/policytagmanagerserialization.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/policytagmanagerserialization.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/schema.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/search.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/table_spec.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/table_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/tags.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/tags.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/timestamps.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/timestamps.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_create_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_delete_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_get_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_import_entries_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_import_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entries_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entries_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entry_groups_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entry_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entry_groups_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_entry_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_tags_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_tags_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_list_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_lookup_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_lookup_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_lookup_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_lookup_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_contacts_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_contacts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_contacts_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_contacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_overview_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_overview_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_overview_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_modify_entry_overview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_reconcile_tags_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_reconcile_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_enum_value_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_enum_value_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_enum_value_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_enum_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_rename_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_config_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_config_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_effective_config_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_effective_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_effective_config_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_retrieve_effective_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_search_catalog_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_search_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_search_catalog_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_search_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_config_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_config_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_star_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_star_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_star_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_star_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_test_iam_permissions_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_test_iam_permissions_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_unstar_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_unstar_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_unstar_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_unstar_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_data_catalog_update_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_create_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_delete_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_get_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_policy_tags_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_policy_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_policy_tags_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_policy_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_taxonomies_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_taxonomies_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_list_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_export_taxonomies_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_export_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_export_taxonomies_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_export_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_import_taxonomies_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_import_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_import_taxonomies_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_import_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_replace_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_replace_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_replace_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_serialization_replace_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_set_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_set_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_test_iam_permissions_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_test_iam_permissions_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1_generated_policy_tag_manager_update_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_create_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_delete_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_get_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entries_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entries_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entry_groups_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entry_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entry_groups_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_entry_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_tags_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_tags_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_list_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_lookup_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_lookup_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_lookup_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_lookup_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_enum_value_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_enum_value_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_enum_value_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_enum_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_rename_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_search_catalog_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_search_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_search_catalog_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_search_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_set_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_set_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_test_iam_permissions_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_test_iam_permissions_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_group_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_group_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_field_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_field_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_data_catalog_update_tag_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_create_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_delete_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_get_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_policy_tags_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_policy_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_policy_tags_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_policy_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_taxonomies_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_taxonomies_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_list_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_export_taxonomies_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_export_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_export_taxonomies_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_export_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_import_taxonomies_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_import_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_import_taxonomies_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_serialization_import_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_set_iam_policy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_set_iam_policy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_test_iam_permissions_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_test_iam_permissions_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_policy_tag_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_policy_tag_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_policy_tag_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_policy_tag_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_taxonomy_async.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_taxonomy_sync.py
+++ b/packages/google-cloud-datacatalog/samples/generated_samples/datacatalog_v1beta1_generated_policy_tag_manager_update_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/tests/__init__.py
+++ b/packages/google-cloud-datacatalog/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/tests/unit/__init__.py
+++ b/packages/google-cloud-datacatalog/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-datacatalog/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/tests/unit/gapic/datacatalog_v1/__init__.py
+++ b/packages/google-cloud-datacatalog/tests/unit/gapic/datacatalog_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datacatalog/tests/unit/gapic/datacatalog_v1beta1/__init__.py
+++ b/packages/google-cloud-datacatalog/tests/unit/gapic/datacatalog_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/.flake8
+++ b/packages/google-cloud-dataflow-client/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/MANIFEST.in
+++ b/packages/google-cloud-dataflow-client/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow/gapic_version.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/gapic_version.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/async_client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/grpc.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/rest.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/rest_base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/flex_templates_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/async_client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/pagers.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/grpc.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/rest.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/rest_base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/jobs_v1_beta3/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/async_client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/pagers.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/grpc.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/rest.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/rest_base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/messages_v1_beta3/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/async_client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/pagers.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/grpc.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/rest.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/rest_base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/metrics_v1_beta3/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/async_client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/grpc.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/rest.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/rest_base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/snapshots_v1_beta3/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/async_client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/client.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/grpc.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/rest.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/rest_base.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/services/templates_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/__init__.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/environment.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/environment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/jobs.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/jobs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/messages.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/metrics.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/metrics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/snapshots.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/snapshots.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/streaming.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/streaming.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/templates.py
+++ b/packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/templates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_flex_templates_service_launch_flex_template_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_flex_templates_service_launch_flex_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_flex_templates_service_launch_flex_template_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_flex_templates_service_launch_flex_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_aggregated_list_jobs_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_aggregated_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_aggregated_list_jobs_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_aggregated_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_check_active_jobs_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_check_active_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_check_active_jobs_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_check_active_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_create_job_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_create_job_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_get_job_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_get_job_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_list_jobs_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_list_jobs_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_snapshot_job_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_snapshot_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_snapshot_job_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_snapshot_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_update_job_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_update_job_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_jobs_v1_beta3_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_messages_v1_beta3_list_job_messages_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_messages_v1_beta3_list_job_messages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_messages_v1_beta3_list_job_messages_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_messages_v1_beta3_list_job_messages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_execution_details_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_execution_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_execution_details_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_execution_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_metrics_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_metrics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_metrics_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_job_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_stage_execution_details_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_stage_execution_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_stage_execution_details_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_metrics_v1_beta3_get_stage_execution_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_delete_snapshot_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_delete_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_delete_snapshot_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_delete_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_get_snapshot_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_get_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_get_snapshot_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_get_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_list_snapshots_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_list_snapshots_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_list_snapshots_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_snapshots_v1_beta3_list_snapshots_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_create_job_from_template_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_create_job_from_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_create_job_from_template_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_create_job_from_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_get_template_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_get_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_get_template_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_get_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_launch_template_async.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_launch_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_launch_template_sync.py
+++ b/packages/google-cloud-dataflow-client/samples/generated_samples/dataflow_v1beta3_generated_templates_service_launch_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/tests/__init__.py
+++ b/packages/google-cloud-dataflow-client/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/tests/unit/__init__.py
+++ b/packages/google-cloud-dataflow-client/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dataflow-client/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataflow-client/tests/unit/gapic/dataflow_v1beta3/__init__.py
+++ b/packages/google-cloud-dataflow-client/tests/unit/gapic/dataflow_v1beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/.flake8
+++ b/packages/google-cloud-dataform/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/MANIFEST.in
+++ b/packages/google-cloud-dataform/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform/gapic_version.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/gapic_version.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/client.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/pagers.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/base.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/grpc.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/rest.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/rest_base.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/services/dataform/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/types/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1/types/dataform.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1/types/dataform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/gapic_version.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/client.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/pagers.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/base.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/grpc.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/rest.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/rest_base.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/services/dataform/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/types/__init__.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/types/dataform.py
+++ b/packages/google-cloud-dataform/google/cloud/dataform_v1beta1/types/dataform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_cancel_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_cancel_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_cancel_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_cancel_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_repository_changes_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_repository_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_repository_changes_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_repository_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_workspace_changes_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_workspace_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_workspace_changes_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_commit_workspace_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_compute_repository_access_token_status_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_compute_repository_access_token_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_compute_repository_access_token_status_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_compute_repository_access_token_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_compilation_result_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_compilation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_compilation_result_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_compilation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workspace_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workspace_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_create_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_folder_tree_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_folder_tree_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_team_folder_tree_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_team_folder_tree_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workspace_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workspace_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_delete_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_diff_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_diff_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_diff_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_diff_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_git_statuses_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_git_statuses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_git_statuses_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_file_git_statuses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_git_ahead_behind_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_git_ahead_behind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_git_ahead_behind_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_git_ahead_behind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_remote_branches_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_remote_branches_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_remote_branches_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_remote_branches_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_repository_history_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_repository_history_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_repository_history_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_fetch_repository_history_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_compilation_result_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_compilation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_compilation_result_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_compilation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_iam_policy_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_iam_policy_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workspace_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workspace_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_get_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_install_npm_packages_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_install_npm_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_install_npm_packages_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_install_npm_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_compilation_results_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_compilation_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_compilation_results_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_compilation_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_release_configs_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_release_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_release_configs_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_release_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_repositories_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_repositories_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_configs_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_configs_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_invocations_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_invocations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_invocations_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workflow_invocations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workspaces_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workspaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workspaces_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_list_workspaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_make_directory_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_make_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_make_directory_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_make_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_directory_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_directory_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_move_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_pull_git_commits_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_pull_git_commits_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_pull_git_commits_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_pull_git_commits_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_push_git_commits_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_push_git_commits_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_push_git_commits_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_push_git_commits_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_compilation_result_actions_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_compilation_result_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_compilation_result_actions_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_compilation_result_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_directory_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_directory_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_directory_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_directory_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_folder_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_folder_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_folder_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_folder_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_repository_directory_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_repository_directory_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_repository_directory_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_repository_directory_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_team_folder_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_team_folder_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_team_folder_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_team_folder_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_user_root_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_user_root_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_user_root_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_user_root_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_workflow_invocation_actions_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_workflow_invocation_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_workflow_invocation_actions_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_query_workflow_invocation_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_repository_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_repository_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_repository_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_read_repository_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_directory_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_directory_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_remove_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_reset_workspace_changes_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_reset_workspace_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_reset_workspace_changes_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_reset_workspace_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_files_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_files_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_team_folders_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_team_folders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_team_folders_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_search_team_folders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_set_iam_policy_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_set_iam_policy_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_test_iam_permissions_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_test_iam_permissions_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_update_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_write_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_write_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_write_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1_generated_dataform_write_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_cancel_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_cancel_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_cancel_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_cancel_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_repository_changes_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_repository_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_repository_changes_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_repository_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_workspace_changes_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_workspace_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_workspace_changes_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_commit_workspace_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_compute_repository_access_token_status_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_compute_repository_access_token_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_compute_repository_access_token_status_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_compute_repository_access_token_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_compilation_result_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_compilation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_compilation_result_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_compilation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workspace_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workspace_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_create_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workspace_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workspace_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_delete_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_diff_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_diff_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_diff_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_diff_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_git_statuses_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_git_statuses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_git_statuses_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_file_git_statuses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_git_ahead_behind_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_git_ahead_behind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_git_ahead_behind_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_git_ahead_behind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_remote_branches_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_remote_branches_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_remote_branches_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_remote_branches_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_repository_history_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_repository_history_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_repository_history_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_fetch_repository_history_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_compilation_result_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_compilation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_compilation_result_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_compilation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_iam_policy_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_iam_policy_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_invocation_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_invocation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_invocation_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workflow_invocation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workspace_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workspace_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_get_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_install_npm_packages_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_install_npm_packages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_install_npm_packages_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_install_npm_packages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_compilation_results_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_compilation_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_compilation_results_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_compilation_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_release_configs_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_release_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_release_configs_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_release_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_repositories_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_repositories_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_configs_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_configs_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_invocations_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_invocations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_invocations_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workflow_invocations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workspaces_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workspaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workspaces_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_list_workspaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_make_directory_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_make_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_make_directory_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_make_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_directory_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_directory_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_move_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_pull_git_commits_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_pull_git_commits_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_pull_git_commits_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_pull_git_commits_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_push_git_commits_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_push_git_commits_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_push_git_commits_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_push_git_commits_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_compilation_result_actions_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_compilation_result_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_compilation_result_actions_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_compilation_result_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_directory_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_directory_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_directory_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_directory_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_folder_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_folder_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_folder_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_folder_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_repository_directory_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_repository_directory_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_repository_directory_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_repository_directory_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_team_folder_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_team_folder_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_team_folder_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_team_folder_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_user_root_contents_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_user_root_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_user_root_contents_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_user_root_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_workflow_invocation_actions_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_workflow_invocation_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_workflow_invocation_actions_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_query_workflow_invocation_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_repository_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_repository_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_repository_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_read_repository_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_directory_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_directory_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_remove_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_reset_workspace_changes_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_reset_workspace_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_reset_workspace_changes_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_reset_workspace_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_files_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_files_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_team_folders_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_team_folders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_team_folders_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_search_team_folders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_set_iam_policy_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_set_iam_policy_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_test_iam_permissions_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_test_iam_permissions_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_release_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_release_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_release_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_release_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_repository_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_repository_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_team_folder_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_team_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_team_folder_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_team_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_workflow_config_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_workflow_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_workflow_config_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_update_workflow_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_write_file_async.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_write_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_write_file_sync.py
+++ b/packages/google-cloud-dataform/samples/generated_samples/dataform_v1beta1_generated_dataform_write_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/tests/__init__.py
+++ b/packages/google-cloud-dataform/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/tests/unit/__init__.py
+++ b/packages/google-cloud-dataform/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dataform/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/tests/unit/gapic/dataform_v1/__init__.py
+++ b/packages/google-cloud-dataform/tests/unit/gapic/dataform_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataform/tests/unit/gapic/dataform_v1beta1/__init__.py
+++ b/packages/google-cloud-dataform/tests/unit/gapic/dataform_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/.flake8
+++ b/packages/google-cloud-datalabeling/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/MANIFEST.in
+++ b/packages/google-cloud-datalabeling/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling/__init__.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling/gapic_version.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/gapic_version.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/__init__.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/__init__.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/client.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/pagers.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/__init__.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/base.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/grpc.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/services/data_labeling_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/__init__.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/annotation.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/annotation_spec_set.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/annotation_spec_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/data_labeling_service.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/data_labeling_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/data_payloads.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/data_payloads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/dataset.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/evaluation.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/evaluation_job.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/evaluation_job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/human_annotation_config.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/human_annotation_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/instruction.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/instruction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/operations.py
+++ b/packages/google-cloud-datalabeling/google/cloud/datalabeling_v1beta1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_annotation_spec_set_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_annotation_spec_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_annotation_spec_set_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_annotation_spec_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_dataset_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_dataset_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_evaluation_job_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_evaluation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_evaluation_job_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_evaluation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_instruction_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_create_instruction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotated_dataset_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotated_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotated_dataset_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotated_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotation_spec_set_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotation_spec_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotation_spec_set_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_annotation_spec_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_dataset_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_dataset_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_evaluation_job_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_evaluation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_evaluation_job_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_evaluation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_instruction_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_instruction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_instruction_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_delete_instruction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_export_data_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotated_dataset_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotated_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotated_dataset_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotated_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotation_spec_set_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotation_spec_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotation_spec_set_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_annotation_spec_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_data_item_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_data_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_data_item_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_data_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_dataset_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_dataset_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_job_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_job_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_example_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_example_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_instruction_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_instruction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_instruction_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_get_instruction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_import_data_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_label_image_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_label_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_label_text_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_label_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_label_video_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_label_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotated_datasets_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotated_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotated_datasets_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotated_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotation_spec_sets_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotation_spec_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotation_spec_sets_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_annotation_spec_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_data_items_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_data_items_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_data_items_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_data_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_datasets_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_datasets_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_evaluation_jobs_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_evaluation_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_evaluation_jobs_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_evaluation_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_examples_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_examples_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_examples_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_instructions_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_instructions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_instructions_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_list_instructions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_pause_evaluation_job_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_pause_evaluation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_pause_evaluation_job_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_pause_evaluation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_resume_evaluation_job_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_resume_evaluation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_resume_evaluation_job_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_resume_evaluation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_evaluations_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_evaluations_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_example_comparisons_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_example_comparisons_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_example_comparisons_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_search_example_comparisons_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_update_evaluation_job_async.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_update_evaluation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_update_evaluation_job_sync.py
+++ b/packages/google-cloud-datalabeling/samples/generated_samples/datalabeling_v1beta1_generated_data_labeling_service_update_evaluation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/tests/__init__.py
+++ b/packages/google-cloud-datalabeling/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/tests/unit/__init__.py
+++ b/packages/google-cloud-datalabeling/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-datalabeling/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datalabeling/tests/unit/gapic/datalabeling_v1beta1/__init__.py
+++ b/packages/google-cloud-datalabeling/tests/unit/gapic/datalabeling_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/.flake8
+++ b/packages/google-cloud-dataplex/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/MANIFEST.in
+++ b/packages/google-cloud-dataplex/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex/gapic_version.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/gapic_version.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/business_glossary_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/catalog_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/cmek_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/async_client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/content_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_product_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_scan_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/data_taxonomy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/dataplex_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/async_client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/client.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/pagers.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/grpc.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/rest.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/rest_base.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/services/metadata_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/__init__.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/analyze.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/analyze.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/catalog.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/cmek.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/cmek.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/content.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_discovery.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_discovery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_documentation.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_documentation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_products.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_products.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_profile.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_profile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_quality.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_quality.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_taxonomy.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/data_taxonomy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/datascans.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/datascans.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/datascans_common.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/datascans_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/logs.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/logs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/metadata_.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/metadata_.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/processing.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/processing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/resources.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/security.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/security.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/service.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/tasks.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/tasks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_category_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_category_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_category_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_category_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_term_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_term_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_term_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_create_glossary_term_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_category_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_category_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_category_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_category_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_term_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_term_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_term_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_delete_glossary_term_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_category_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_category_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_category_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_category_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_term_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_term_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_term_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_get_glossary_term_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossaries_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossaries_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_categories_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_categories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_categories_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_categories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_terms_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_terms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_terms_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_list_glossary_terms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_category_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_category_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_category_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_category_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_term_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_term_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_term_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_business_glossary_service_update_glossary_term_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_cancel_metadata_job_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_cancel_metadata_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_cancel_metadata_job_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_cancel_metadata_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_aspect_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_aspect_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_group_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_link_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_link_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_entry_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_metadata_feed_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_metadata_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_metadata_job_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_create_metadata_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_aspect_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_aspect_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_group_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_link_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_link_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_entry_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_metadata_feed_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_delete_metadata_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_aspect_type_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_aspect_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_aspect_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_aspect_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_group_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_group_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_link_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_link_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_type_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_entry_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_feed_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_feed_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_job_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_job_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_get_metadata_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_aspect_types_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_aspect_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_aspect_types_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_aspect_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entries_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entries_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_groups_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_groups_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_types_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_types_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_entry_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_feeds_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_feeds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_feeds_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_feeds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_jobs_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_jobs_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_list_metadata_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_context_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_context_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_context_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_context_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_links_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_links_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_lookup_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_search_entries_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_search_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_search_entries_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_search_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_aspect_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_aspect_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_group_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_link_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_link_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_type_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_entry_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_metadata_feed_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_catalog_service_update_metadata_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_create_encryption_config_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_create_encryption_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_delete_encryption_config_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_delete_encryption_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_get_encryption_config_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_get_encryption_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_get_encryption_config_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_get_encryption_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_list_encryption_configs_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_list_encryption_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_list_encryption_configs_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_list_encryption_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_update_encryption_config_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_cmek_service_update_encryption_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_create_data_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_create_data_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_create_data_product_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_create_data_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_delete_data_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_delete_data_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_delete_data_product_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_delete_data_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_asset_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_product_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_product_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_get_data_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_assets_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_assets_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_products_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_products_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_list_data_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_update_data_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_update_data_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_update_data_product_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_product_service_update_data_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_create_data_scan_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_create_data_scan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_delete_data_scan_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_delete_data_scan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_generate_data_quality_rules_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_generate_data_quality_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_generate_data_quality_rules_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_generate_data_quality_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_job_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_job_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_get_data_scan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scan_jobs_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scan_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scan_jobs_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scan_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scans_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scans_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scans_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_list_data_scans_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_run_data_scan_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_run_data_scan_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_run_data_scan_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_run_data_scan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_update_data_scan_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_scan_service_update_data_scan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_create_data_attribute_binding_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_create_data_attribute_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_create_data_attribute_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_create_data_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_create_data_taxonomy_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_create_data_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_delete_data_attribute_binding_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_delete_data_attribute_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_delete_data_attribute_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_delete_data_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_delete_data_taxonomy_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_delete_data_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_binding_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_binding_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_taxonomy_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_taxonomy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_taxonomy_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_get_data_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attribute_bindings_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attribute_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attribute_bindings_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attribute_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attributes_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attributes_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_taxonomies_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_taxonomies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_taxonomies_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_list_data_taxonomies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_update_data_attribute_binding_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_update_data_attribute_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_update_data_attribute_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_update_data_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_update_data_taxonomy_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_data_taxonomy_service_update_data_taxonomy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_cancel_job_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_cancel_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_cancel_job_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_cancel_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_lake_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_lake_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_task_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_zone_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_create_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_lake_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_lake_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_task_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_zone_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_delete_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_asset_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_job_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_job_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_lake_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_lake_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_lake_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_lake_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_task_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_task_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_zone_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_zone_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_zone_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_get_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_asset_actions_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_asset_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_asset_actions_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_asset_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_assets_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_assets_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_jobs_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_jobs_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lake_actions_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lake_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lake_actions_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lake_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lakes_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lakes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lakes_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_lakes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_tasks_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_tasks_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zone_actions_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zone_actions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zone_actions_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zone_actions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zones_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zones_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zones_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_list_zones_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_run_task_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_run_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_run_task_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_run_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_asset_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_lake_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_lake_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_task_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_zone_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_dataplex_service_update_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_entity_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_entity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_entity_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_entity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_partition_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_partition_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_partition_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_create_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_entity_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_entity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_entity_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_entity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_partition_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_partition_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_partition_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_delete_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_entity_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_entity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_entity_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_entity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_partition_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_partition_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_partition_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_get_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_entities_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_entities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_entities_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_partitions_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_partitions_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_list_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_update_entity_async.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_update_entity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_update_entity_sync.py
+++ b/packages/google-cloud-dataplex/samples/generated_samples/dataplex_v1_generated_metadata_service_update_entity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/tests/__init__.py
+++ b/packages/google-cloud-dataplex/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/tests/unit/__init__.py
+++ b/packages/google-cloud-dataplex/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dataplex/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataplex/tests/unit/gapic/dataplex_v1/__init__.py
+++ b/packages/google-cloud-dataplex/tests/unit/gapic/dataplex_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/.flake8
+++ b/packages/google-cloud-dataproc-metastore/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/MANIFEST.in
+++ b/packages/google-cloud-dataproc-metastore/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore/gapic_version.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/gapic_version.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/pagers.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/grpc.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/rest.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/rest_base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/pagers.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/grpc.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/rest.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/rest_base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/types/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/types/metastore.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/types/metastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/types/metastore_federation.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/types/metastore_federation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/gapic_version.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/pagers.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/grpc.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/rest.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/rest_base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/pagers.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/grpc.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/rest.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/rest_base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/types/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/types/metastore.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/types/metastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/types/metastore_federation.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/types/metastore_federation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/gapic_version.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/pagers.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/grpc.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/rest.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/rest_base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/pagers.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/grpc.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/rest.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/rest_base.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/types/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/types/metastore.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/types/metastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/types/metastore_federation.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/types/metastore_federation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_alter_metadata_resource_location_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_alter_metadata_resource_location_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_create_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_create_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_create_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_create_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_delete_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_delete_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_export_metadata_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_export_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_create_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_create_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_delete_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_delete_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_get_federation_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_get_federation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_get_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_get_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_list_federations_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_list_federations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_list_federations_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_list_federations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_update_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_federation_update_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_backup_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_metadata_import_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_metadata_import_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_service_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_backups_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_backups_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_metadata_imports_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_metadata_imports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_metadata_imports_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_metadata_imports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_services_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_services_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_move_table_to_database_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_move_table_to_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_query_metadata_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_query_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_restore_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_restore_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_update_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_update_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_update_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1_generated_dataproc_metastore_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_alter_metadata_resource_location_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_alter_metadata_resource_location_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_create_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_create_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_create_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_create_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_delete_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_delete_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_export_metadata_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_export_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_create_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_create_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_delete_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_delete_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_get_federation_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_get_federation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_get_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_get_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_list_federations_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_list_federations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_list_federations_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_list_federations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_update_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_federation_update_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_backup_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_metadata_import_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_metadata_import_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_service_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_backups_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_backups_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_metadata_imports_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_metadata_imports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_metadata_imports_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_metadata_imports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_services_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_services_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_move_table_to_database_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_move_table_to_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_query_metadata_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_query_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_remove_iam_policy_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_remove_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_remove_iam_policy_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_remove_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_restore_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_restore_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_update_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_update_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_update_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1alpha_generated_dataproc_metastore_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_alter_metadata_resource_location_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_alter_metadata_resource_location_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_create_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_create_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_create_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_create_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_delete_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_delete_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_export_metadata_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_export_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_create_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_create_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_delete_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_delete_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_get_federation_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_get_federation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_get_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_get_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_list_federations_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_list_federations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_list_federations_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_list_federations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_update_federation_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_federation_update_federation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_backup_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_backup_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_metadata_import_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_metadata_import_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_service_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_backups_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_backups_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_metadata_imports_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_metadata_imports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_metadata_imports_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_metadata_imports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_services_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_services_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_move_table_to_database_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_move_table_to_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_query_metadata_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_query_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_remove_iam_policy_async.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_remove_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_remove_iam_policy_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_remove_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_restore_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_restore_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_update_metadata_import_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_update_metadata_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_update_service_sync.py
+++ b/packages/google-cloud-dataproc-metastore/samples/generated_samples/metastore_v1beta_generated_dataproc_metastore_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/tests/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/tests/unit/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1alpha/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1beta/__init__.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/.flake8
+++ b/packages/google-cloud-dataproc/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/MANIFEST.in
+++ b/packages/google-cloud-dataproc/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc/gapic_version.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/gapic_version.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/async_client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/batch_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/cluster_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/job_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/node_group_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/async_client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/session_template_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/client.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/pagers.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/grpc.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/rest.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/rest_base.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/services/workflow_template_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/__init__.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/autoscaling_policies.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/autoscaling_policies.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/batches.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/batches.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/clusters.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/clusters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/jobs.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/jobs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/node_groups.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/node_groups.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/operations.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/session_templates.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/session_templates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/sessions.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/sessions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/shared.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/shared.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/workflow_templates.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/workflow_templates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_create_autoscaling_policy_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_create_autoscaling_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_create_autoscaling_policy_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_create_autoscaling_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_delete_autoscaling_policy_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_delete_autoscaling_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_delete_autoscaling_policy_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_delete_autoscaling_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_get_autoscaling_policy_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_get_autoscaling_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_get_autoscaling_policy_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_get_autoscaling_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_list_autoscaling_policies_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_list_autoscaling_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_list_autoscaling_policies_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_list_autoscaling_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_update_autoscaling_policy_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_update_autoscaling_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_update_autoscaling_policy_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_autoscaling_policy_service_update_autoscaling_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_create_batch_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_create_batch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_delete_batch_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_delete_batch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_delete_batch_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_delete_batch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_get_batch_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_get_batch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_get_batch_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_get_batch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_list_batches_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_list_batches_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_list_batches_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_batch_controller_list_batches_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_create_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_delete_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_diagnose_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_diagnose_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_get_cluster_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_get_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_list_clusters_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_list_clusters_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_start_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_start_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_stop_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_stop_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_update_cluster_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_cluster_controller_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_cancel_job_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_cancel_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_cancel_job_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_cancel_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_delete_job_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_delete_job_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_get_job_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_get_job_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_list_jobs_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_list_jobs_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_submit_job_as_operation_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_submit_job_as_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_submit_job_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_submit_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_submit_job_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_submit_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_update_job_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_update_job_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_job_controller_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_create_node_group_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_create_node_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_get_node_group_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_get_node_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_get_node_group_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_get_node_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_resize_node_group_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_node_group_controller_resize_node_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_create_session_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_delete_session_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_get_session_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_get_session_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_list_sessions_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_list_sessions_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_terminate_session_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_controller_terminate_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_create_session_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_create_session_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_create_session_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_create_session_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_delete_session_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_delete_session_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_delete_session_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_delete_session_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_get_session_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_get_session_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_get_session_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_get_session_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_list_session_templates_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_list_session_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_list_session_templates_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_list_session_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_update_session_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_update_session_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_update_session_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_session_template_controller_update_session_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_create_workflow_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_create_workflow_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_create_workflow_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_create_workflow_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_delete_workflow_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_delete_workflow_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_delete_workflow_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_delete_workflow_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_get_workflow_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_get_workflow_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_get_workflow_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_get_workflow_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_instantiate_inline_workflow_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_instantiate_inline_workflow_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_instantiate_workflow_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_instantiate_workflow_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_list_workflow_templates_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_list_workflow_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_list_workflow_templates_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_list_workflow_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_update_workflow_template_async.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_update_workflow_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_update_workflow_template_sync.py
+++ b/packages/google-cloud-dataproc/samples/generated_samples/dataproc_v1_generated_workflow_template_service_update_workflow_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/tests/__init__.py
+++ b/packages/google-cloud-dataproc/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/tests/unit/__init__.py
+++ b/packages/google-cloud-dataproc/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dataproc/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dataproc/tests/unit/gapic/dataproc_v1/__init__.py
+++ b/packages/google-cloud-dataproc/tests/unit/gapic/dataproc_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/.flake8
+++ b/packages/google-cloud-datastore/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/MANIFEST.in
+++ b/packages/google-cloud-datastore/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore/gapic_version.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin/gapic_version.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/gapic_version.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/client.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/pagers.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/base.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/grpc.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/rest.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/rest_base.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/services/datastore_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/datastore_admin.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/datastore_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/index.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/index.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/migration.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_admin_v1/types/migration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/gapic_version.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/async_client.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/client.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/base.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/grpc.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/rest.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/rest_base.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/services/datastore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/types/__init__.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/types/aggregation_result.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/types/aggregation_result.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/types/datastore.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/types/datastore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/types/entity.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/types/entity.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/types/query.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/types/query.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/google/cloud/datastore_v1/types/query_profile.py
+++ b/packages/google-cloud-datastore/google/cloud/datastore_v1/types/query_profile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_create_index_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_create_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_delete_index_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_delete_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_export_entities_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_export_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_get_index_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_get_index_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_get_index_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_get_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_import_entities_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_import_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_list_indexes_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_list_indexes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_list_indexes_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_admin_list_indexes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_allocate_ids_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_allocate_ids_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_allocate_ids_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_allocate_ids_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_begin_transaction_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_begin_transaction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_begin_transaction_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_begin_transaction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_commit_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_commit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_commit_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_commit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_lookup_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_lookup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_lookup_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_lookup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_reserve_ids_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_reserve_ids_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_reserve_ids_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_reserve_ids_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_rollback_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_rollback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_rollback_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_rollback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_aggregation_query_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_aggregation_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_aggregation_query_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_aggregation_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_query_async.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_query_sync.py
+++ b/packages/google-cloud-datastore/samples/generated_samples/datastore_v1_generated_datastore_run_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/tests/__init__.py
+++ b/packages/google-cloud-datastore/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/tests/unit/__init__.py
+++ b/packages/google-cloud-datastore/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-datastore/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/tests/unit/gapic/datastore_admin_v1/__init__.py
+++ b/packages/google-cloud-datastore/tests/unit/gapic/datastore_admin_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastore/tests/unit/gapic/datastore_v1/__init__.py
+++ b/packages/google-cloud-datastore/tests/unit/gapic/datastore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/.flake8
+++ b/packages/google-cloud-datastream/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/MANIFEST.in
+++ b/packages/google-cloud-datastream/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream/gapic_version.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/gapic_version.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/client.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/pagers.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/base.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/grpc.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/rest.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/rest_base.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/services/datastream/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/types/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/types/datastream.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/types/datastream.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1/types/datastream_resources.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1/types/datastream_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/client.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/pagers.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/base.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/grpc.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/grpc_asyncio.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/rest.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/rest_base.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/services/datastream/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/types/datastream.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/types/datastream.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/types/datastream_resources.py
+++ b/packages/google-cloud-datastream/google/cloud/datastream_v1alpha1/types/datastream_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_private_connection_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_route_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_create_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_private_connection_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_route_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_delete_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_discover_connection_profile_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_discover_connection_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_discover_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_discover_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_fetch_static_ips_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_fetch_static_ips_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_fetch_static_ips_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_fetch_static_ips_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_connection_profile_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_connection_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_private_connection_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_private_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_private_connection_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_route_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_route_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_object_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_object_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_get_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_connection_profiles_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_connection_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_connection_profiles_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_connection_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_private_connections_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_private_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_private_connections_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_private_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_routes_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_routes_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_stream_objects_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_stream_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_stream_objects_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_stream_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_streams_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_streams_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_list_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_lookup_stream_object_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_lookup_stream_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_lookup_stream_object_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_lookup_stream_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_run_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_run_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_start_backfill_job_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_start_backfill_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_start_backfill_job_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_start_backfill_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_stop_backfill_job_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_stop_backfill_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_stop_backfill_job_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_stop_backfill_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_update_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_update_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_update_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1_generated_datastream_update_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_private_connection_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_route_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_create_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_private_connection_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_route_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_delete_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_discover_connection_profile_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_discover_connection_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_discover_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_discover_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_fetch_errors_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_fetch_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_fetch_static_ips_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_fetch_static_ips_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_fetch_static_ips_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_fetch_static_ips_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_connection_profile_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_connection_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_private_connection_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_private_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_private_connection_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_route_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_route_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_stream_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_get_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_connection_profiles_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_connection_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_connection_profiles_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_connection_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_private_connections_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_private_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_private_connections_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_private_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_routes_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_routes_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_streams_async.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_streams_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_list_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_update_connection_profile_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_update_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_update_stream_sync.py
+++ b/packages/google-cloud-datastream/samples/generated_samples/datastream_v1alpha1_generated_datastream_update_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/tests/__init__.py
+++ b/packages/google-cloud-datastream/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/tests/unit/__init__.py
+++ b/packages/google-cloud-datastream/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-datastream/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/tests/unit/gapic/datastream_v1/__init__.py
+++ b/packages/google-cloud-datastream/tests/unit/gapic/datastream_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-datastream/tests/unit/gapic/datastream_v1alpha1/__init__.py
+++ b/packages/google-cloud-datastream/tests/unit/gapic/datastream_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/.flake8
+++ b/packages/google-cloud-deploy/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/MANIFEST.in
+++ b/packages/google-cloud-deploy/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy/__init__.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy/gapic_version.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/gapic_version.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/__init__.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/__init__.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/client.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/pagers.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/__init__.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/base.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/grpc.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/grpc_asyncio.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/rest.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/rest_base.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/services/cloud_deploy/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/__init__.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/automation_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/automation_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/automationrun_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/automationrun_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/cloud_deploy.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/cloud_deploy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/customtargettype_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/customtargettype_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/deliverypipeline_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/deliverypipeline_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/deploypolicy_evaluation_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/deploypolicy_evaluation_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/deploypolicy_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/deploypolicy_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/jobrun_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/jobrun_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/log_enums.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/log_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/release_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/release_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/release_render_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/release_render_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/rollout_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/rollout_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/rollout_update_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/rollout_update_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/google/cloud/deploy_v1/types/target_notification_payload.py
+++ b/packages/google-cloud-deploy/google/cloud/deploy_v1/types/target_notification_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_abandon_release_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_abandon_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_abandon_release_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_abandon_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_advance_rollout_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_advance_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_advance_rollout_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_advance_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_approve_rollout_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_approve_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_approve_rollout_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_approve_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_automation_run_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_automation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_automation_run_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_automation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_rollout_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_rollout_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_cancel_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_automation_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_automation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_custom_target_type_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_custom_target_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_delivery_pipeline_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_delivery_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_deploy_policy_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_deploy_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_release_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_rollout_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_target_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_create_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_automation_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_automation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_custom_target_type_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_custom_target_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_delivery_pipeline_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_delivery_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_deploy_policy_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_deploy_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_target_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_delete_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_run_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_run_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_automation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_config_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_config_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_custom_target_type_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_custom_target_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_custom_target_type_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_custom_target_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_delivery_pipeline_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_delivery_pipeline_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_delivery_pipeline_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_delivery_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_deploy_policy_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_deploy_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_deploy_policy_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_deploy_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_job_run_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_job_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_job_run_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_job_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_release_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_release_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_rollout_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_rollout_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_target_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_target_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_target_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_get_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_ignore_job_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_ignore_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_ignore_job_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_ignore_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automation_runs_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automation_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automation_runs_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automation_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automations_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automations_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_automations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_custom_target_types_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_custom_target_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_custom_target_types_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_custom_target_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_delivery_pipelines_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_delivery_pipelines_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_delivery_pipelines_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_delivery_pipelines_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_deploy_policies_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_deploy_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_deploy_policies_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_deploy_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_job_runs_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_job_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_job_runs_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_job_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_releases_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_releases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_releases_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_releases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_rollouts_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_rollouts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_rollouts_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_rollouts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_targets_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_targets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_targets_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_list_targets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_retry_job_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_retry_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_retry_job_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_retry_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_rollback_target_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_rollback_target_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_rollback_target_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_rollback_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_terminate_job_run_async.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_terminate_job_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_terminate_job_run_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_terminate_job_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_automation_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_automation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_custom_target_type_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_custom_target_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_delivery_pipeline_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_delivery_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_deploy_policy_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_deploy_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_target_sync.py
+++ b/packages/google-cloud-deploy/samples/generated_samples/clouddeploy_v1_generated_cloud_deploy_update_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/tests/__init__.py
+++ b/packages/google-cloud-deploy/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/tests/unit/__init__.py
+++ b/packages/google-cloud-deploy/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-deploy/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-deploy/tests/unit/gapic/deploy_v1/__init__.py
+++ b/packages/google-cloud-deploy/tests/unit/gapic/deploy_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/.flake8
+++ b/packages/google-cloud-developerconnect/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/MANIFEST.in
+++ b/packages/google-cloud-developerconnect/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect/gapic_version.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/gapic_version.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/client.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/pagers.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/base.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/grpc.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/grpc_asyncio.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/rest.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/rest_base.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/developer_connect/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/client.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/pagers.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/base.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/grpc.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/rest.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/rest_base.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/services/insights_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/types/__init__.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/types/developer_connect.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/types/developer_connect.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/types/insights_config.py
+++ b/packages/google-cloud-developerconnect/google/cloud/developerconnect_v1/types/insights_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_create_account_connector_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_create_account_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_create_connection_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_create_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_create_git_repository_link_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_create_git_repository_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_account_connector_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_account_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_connection_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_git_repository_link_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_git_repository_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_self_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_self_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_user_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_delete_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_access_token_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_access_token_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_hub_installations_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_hub_installations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_hub_installations_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_hub_installations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_refs_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_refs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_refs_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_git_refs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_linkable_git_repositories_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_linkable_git_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_linkable_git_repositories_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_linkable_git_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_token_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_token_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_write_token_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_write_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_write_token_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_read_write_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_self_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_self_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_self_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_fetch_self_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_finish_o_auth_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_finish_o_auth_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_finish_o_auth_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_finish_o_auth_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_account_connector_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_account_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_account_connector_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_account_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_connection_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_connection_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_git_repository_link_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_git_repository_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_git_repository_link_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_get_git_repository_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_account_connectors_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_account_connectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_account_connectors_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_account_connectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_connections_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_connections_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_git_repository_links_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_git_repository_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_git_repository_links_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_git_repository_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_users_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_users_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_list_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_start_o_auth_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_start_o_auth_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_start_o_auth_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_start_o_auth_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_update_account_connector_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_update_account_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_update_connection_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_developer_connect_update_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_create_insights_config_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_create_insights_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_delete_insights_config_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_delete_insights_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_deployment_event_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_deployment_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_deployment_event_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_deployment_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_insights_config_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_insights_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_insights_config_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_get_insights_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_deployment_events_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_deployment_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_deployment_events_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_deployment_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_insights_configs_async.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_insights_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_insights_configs_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_list_insights_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_update_insights_config_sync.py
+++ b/packages/google-cloud-developerconnect/samples/generated_samples/developerconnect_v1_generated_insights_config_service_update_insights_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/tests/__init__.py
+++ b/packages/google-cloud-developerconnect/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/tests/unit/__init__.py
+++ b/packages/google-cloud-developerconnect/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-developerconnect/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-developerconnect/tests/unit/gapic/developerconnect_v1/__init__.py
+++ b/packages/google-cloud-developerconnect/tests/unit/gapic/developerconnect_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/.flake8
+++ b/packages/google-cloud-devicestreaming/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/MANIFEST.in
+++ b/packages/google-cloud-devicestreaming/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming/__init__.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming/gapic_version.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/gapic_version.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/__init__.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/__init__.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/async_client.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/client.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/pagers.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/__init__.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/base.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/grpc.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/rest.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/rest_base.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/services/direct_access_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/types/__init__.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/types/adb_service.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/types/adb_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/types/service.py
+++ b/packages/google-cloud-devicestreaming/google/cloud/devicestreaming_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_adb_connect_async.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_adb_connect_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_adb_connect_sync.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_adb_connect_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_cancel_device_session_async.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_cancel_device_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_cancel_device_session_sync.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_cancel_device_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_create_device_session_async.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_create_device_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_create_device_session_sync.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_create_device_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_get_device_session_async.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_get_device_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_get_device_session_sync.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_get_device_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_list_device_sessions_async.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_list_device_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_list_device_sessions_sync.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_list_device_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_update_device_session_async.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_update_device_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_update_device_session_sync.py
+++ b/packages/google-cloud-devicestreaming/samples/generated_samples/devicestreaming_v1_generated_direct_access_service_update_device_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/tests/__init__.py
+++ b/packages/google-cloud-devicestreaming/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/tests/unit/__init__.py
+++ b/packages/google-cloud-devicestreaming/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-devicestreaming/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-devicestreaming/tests/unit/gapic/devicestreaming_v1/__init__.py
+++ b/packages/google-cloud-devicestreaming/tests/unit/gapic/devicestreaming_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/.flake8
+++ b/packages/google-cloud-dialogflow-cx/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/MANIFEST.in
+++ b/packages/google-cloud-dialogflow-cx/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx/gapic_version.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/gapic_version.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/agents/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/changelogs/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/deployments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/entity_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/environments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/examples/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/experiments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/flows/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/generators/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/intents/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/pages/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/playbooks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/security_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/session_entity_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/sessions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/test_cases/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/tools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/transition_route_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/versions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/services/webhooks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/advanced_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/advanced_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/agent.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/audio_config.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/audio_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/changelog.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/changelog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/code_block.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/code_block.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/data_store_connection.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/data_store_connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/deployment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/deployment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/entity_type.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/entity_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/environment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/environment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/example.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/example.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/experiment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/experiment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/flow.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/flow.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/fulfillment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/fulfillment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/gcs.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/gcs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/generative_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/generative_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/generator.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/import_strategy.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/import_strategy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/inline.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/inline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/intent.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/intent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/page.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/page.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/parameter_definition.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/parameter_definition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/playbook.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/playbook.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/response_message.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/response_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/safety_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/safety_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/security_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/security_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/session.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/session.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/session_entity_type.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/session_entity_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/test_case.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/test_case.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/tool.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/tool_call.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/tool_call.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/trace.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/transition_route_group.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/transition_route_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/validation_message.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/validation_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/version.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/webhook.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3/types/webhook.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/gapic_version.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/agents/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/changelogs/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/conversation_history/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/deployments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/entity_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/environments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/examples/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/experiments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/flows/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/generators/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/intents/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/pages/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/playbooks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/security_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/session_entity_types/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/sessions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/test_cases/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/tools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/transition_route_groups/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/versions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/async_client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/client.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/pagers.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/grpc.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/rest.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/rest_base.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/services/webhooks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/advanced_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/advanced_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/agent.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/audio_config.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/audio_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/bigquery_export.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/bigquery_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/changelog.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/changelog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/code_block.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/code_block.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/conversation_history.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/conversation_history.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/data_store_connection.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/data_store_connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/deployment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/deployment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/entity_type.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/entity_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/environment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/environment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/example.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/example.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/experiment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/experiment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/flow.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/flow.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/fulfillment.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/fulfillment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/gcs.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/gcs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/generative_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/generative_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/generator.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/import_strategy.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/import_strategy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/inline.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/inline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/intent.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/intent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/page.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/page.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/parameter_definition.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/parameter_definition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/playbook.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/playbook.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/response_message.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/response_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/safety_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/safety_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/security_settings.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/security_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/session.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/session.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/session_entity_type.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/session_entity_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/test_case.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/test_case.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/tool.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/tool_call.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/tool_call.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/trace.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/transition_route_group.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/transition_route_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/validation_message.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/validation_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/version.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/webhook.py
+++ b/packages/google-cloud-dialogflow-cx/google/cloud/dialogflowcx_v3beta1/types/webhook.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_create_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_create_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_create_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_create_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_delete_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_delete_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_delete_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_delete_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_export_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_export_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_validation_result_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_validation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_validation_result_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_agent_validation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_generative_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_generative_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_generative_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_get_generative_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_list_agents_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_list_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_list_agents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_list_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_restore_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_restore_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_generative_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_generative_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_generative_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_update_generative_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_validate_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_validate_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_validate_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_agents_validate_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_get_changelog_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_get_changelog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_get_changelog_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_get_changelog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_list_changelogs_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_list_changelogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_list_changelogs_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_changelogs_list_changelogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_get_deployment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_get_deployment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_list_deployments_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_list_deployments_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_deployments_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_create_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_create_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_create_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_create_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_delete_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_delete_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_delete_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_delete_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_export_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_export_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_get_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_get_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_get_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_get_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_import_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_import_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_list_entity_types_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_list_entity_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_list_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_list_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_update_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_update_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_update_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_entity_types_update_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_create_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_create_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_delete_environment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_delete_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_delete_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_delete_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_deploy_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_deploy_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_get_environment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_get_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_continuous_test_results_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_continuous_test_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_continuous_test_results_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_continuous_test_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_environments_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_environments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_environments_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_list_environments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_lookup_environment_history_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_lookup_environment_history_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_lookup_environment_history_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_lookup_environment_history_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_run_continuous_test_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_run_continuous_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_update_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_environments_update_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_create_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_create_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_create_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_create_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_delete_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_delete_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_delete_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_delete_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_get_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_get_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_get_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_get_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_list_examples_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_list_examples_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_list_examples_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_list_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_update_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_update_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_update_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_examples_update_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_create_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_create_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_create_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_create_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_delete_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_delete_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_delete_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_delete_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_get_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_get_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_get_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_get_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_list_experiments_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_list_experiments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_list_experiments_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_list_experiments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_start_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_start_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_start_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_start_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_stop_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_stop_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_stop_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_stop_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_update_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_update_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_update_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_experiments_update_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_create_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_create_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_create_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_create_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_delete_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_delete_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_delete_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_delete_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_export_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_export_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_validation_result_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_validation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_validation_result_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_get_flow_validation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_import_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_import_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_list_flows_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_list_flows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_list_flows_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_list_flows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_train_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_train_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_update_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_update_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_update_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_update_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_validate_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_validate_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_validate_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_flows_validate_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_create_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_create_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_create_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_create_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_delete_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_delete_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_delete_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_delete_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_get_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_get_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_get_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_get_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_list_generators_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_list_generators_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_list_generators_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_list_generators_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_update_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_update_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_update_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_generators_update_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_create_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_create_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_create_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_create_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_delete_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_delete_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_delete_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_delete_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_export_intents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_export_intents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_get_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_get_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_get_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_get_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_import_intents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_import_intents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_list_intents_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_list_intents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_list_intents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_list_intents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_update_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_update_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_update_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_intents_update_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_create_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_create_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_create_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_create_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_delete_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_delete_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_delete_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_delete_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_get_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_get_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_get_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_get_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_list_pages_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_list_pages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_list_pages_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_list_pages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_update_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_update_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_update_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_pages_update_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_create_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_delete_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_export_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_export_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_get_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_import_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_import_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbook_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbook_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbook_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbook_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbooks_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbooks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbooks_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_list_playbooks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_restore_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_restore_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_restore_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_restore_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_update_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_update_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_update_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_playbooks_update_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_create_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_create_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_create_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_create_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_delete_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_delete_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_delete_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_delete_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_get_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_get_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_get_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_get_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_list_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_list_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_list_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_list_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_update_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_update_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_update_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_security_settings_service_update_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_create_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_create_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_create_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_create_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_delete_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_delete_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_delete_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_delete_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_get_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_get_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_get_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_get_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_list_session_entity_types_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_list_session_entity_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_list_session_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_list_session_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_update_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_update_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_update_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_session_entity_types_update_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_detect_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_detect_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_detect_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_detect_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_fulfill_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_fulfill_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_fulfill_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_fulfill_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_match_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_match_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_match_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_match_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_server_streaming_detect_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_server_streaming_detect_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_server_streaming_detect_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_server_streaming_detect_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_streaming_detect_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_streaming_detect_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_streaming_detect_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_streaming_detect_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_submit_answer_feedback_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_submit_answer_feedback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_submit_answer_feedback_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_sessions_submit_answer_feedback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_batch_delete_test_cases_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_batch_delete_test_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_batch_delete_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_batch_delete_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_batch_run_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_batch_run_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_calculate_coverage_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_calculate_coverage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_calculate_coverage_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_calculate_coverage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_create_test_case_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_create_test_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_create_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_create_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_export_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_export_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_result_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_result_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_get_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_import_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_import_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_case_results_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_case_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_case_results_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_case_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_cases_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_list_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_run_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_run_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_update_test_case_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_update_test_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_update_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_test_cases_update_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_create_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_delete_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_get_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tool_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tool_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tool_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tool_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tools_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tools_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_list_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_restore_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_restore_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_restore_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_restore_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_update_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_update_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_update_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_tools_update_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_create_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_create_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_create_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_create_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_delete_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_delete_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_delete_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_delete_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_get_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_get_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_get_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_get_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_list_transition_route_groups_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_list_transition_route_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_list_transition_route_groups_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_list_transition_route_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_update_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_update_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_update_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_transition_route_groups_update_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_compare_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_compare_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_compare_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_compare_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_create_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_create_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_delete_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_delete_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_delete_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_get_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_get_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_list_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_list_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_load_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_load_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_update_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_update_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_update_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_versions_update_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_create_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_create_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_create_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_create_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_delete_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_delete_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_delete_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_delete_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_get_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_get_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_get_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_get_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_list_webhooks_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_list_webhooks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_list_webhooks_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_list_webhooks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_update_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_update_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_update_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3_generated_webhooks_update_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_create_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_create_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_create_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_create_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_delete_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_delete_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_delete_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_delete_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_export_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_export_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_validation_result_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_validation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_validation_result_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_agent_validation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_generative_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_generative_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_generative_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_get_generative_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_list_agents_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_list_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_list_agents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_list_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_restore_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_restore_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_generative_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_generative_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_generative_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_update_generative_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_validate_agent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_validate_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_validate_agent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_agents_validate_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_get_changelog_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_get_changelog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_get_changelog_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_get_changelog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_list_changelogs_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_list_changelogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_list_changelogs_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_changelogs_list_changelogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_delete_conversation_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_delete_conversation_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_get_conversation_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_get_conversation_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_list_conversations_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_list_conversations_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_conversation_history_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_get_deployment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_get_deployment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_list_deployments_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_list_deployments_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_deployments_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_create_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_create_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_create_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_create_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_delete_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_delete_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_delete_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_delete_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_export_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_export_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_get_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_get_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_get_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_get_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_import_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_import_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_list_entity_types_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_list_entity_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_list_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_list_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_update_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_update_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_update_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_entity_types_update_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_create_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_create_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_delete_environment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_delete_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_delete_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_delete_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_deploy_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_deploy_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_get_environment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_get_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_continuous_test_results_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_continuous_test_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_continuous_test_results_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_continuous_test_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_environments_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_environments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_environments_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_list_environments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_lookup_environment_history_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_lookup_environment_history_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_lookup_environment_history_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_lookup_environment_history_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_run_continuous_test_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_run_continuous_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_update_environment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_environments_update_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_create_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_create_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_create_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_create_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_delete_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_delete_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_delete_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_delete_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_get_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_get_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_get_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_get_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_list_examples_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_list_examples_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_list_examples_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_list_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_update_example_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_update_example_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_update_example_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_examples_update_example_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_create_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_create_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_create_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_create_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_delete_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_delete_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_delete_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_delete_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_get_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_get_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_get_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_get_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_list_experiments_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_list_experiments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_list_experiments_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_list_experiments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_start_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_start_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_start_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_start_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_stop_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_stop_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_stop_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_stop_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_update_experiment_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_update_experiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_update_experiment_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_experiments_update_experiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_create_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_create_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_create_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_create_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_delete_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_delete_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_delete_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_delete_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_export_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_export_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_validation_result_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_validation_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_validation_result_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_get_flow_validation_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_import_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_import_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_list_flows_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_list_flows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_list_flows_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_list_flows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_train_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_train_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_update_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_update_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_update_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_update_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_validate_flow_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_validate_flow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_validate_flow_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_flows_validate_flow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_create_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_create_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_create_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_create_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_delete_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_delete_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_delete_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_delete_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_get_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_get_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_get_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_get_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_list_generators_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_list_generators_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_list_generators_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_list_generators_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_update_generator_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_update_generator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_update_generator_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_generators_update_generator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_create_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_create_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_create_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_create_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_delete_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_delete_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_delete_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_delete_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_export_intents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_export_intents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_get_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_get_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_get_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_get_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_import_intents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_import_intents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_list_intents_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_list_intents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_list_intents_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_list_intents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_update_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_update_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_update_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_intents_update_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_create_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_create_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_create_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_create_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_delete_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_delete_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_delete_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_delete_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_get_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_get_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_get_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_get_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_list_pages_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_list_pages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_list_pages_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_list_pages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_update_page_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_update_page_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_update_page_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_pages_update_page_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_create_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_delete_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_export_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_export_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_get_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_import_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_import_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbook_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbook_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbook_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbook_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbooks_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbooks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbooks_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_list_playbooks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_restore_playbook_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_restore_playbook_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_restore_playbook_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_restore_playbook_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_update_playbook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_update_playbook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_update_playbook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_playbooks_update_playbook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_create_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_create_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_create_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_create_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_delete_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_delete_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_delete_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_delete_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_get_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_get_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_get_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_get_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_list_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_list_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_list_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_list_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_update_security_settings_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_update_security_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_update_security_settings_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_security_settings_service_update_security_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_create_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_create_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_create_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_create_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_delete_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_delete_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_delete_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_delete_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_get_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_get_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_get_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_get_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_list_session_entity_types_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_list_session_entity_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_list_session_entity_types_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_list_session_entity_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_update_session_entity_type_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_update_session_entity_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_update_session_entity_type_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_session_entity_types_update_session_entity_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_detect_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_detect_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_detect_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_detect_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_fulfill_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_fulfill_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_fulfill_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_fulfill_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_match_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_match_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_match_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_match_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_server_streaming_detect_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_server_streaming_detect_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_server_streaming_detect_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_server_streaming_detect_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_streaming_detect_intent_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_streaming_detect_intent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_streaming_detect_intent_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_streaming_detect_intent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_submit_answer_feedback_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_submit_answer_feedback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_submit_answer_feedback_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_sessions_submit_answer_feedback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_batch_delete_test_cases_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_batch_delete_test_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_batch_delete_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_batch_delete_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_batch_run_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_batch_run_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_calculate_coverage_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_calculate_coverage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_calculate_coverage_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_calculate_coverage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_create_test_case_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_create_test_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_create_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_create_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_export_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_export_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_result_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_result_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_get_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_import_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_import_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_case_results_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_case_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_case_results_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_case_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_cases_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_cases_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_list_test_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_run_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_run_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_update_test_case_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_update_test_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_update_test_case_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_test_cases_update_test_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_create_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_delete_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_export_tools_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_export_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_get_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tool_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tool_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tool_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tool_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tools_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tools_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_list_tools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_restore_tool_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_restore_tool_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_restore_tool_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_restore_tool_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_update_tool_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_update_tool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_update_tool_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_tools_update_tool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_create_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_create_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_create_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_create_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_delete_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_delete_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_delete_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_delete_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_get_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_get_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_get_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_get_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_list_transition_route_groups_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_list_transition_route_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_list_transition_route_groups_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_list_transition_route_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_update_transition_route_group_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_update_transition_route_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_update_transition_route_group_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_transition_route_groups_update_transition_route_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_compare_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_compare_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_compare_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_compare_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_create_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_create_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_delete_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_delete_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_delete_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_get_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_get_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_list_versions_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_list_versions_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_load_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_load_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_update_version_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_update_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_update_version_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_versions_update_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_create_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_create_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_create_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_create_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_delete_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_delete_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_delete_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_delete_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_get_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_get_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_get_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_get_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_list_webhooks_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_list_webhooks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_list_webhooks_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_list_webhooks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_update_webhook_async.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_update_webhook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_update_webhook_sync.py
+++ b/packages/google-cloud-dialogflow-cx/samples/generated_samples/dialogflow_v3beta1_generated_webhooks_update_webhook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/tests/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/tests/unit/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/tests/unit/gapic/dialogflowcx_v3/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/tests/unit/gapic/dialogflowcx_v3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dialogflow-cx/tests/unit/gapic/dialogflowcx_v3beta1/__init__.py
+++ b/packages/google-cloud-dialogflow-cx/tests/unit/gapic/dialogflowcx_v3beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/.flake8
+++ b/packages/google-cloud-discoveryengine/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/MANIFEST.in
+++ b/packages/google-cloud-discoveryengine/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine/gapic_version.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/gapic_version.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/assistant_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/cmek_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/completion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/conversational_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/data_store_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/document_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/engine_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/grounded_generation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/identity_mapping_store_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/project_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/rank_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/recommendation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/schema_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/search_tuning_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/serving_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/session_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/site_search_engine_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/services/user_license_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/answer.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/answer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/assist_answer.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/assist_answer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/assistant.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/assistant.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/assistant_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/assistant_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/chunk.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/chunk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/cmek_config_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/cmek_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/common.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/completion.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/completion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/completion_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/control.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/control_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/control_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/conversation.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/conversational_search_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/conversational_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/custom_tuning_model.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/custom_tuning_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/data_store.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/data_store.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/data_store_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/data_store_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/document.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/document_processing_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/document_processing_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/document_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/document_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/engine.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/engine_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/engine_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/grounded_generation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/grounded_generation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/grounding.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/grounding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/identity_mapping_store.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/identity_mapping_store.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/identity_mapping_store_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/identity_mapping_store_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/import_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/import_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/project.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/project.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/project_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/project_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/purge_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/purge_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/rank_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/rank_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/recommendation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/recommendation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/safety.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/schema.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/schema_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/schema_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/search_tuning_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/search_tuning_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/serving_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/serving_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/serving_config_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/serving_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/session.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/session.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/session_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/session_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/site_search_engine.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/site_search_engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/site_search_engine_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/site_search_engine_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_event.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_event_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_license.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_license.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_license_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/user_license_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/gapic_version.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/acl_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/chunk_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/completion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/conversational_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/data_store_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/document_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/engine_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/estimate_billing_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/evaluation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/grounded_generation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/project_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/rank_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/recommendation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/sample_query_set_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/schema_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/search_tuning_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/serving_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/session_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/site_search_engine_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/acl_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/acl_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/acl_config_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/acl_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/answer.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/answer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/chunk.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/chunk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/chunk_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/chunk_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/common.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/completion.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/completion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/completion_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/control.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/control_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/control_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/conversation.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/conversational_search_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/conversational_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/custom_tuning_model.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/custom_tuning_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/data_store.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/data_store.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/data_store_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/data_store_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/document.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/document_processing_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/document_processing_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/document_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/document_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/engine.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/engine_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/engine_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/estimate_billing_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/estimate_billing_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/evaluation.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/evaluation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/evaluation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/grounded_generation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/grounded_generation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/grounding.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/grounding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/import_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/import_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/project.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/project.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/project_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/project_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/purge_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/purge_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/rank_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/rank_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/recommendation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/recommendation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query_set.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query_set_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/sample_query_set_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/schema.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/schema_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/schema_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/search_tuning_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/search_tuning_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/serving_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/serving_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/serving_config_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/serving_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/session.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/session.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/session_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/session_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/site_search_engine.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/site_search_engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/site_search_engine_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/site_search_engine_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/user_event.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/user_event_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/gapic_version.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/completion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/conversational_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/data_store_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/document_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/engine_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/evaluation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/grounded_generation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/project_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/rank_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/recommendation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/sample_query_set_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/schema_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/search_tuning_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/serving_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/async_client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/session_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/pagers.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/site_search_engine_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/client.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/__init__.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/answer.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/answer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/chunk.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/chunk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/common.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/completion.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/completion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/completion_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/control.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/control_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/control_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/conversation.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/conversational_search_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/conversational_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/custom_tuning_model.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/custom_tuning_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/data_store.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/data_store.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/data_store_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/data_store_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/document.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/document_processing_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/document_processing_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/document_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/document_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/engine.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/engine_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/engine_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/evaluation.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/evaluation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/evaluation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/grounded_generation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/grounded_generation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/grounding.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/grounding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/import_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/import_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/project.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/project.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/project_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/project_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/purge_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/purge_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/rank_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/rank_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/recommendation_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/recommendation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query_set.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query_set_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/sample_query_set_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/schema.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/schema_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/schema_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/search_tuning_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/search_tuning_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/serving_config.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/serving_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/serving_config_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/serving_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/session.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/session.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/session_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/session_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/site_search_engine.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/site_search_engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/site_search_engine_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/site_search_engine_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/user_event.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/user_event_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_assistant_service_stream_assist_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_assistant_service_stream_assist_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_assistant_service_stream_assist_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_assistant_service_stream_assist_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_delete_cmek_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_delete_cmek_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_get_cmek_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_get_cmek_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_get_cmek_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_get_cmek_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_list_cmek_configs_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_list_cmek_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_list_cmek_configs_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_list_cmek_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_update_cmek_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_cmek_config_service_update_cmek_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_complete_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_complete_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_import_completion_suggestions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_import_completion_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_import_suggestion_deny_list_entries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_import_suggestion_deny_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_purge_completion_suggestions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_purge_completion_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_purge_suggestion_deny_list_entries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_completion_service_purge_suggestion_deny_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_create_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_create_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_create_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_create_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_delete_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_delete_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_delete_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_delete_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_get_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_get_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_get_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_get_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_list_controls_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_list_controls_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_update_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_update_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_update_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_control_service_update_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_answer_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_answer_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_answer_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_answer_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_converse_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_converse_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_converse_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_converse_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_answer_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_answer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_answer_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_answer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_conversations_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_conversations_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_sessions_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_sessions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_stream_answer_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_stream_answer_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_stream_answer_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_stream_answer_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_conversational_search_service_update_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_create_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_create_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_delete_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_delete_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_get_data_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_get_data_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_get_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_get_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_list_data_stores_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_list_data_stores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_list_data_stores_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_list_data_stores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_update_data_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_update_data_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_update_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_data_store_service_update_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_batch_get_documents_metadata_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_batch_get_documents_metadata_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_batch_get_documents_metadata_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_batch_get_documents_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_create_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_create_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_delete_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_delete_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_get_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_get_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_import_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_import_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_list_documents_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_list_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_purge_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_purge_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_update_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_update_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_document_service_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_create_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_create_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_delete_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_delete_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_get_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_get_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_get_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_get_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_list_engines_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_list_engines_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_list_engines_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_list_engines_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_update_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_update_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_update_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_engine_service_update_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_check_grounding_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_check_grounding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_check_grounding_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_check_grounding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_generate_grounded_content_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_generate_grounded_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_generate_grounded_content_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_generate_grounded_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_stream_generate_grounded_content_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_stream_generate_grounded_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_stream_generate_grounded_content_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_grounded_generation_service_stream_generate_grounded_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_create_identity_mapping_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_create_identity_mapping_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_create_identity_mapping_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_create_identity_mapping_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_delete_identity_mapping_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_delete_identity_mapping_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_get_identity_mapping_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_get_identity_mapping_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_get_identity_mapping_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_get_identity_mapping_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_import_identity_mappings_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_import_identity_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mapping_stores_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mapping_stores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mapping_stores_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mapping_stores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mappings_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mappings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mappings_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_list_identity_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_purge_identity_mappings_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_identity_mapping_store_service_purge_identity_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_project_service_provision_project_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_project_service_provision_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_rank_service_rank_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_rank_service_rank_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_rank_service_rank_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_rank_service_rank_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_recommendation_service_recommend_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_recommendation_service_recommend_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_recommendation_service_recommend_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_recommendation_service_recommend_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_create_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_create_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_delete_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_delete_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_get_schema_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_get_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_get_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_get_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_list_schemas_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_list_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_list_schemas_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_list_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_update_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_schema_service_update_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_lite_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_lite_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_lite_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_lite_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_tuning_service_list_custom_models_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_tuning_service_list_custom_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_tuning_service_list_custom_models_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_tuning_service_list_custom_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_tuning_service_train_custom_model_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_search_tuning_service_train_custom_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_serving_config_service_update_serving_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_serving_config_service_update_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_serving_config_service_update_serving_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_serving_config_service_update_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_create_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_create_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_delete_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_delete_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_get_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_get_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_list_sessions_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_list_sessions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_update_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_update_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_update_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_session_service_update_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_batch_create_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_batch_create_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_batch_verify_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_batch_verify_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_create_sitemap_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_create_sitemap_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_create_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_create_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_delete_sitemap_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_delete_sitemap_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_delete_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_delete_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_disable_advanced_site_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_disable_advanced_site_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_enable_advanced_site_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_enable_advanced_site_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_domain_verification_status_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_domain_verification_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_domain_verification_status_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_domain_verification_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_sitemaps_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_sitemaps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_sitemaps_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_fetch_sitemaps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_site_search_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_site_search_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_site_search_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_site_search_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_target_site_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_target_site_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_get_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_list_target_sites_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_list_target_sites_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_list_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_list_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_recrawl_uris_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_recrawl_uris_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_update_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_site_search_engine_service_update_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_license_service_batch_update_user_licenses_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_license_service_batch_update_user_licenses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_license_service_list_user_licenses_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_license_service_list_user_licenses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_license_service_list_user_licenses_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1_generated_user_license_service_list_user_licenses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_get_acl_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_get_acl_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_get_acl_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_get_acl_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_update_acl_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_update_acl_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_update_acl_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_acl_config_service_update_acl_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_get_chunk_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_get_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_get_chunk_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_get_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_list_chunks_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_list_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_list_chunks_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_chunk_service_list_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_complete_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_complete_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_import_completion_suggestions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_import_completion_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_import_suggestion_deny_list_entries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_import_suggestion_deny_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_purge_completion_suggestions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_purge_completion_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_purge_suggestion_deny_list_entries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_completion_service_purge_suggestion_deny_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_create_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_create_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_create_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_create_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_delete_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_delete_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_delete_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_delete_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_get_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_get_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_get_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_get_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_list_controls_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_list_controls_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_update_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_update_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_update_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_control_service_update_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_answer_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_answer_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_answer_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_answer_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_converse_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_converse_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_converse_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_converse_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_answer_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_answer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_answer_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_answer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_conversations_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_conversations_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_sessions_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_sessions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_conversational_search_service_update_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_create_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_create_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_delete_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_delete_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_data_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_data_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_document_processing_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_document_processing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_document_processing_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_get_document_processing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_list_data_stores_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_list_data_stores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_list_data_stores_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_list_data_stores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_data_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_data_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_document_processing_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_document_processing_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_document_processing_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_data_store_service_update_document_processing_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_batch_get_documents_metadata_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_batch_get_documents_metadata_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_batch_get_documents_metadata_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_batch_get_documents_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_create_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_create_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_delete_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_delete_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_processed_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_processed_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_processed_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_get_processed_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_import_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_import_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_list_documents_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_list_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_purge_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_purge_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_update_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_update_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_document_service_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_create_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_create_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_delete_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_delete_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_get_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_get_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_get_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_get_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_list_engines_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_list_engines_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_list_engines_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_list_engines_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_pause_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_pause_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_pause_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_pause_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_resume_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_resume_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_resume_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_resume_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_tune_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_tune_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_update_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_update_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_update_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_engine_service_update_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_estimate_billing_service_estimate_data_size_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_estimate_billing_service_estimate_data_size_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_create_evaluation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_create_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_get_evaluation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_get_evaluation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluation_results_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluation_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluation_results_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluation_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluations_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluations_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_evaluation_service_list_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_grounded_generation_service_check_grounding_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_grounded_generation_service_check_grounding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_grounded_generation_service_check_grounding_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_grounded_generation_service_check_grounding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_get_project_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_get_project_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_get_project_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_get_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_provision_project_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_provision_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_report_consent_change_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_report_consent_change_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_report_consent_change_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_project_service_report_consent_change_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_rank_service_rank_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_rank_service_rank_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_rank_service_rank_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_rank_service_rank_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_recommendation_service_recommend_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_recommendation_service_recommend_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_recommendation_service_recommend_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_recommendation_service_recommend_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_create_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_create_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_create_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_create_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_delete_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_delete_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_delete_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_delete_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_get_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_get_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_get_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_get_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_import_sample_queries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_import_sample_queries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_list_sample_queries_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_list_sample_queries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_list_sample_queries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_list_sample_queries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_update_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_update_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_update_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_service_update_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_create_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_create_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_create_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_create_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_delete_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_delete_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_delete_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_delete_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_get_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_get_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_get_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_get_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_list_sample_query_sets_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_list_sample_query_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_list_sample_query_sets_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_list_sample_query_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_update_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_update_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_update_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_sample_query_set_service_update_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_create_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_create_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_delete_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_delete_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_get_schema_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_get_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_get_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_get_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_list_schemas_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_list_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_list_schemas_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_list_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_update_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_schema_service_update_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_service_search_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_service_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_tuning_service_list_custom_models_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_tuning_service_list_custom_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_tuning_service_list_custom_models_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_tuning_service_list_custom_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_tuning_service_train_custom_model_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_search_tuning_service_train_custom_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_get_serving_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_get_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_get_serving_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_get_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_list_serving_configs_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_list_serving_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_list_serving_configs_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_list_serving_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_update_serving_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_update_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_update_serving_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_serving_config_service_update_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_create_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_create_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_delete_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_delete_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_get_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_get_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_files_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_files_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_sessions_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_sessions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_update_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_update_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_update_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_session_service_update_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_batch_create_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_batch_create_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_batch_verify_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_batch_verify_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_create_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_create_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_delete_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_delete_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_disable_advanced_site_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_disable_advanced_site_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_enable_advanced_site_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_enable_advanced_site_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_fetch_domain_verification_status_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_fetch_domain_verification_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_fetch_domain_verification_status_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_fetch_domain_verification_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_site_search_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_site_search_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_site_search_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_site_search_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_target_site_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_target_site_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_uri_pattern_document_data_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_uri_pattern_document_data_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_uri_pattern_document_data_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_get_uri_pattern_document_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_list_target_sites_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_list_target_sites_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_list_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_list_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_recrawl_uris_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_recrawl_uris_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_set_uri_pattern_document_data_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_set_uri_pattern_document_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_update_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_site_search_engine_service_update_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1alpha_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_advanced_complete_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_advanced_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_advanced_complete_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_advanced_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_complete_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_complete_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_import_completion_suggestions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_import_completion_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_import_suggestion_deny_list_entries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_import_suggestion_deny_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_purge_completion_suggestions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_purge_completion_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_purge_suggestion_deny_list_entries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_completion_service_purge_suggestion_deny_list_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_create_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_create_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_create_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_create_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_delete_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_delete_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_delete_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_delete_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_get_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_get_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_get_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_get_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_list_controls_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_list_controls_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_update_control_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_update_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_update_control_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_control_service_update_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_answer_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_answer_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_answer_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_answer_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_converse_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_converse_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_converse_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_converse_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_answer_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_answer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_answer_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_answer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_conversations_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_conversations_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_sessions_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_sessions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_conversation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_conversation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_conversational_search_service_update_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_create_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_create_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_delete_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_delete_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_get_data_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_get_data_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_get_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_get_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_list_data_stores_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_list_data_stores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_list_data_stores_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_list_data_stores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_update_data_store_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_update_data_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_update_data_store_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_data_store_service_update_data_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_batch_get_documents_metadata_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_batch_get_documents_metadata_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_batch_get_documents_metadata_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_batch_get_documents_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_create_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_create_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_delete_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_delete_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_get_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_get_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_import_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_import_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_list_documents_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_list_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_purge_documents_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_purge_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_update_document_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_update_document_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_document_service_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_create_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_create_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_delete_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_delete_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_get_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_get_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_get_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_get_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_list_engines_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_list_engines_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_list_engines_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_list_engines_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_pause_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_pause_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_pause_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_pause_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_resume_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_resume_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_resume_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_resume_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_tune_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_tune_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_update_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_update_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_update_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_engine_service_update_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_create_evaluation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_create_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_get_evaluation_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_get_evaluation_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluation_results_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluation_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluation_results_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluation_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluations_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluations_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_evaluation_service_list_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_check_grounding_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_check_grounding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_check_grounding_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_check_grounding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_generate_grounded_content_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_generate_grounded_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_generate_grounded_content_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_generate_grounded_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_stream_generate_grounded_content_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_stream_generate_grounded_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_stream_generate_grounded_content_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_grounded_generation_service_stream_generate_grounded_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_project_service_provision_project_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_project_service_provision_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_rank_service_rank_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_rank_service_rank_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_rank_service_rank_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_rank_service_rank_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_recommendation_service_recommend_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_recommendation_service_recommend_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_recommendation_service_recommend_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_recommendation_service_recommend_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_create_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_create_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_create_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_create_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_delete_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_delete_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_delete_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_delete_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_get_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_get_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_get_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_get_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_import_sample_queries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_import_sample_queries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_list_sample_queries_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_list_sample_queries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_list_sample_queries_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_list_sample_queries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_update_sample_query_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_update_sample_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_update_sample_query_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_service_update_sample_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_create_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_create_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_create_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_create_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_delete_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_delete_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_delete_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_delete_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_get_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_get_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_get_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_get_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_list_sample_query_sets_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_list_sample_query_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_list_sample_query_sets_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_list_sample_query_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_update_sample_query_set_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_update_sample_query_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_update_sample_query_set_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_sample_query_set_service_update_sample_query_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_create_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_create_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_delete_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_delete_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_get_schema_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_get_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_get_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_get_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_list_schemas_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_list_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_list_schemas_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_list_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_update_schema_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_schema_service_update_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_lite_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_lite_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_lite_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_lite_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_tuning_service_list_custom_models_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_tuning_service_list_custom_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_tuning_service_list_custom_models_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_tuning_service_list_custom_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_tuning_service_train_custom_model_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_search_tuning_service_train_custom_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_get_serving_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_get_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_get_serving_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_get_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_list_serving_configs_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_list_serving_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_list_serving_configs_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_list_serving_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_update_serving_config_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_update_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_update_serving_config_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_serving_config_service_update_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_create_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_create_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_delete_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_delete_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_get_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_get_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_list_sessions_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_list_sessions_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_update_session_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_update_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_update_session_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_session_service_update_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_batch_create_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_batch_create_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_batch_verify_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_batch_verify_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_create_sitemap_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_create_sitemap_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_create_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_create_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_delete_sitemap_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_delete_sitemap_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_delete_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_delete_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_disable_advanced_site_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_disable_advanced_site_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_enable_advanced_site_search_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_enable_advanced_site_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_domain_verification_status_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_domain_verification_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_domain_verification_status_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_domain_verification_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_sitemaps_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_sitemaps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_sitemaps_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_fetch_sitemaps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_site_search_engine_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_site_search_engine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_site_search_engine_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_site_search_engine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_target_site_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_target_site_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_get_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_list_target_sites_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_list_target_sites_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_list_target_sites_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_list_target_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_recrawl_uris_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_recrawl_uris_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_update_target_site_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_site_search_engine_service_update_target_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-discoveryengine/samples/generated_samples/discoveryengine_v1beta_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/tests/__init__.py
+++ b/packages/google-cloud-discoveryengine/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/tests/unit/__init__.py
+++ b/packages/google-cloud-discoveryengine/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-discoveryengine/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1/__init__.py
+++ b/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1alpha/__init__.py
+++ b/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1beta/__init__.py
+++ b/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/.flake8
+++ b/packages/google-cloud-dlp/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/MANIFEST.in
+++ b/packages/google-cloud-dlp/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp/__init__.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp/gapic_version.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/gapic_version.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/__init__.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/__init__.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/async_client.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/client.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/pagers.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/__init__.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/base.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/grpc.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/rest.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/rest_base.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/services/dlp_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/types/__init__.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/types/dlp.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/types/dlp.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/types/storage.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/types/storage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_activate_job_trigger_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_activate_job_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_activate_job_trigger_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_activate_job_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_cancel_dlp_job_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_cancel_dlp_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_cancel_dlp_job_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_cancel_dlp_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_connection_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_connection_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_deidentify_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_deidentify_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_deidentify_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_deidentify_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_discovery_config_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_discovery_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_discovery_config_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_discovery_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_dlp_job_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_dlp_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_dlp_job_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_dlp_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_inspect_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_inspect_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_inspect_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_inspect_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_job_trigger_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_job_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_job_trigger_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_job_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_stored_info_type_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_stored_info_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_stored_info_type_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_create_stored_info_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_deidentify_content_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_deidentify_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_deidentify_content_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_deidentify_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_connection_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_connection_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_deidentify_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_deidentify_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_deidentify_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_deidentify_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_discovery_config_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_discovery_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_discovery_config_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_discovery_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_dlp_job_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_dlp_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_dlp_job_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_dlp_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_file_store_data_profile_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_file_store_data_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_file_store_data_profile_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_file_store_data_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_inspect_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_inspect_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_inspect_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_inspect_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_job_trigger_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_job_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_job_trigger_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_job_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_stored_info_type_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_stored_info_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_stored_info_type_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_stored_info_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_table_data_profile_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_table_data_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_table_data_profile_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_delete_table_data_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_finish_dlp_job_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_finish_dlp_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_finish_dlp_job_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_finish_dlp_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_column_data_profile_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_column_data_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_column_data_profile_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_column_data_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_connection_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_connection_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_deidentify_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_deidentify_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_deidentify_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_deidentify_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_discovery_config_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_discovery_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_discovery_config_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_discovery_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_dlp_job_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_dlp_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_dlp_job_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_dlp_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_file_store_data_profile_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_file_store_data_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_file_store_data_profile_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_file_store_data_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_inspect_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_inspect_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_inspect_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_inspect_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_job_trigger_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_job_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_job_trigger_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_job_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_project_data_profile_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_project_data_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_project_data_profile_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_project_data_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_stored_info_type_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_stored_info_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_stored_info_type_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_stored_info_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_table_data_profile_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_table_data_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_table_data_profile_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_get_table_data_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_dlp_job_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_dlp_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_dlp_job_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_dlp_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_job_trigger_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_job_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_job_trigger_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_hybrid_inspect_job_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_inspect_content_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_inspect_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_inspect_content_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_inspect_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_column_data_profiles_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_column_data_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_column_data_profiles_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_column_data_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_connections_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_connections_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_deidentify_templates_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_deidentify_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_deidentify_templates_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_deidentify_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_discovery_configs_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_discovery_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_discovery_configs_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_discovery_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_dlp_jobs_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_dlp_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_dlp_jobs_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_dlp_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_file_store_data_profiles_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_file_store_data_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_file_store_data_profiles_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_file_store_data_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_info_types_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_info_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_info_types_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_info_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_inspect_templates_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_inspect_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_inspect_templates_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_inspect_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_job_triggers_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_job_triggers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_job_triggers_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_job_triggers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_project_data_profiles_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_project_data_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_project_data_profiles_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_project_data_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_stored_info_types_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_stored_info_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_stored_info_types_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_stored_info_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_table_data_profiles_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_table_data_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_table_data_profiles_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_list_table_data_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_redact_image_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_redact_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_redact_image_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_redact_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_reidentify_content_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_reidentify_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_reidentify_content_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_reidentify_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_search_connections_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_search_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_search_connections_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_search_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_connection_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_connection_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_deidentify_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_deidentify_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_deidentify_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_deidentify_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_discovery_config_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_discovery_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_discovery_config_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_discovery_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_inspect_template_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_inspect_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_inspect_template_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_inspect_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_job_trigger_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_job_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_job_trigger_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_job_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_stored_info_type_async.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_stored_info_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_stored_info_type_sync.py
+++ b/packages/google-cloud-dlp/samples/generated_samples/dlp_v2_generated_dlp_service_update_stored_info_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/tests/__init__.py
+++ b/packages/google-cloud-dlp/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/tests/unit/__init__.py
+++ b/packages/google-cloud-dlp/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dlp/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dlp/tests/unit/gapic/dlp_v2/__init__.py
+++ b/packages/google-cloud-dlp/tests/unit/gapic/dlp_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/.flake8
+++ b/packages/google-cloud-dms/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/MANIFEST.in
+++ b/packages/google-cloud-dms/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms/__init__.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms/gapic_version.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/gapic_version.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/__init__.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/__init__.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/client.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/pagers.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/__init__.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/base.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/grpc.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/services/data_migration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/types/__init__.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/types/clouddms.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/types/clouddms.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/google/cloud/clouddms_v1/types/clouddms_resources.py
+++ b/packages/google-cloud-dms/google/cloud/clouddms_v1/types/clouddms_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_apply_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_apply_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_commit_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_commit_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_convert_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_convert_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_connection_profile_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_mapping_rule_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_mapping_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_mapping_rule_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_mapping_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_private_connection_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_create_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_connection_profile_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_mapping_rule_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_mapping_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_mapping_rule_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_mapping_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_private_connection_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_delete_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_conversion_workspace_revisions_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_conversion_workspace_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_conversion_workspace_revisions_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_conversion_workspace_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_database_entities_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_database_entities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_database_entities_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_describe_database_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_fetch_static_ips_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_fetch_static_ips_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_fetch_static_ips_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_fetch_static_ips_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_ssh_script_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_ssh_script_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_ssh_script_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_ssh_script_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_tcp_proxy_script_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_tcp_proxy_script_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_tcp_proxy_script_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_generate_tcp_proxy_script_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_connection_profile_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_connection_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_connection_profile_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_conversion_workspace_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_conversion_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_mapping_rule_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_mapping_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_mapping_rule_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_mapping_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_migration_job_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_migration_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_private_connection_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_private_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_private_connection_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_get_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_import_mapping_rules_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_import_mapping_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_connection_profiles_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_connection_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_connection_profiles_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_connection_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_conversion_workspaces_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_conversion_workspaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_conversion_workspaces_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_conversion_workspaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_mapping_rules_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_mapping_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_mapping_rules_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_mapping_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_migration_jobs_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_migration_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_migration_jobs_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_migration_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_private_connections_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_private_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_private_connections_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_list_private_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_promote_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_promote_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_restart_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_restart_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_resume_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_resume_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_rollback_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_rollback_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_search_background_jobs_async.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_search_background_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_search_background_jobs_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_search_background_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_seed_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_seed_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_start_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_start_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_stop_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_stop_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_update_connection_profile_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_update_connection_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_update_conversion_workspace_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_update_conversion_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_update_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_update_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_verify_migration_job_sync.py
+++ b/packages/google-cloud-dms/samples/generated_samples/datamigration_v1_generated_data_migration_service_verify_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/tests/__init__.py
+++ b/packages/google-cloud-dms/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/tests/unit/__init__.py
+++ b/packages/google-cloud-dms/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-dms/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-dms/tests/unit/gapic/clouddms_v1/__init__.py
+++ b/packages/google-cloud-dms/tests/unit/gapic/clouddms_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/.flake8
+++ b/packages/google-cloud-documentai/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/MANIFEST.in
+++ b/packages/google-cloud-documentai/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai/gapic_version.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/gapic_version.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/client.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/pagers.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/base.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/grpc.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/rest.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/rest_base.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/services/document_processor_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/barcode.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/barcode.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document_io.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document_io.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document_processor_service.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document_processor_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document_schema.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document_schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/evaluation.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/geometry.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/operation_metadata.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/processor.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/processor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1/types/processor_type.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1/types/processor_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/gapic_version.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/client.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/pagers.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/base.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/grpc.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/rest.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/rest_base.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_processor_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/client.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/pagers.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/base.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/grpc.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/rest.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/rest_base.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/services/document_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/__init__.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/barcode.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/barcode.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/dataset.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document_io.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document_io.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document_processor_service.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document_processor_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document_schema.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document_schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/evaluation.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/evaluation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/geometry.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/operation_metadata.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/processor.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/processor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/processor_type.py
+++ b/packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/processor_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_batch_process_documents_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_batch_process_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_create_processor_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_create_processor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_create_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_create_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_delete_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_delete_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_delete_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_delete_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_deploy_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_deploy_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_disable_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_disable_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_enable_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_enable_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_evaluate_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_evaluate_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_fetch_processor_types_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_fetch_processor_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_fetch_processor_types_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_fetch_processor_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_evaluation_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_evaluation_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_type_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_type_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_version_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_get_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_evaluations_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_evaluations_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_types_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_types_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_versions_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_versions_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processor_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processors_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processors_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_list_processors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_process_document_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_process_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_process_document_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_process_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_review_document_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_review_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_set_default_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_set_default_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_train_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_train_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_undeploy_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1_generated_document_processor_service_undeploy_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_batch_process_documents_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_batch_process_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_create_processor_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_create_processor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_create_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_create_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_delete_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_delete_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_delete_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_delete_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_deploy_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_deploy_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_disable_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_disable_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_enable_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_enable_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_evaluate_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_evaluate_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_fetch_processor_types_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_fetch_processor_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_fetch_processor_types_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_fetch_processor_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_evaluation_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_evaluation_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_type_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_type_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_version_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_get_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_import_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_import_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_evaluations_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_evaluations_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_types_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_types_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_versions_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_versions_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processor_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processors_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processors_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_list_processors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_process_document_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_process_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_process_document_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_process_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_review_document_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_review_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_set_default_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_set_default_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_train_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_train_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_undeploy_processor_version_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_processor_service_undeploy_processor_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_batch_delete_documents_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_batch_delete_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_dataset_schema_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_dataset_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_dataset_schema_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_dataset_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_document_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_document_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_import_documents_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_import_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_list_documents_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_list_documents_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_update_dataset_schema_async.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_update_dataset_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_update_dataset_schema_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_update_dataset_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_update_dataset_sync.py
+++ b/packages/google-cloud-documentai/samples/generated_samples/documentai_v1beta3_generated_document_service_update_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/tests/__init__.py
+++ b/packages/google-cloud-documentai/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/tests/unit/__init__.py
+++ b/packages/google-cloud-documentai/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-documentai/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/tests/unit/gapic/documentai_v1/__init__.py
+++ b/packages/google-cloud-documentai/tests/unit/gapic/documentai_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-documentai/tests/unit/gapic/documentai_v1beta3/__init__.py
+++ b/packages/google-cloud-documentai/tests/unit/gapic/documentai_v1beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/.flake8
+++ b/packages/google-cloud-domains/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/MANIFEST.in
+++ b/packages/google-cloud-domains/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains/gapic_version.py
+++ b/packages/google-cloud-domains/google/cloud/domains/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/gapic_version.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/client.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/pagers.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/base.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/grpc.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/grpc_asyncio.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/rest.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/rest_base.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/services/domains/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/types/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1/types/domains.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1/types/domains.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/gapic_version.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/client.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/pagers.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/base.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/grpc.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/grpc_asyncio.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/rest.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/rest_base.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/services/domains/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/types/__init__.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/google/cloud/domains_v1beta1/types/domains.py
+++ b/packages/google-cloud-domains/google/cloud/domains_v1beta1/types/domains.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_configure_contact_settings_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_configure_contact_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_configure_dns_settings_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_configure_dns_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_configure_management_settings_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_configure_management_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_delete_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_delete_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_export_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_export_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_get_registration_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_get_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_get_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_get_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_list_registrations_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_list_registrations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_list_registrations_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_list_registrations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_register_domain_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_register_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_reset_authorization_code_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_reset_authorization_code_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_reset_authorization_code_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_reset_authorization_code_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_authorization_code_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_authorization_code_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_authorization_code_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_authorization_code_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_register_parameters_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_register_parameters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_register_parameters_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_register_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_transfer_parameters_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_transfer_parameters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_transfer_parameters_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_retrieve_transfer_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_search_domains_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_search_domains_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_search_domains_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_search_domains_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_transfer_domain_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_transfer_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_update_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1_generated_domains_update_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_configure_contact_settings_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_configure_contact_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_configure_dns_settings_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_configure_dns_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_configure_management_settings_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_configure_management_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_delete_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_delete_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_export_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_export_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_get_registration_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_get_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_get_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_get_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_list_registrations_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_list_registrations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_list_registrations_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_list_registrations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_register_domain_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_register_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_reset_authorization_code_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_reset_authorization_code_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_reset_authorization_code_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_reset_authorization_code_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_authorization_code_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_authorization_code_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_authorization_code_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_authorization_code_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_register_parameters_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_register_parameters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_register_parameters_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_register_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_transfer_parameters_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_transfer_parameters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_transfer_parameters_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_retrieve_transfer_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_search_domains_async.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_search_domains_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_search_domains_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_search_domains_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_transfer_domain_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_transfer_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_update_registration_sync.py
+++ b/packages/google-cloud-domains/samples/generated_samples/domains_v1beta1_generated_domains_update_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/tests/__init__.py
+++ b/packages/google-cloud-domains/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/tests/unit/__init__.py
+++ b/packages/google-cloud-domains/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-domains/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/tests/unit/gapic/domains_v1/__init__.py
+++ b/packages/google-cloud-domains/tests/unit/gapic/domains_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-domains/tests/unit/gapic/domains_v1beta1/__init__.py
+++ b/packages/google-cloud-domains/tests/unit/gapic/domains_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/.flake8
+++ b/packages/google-cloud-edgecontainer/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/MANIFEST.in
+++ b/packages/google-cloud-edgecontainer/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer/__init__.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer/gapic_version.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/gapic_version.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/__init__.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/__init__.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/client.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/pagers.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/__init__.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/base.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/grpc.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/grpc_asyncio.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/rest.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/rest_base.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/types/__init__.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/types/resources.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/types/service.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_create_cluster_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_create_node_pool_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_create_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_create_vpn_connection_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_create_vpn_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_delete_cluster_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_delete_node_pool_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_delete_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_delete_vpn_connection_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_delete_vpn_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_access_token_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_access_token_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_offline_credential_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_offline_credential_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_offline_credential_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_generate_offline_credential_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_cluster_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_cluster_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_machine_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_machine_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_machine_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_machine_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_node_pool_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_node_pool_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_server_config_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_server_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_server_config_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_server_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_vpn_connection_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_vpn_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_vpn_connection_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_get_vpn_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_clusters_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_clusters_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_machines_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_machines_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_machines_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_machines_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_node_pools_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_node_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_node_pools_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_node_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_vpn_connections_async.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_vpn_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_vpn_connections_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_list_vpn_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_update_cluster_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_update_node_pool_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_update_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_upgrade_cluster_sync.py
+++ b/packages/google-cloud-edgecontainer/samples/generated_samples/edgecontainer_v1_generated_edge_container_upgrade_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/tests/__init__.py
+++ b/packages/google-cloud-edgecontainer/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/tests/unit/__init__.py
+++ b/packages/google-cloud-edgecontainer/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-edgecontainer/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgecontainer/tests/unit/gapic/edgecontainer_v1/__init__.py
+++ b/packages/google-cloud-edgecontainer/tests/unit/gapic/edgecontainer_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/.flake8
+++ b/packages/google-cloud-edgenetwork/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/MANIFEST.in
+++ b/packages/google-cloud-edgenetwork/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork/__init__.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork/gapic_version.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/gapic_version.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/__init__.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/__init__.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/client.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/pagers.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/__init__.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/base.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/grpc.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/grpc_asyncio.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/rest.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/rest_base.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/services/edge_network/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/__init__.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/service.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_interconnect_attachment_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_interconnect_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_network_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_router_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_router_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_subnet_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_create_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_interconnect_attachment_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_interconnect_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_network_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_router_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_router_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_subnet_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_delete_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_interconnect_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_interconnect_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_interconnect_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_interconnect_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_network_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_network_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_network_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_router_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_router_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_router_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_diagnose_router_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_attachment_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_attachment_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_interconnect_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_network_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_network_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_network_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_router_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_router_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_router_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_router_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_subnet_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_subnet_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_subnet_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_zone_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_zone_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_zone_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_get_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_initialize_zone_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_initialize_zone_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_initialize_zone_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_initialize_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnect_attachments_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnect_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnect_attachments_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnect_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnects_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnects_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_interconnects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_networks_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_networks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_networks_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_networks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_routers_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_routers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_routers_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_routers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_subnets_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_subnets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_subnets_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_subnets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_zones_async.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_zones_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_zones_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_list_zones_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_update_router_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_update_router_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_update_subnet_sync.py
+++ b/packages/google-cloud-edgenetwork/samples/generated_samples/edgenetwork_v1_generated_edge_network_update_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/tests/__init__.py
+++ b/packages/google-cloud-edgenetwork/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/tests/unit/__init__.py
+++ b/packages/google-cloud-edgenetwork/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-edgenetwork/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-edgenetwork/tests/unit/gapic/edgenetwork_v1/__init__.py
+++ b/packages/google-cloud-edgenetwork/tests/unit/gapic/edgenetwork_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/.flake8
+++ b/packages/google-cloud-enterpriseknowledgegraph/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/MANIFEST.in
+++ b/packages/google-cloud-enterpriseknowledgegraph/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph/gapic_version.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/gapic_version.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/async_client.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/client.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/pagers.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/base.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/grpc.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/rest.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/rest_base.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/services/enterprise_knowledge_graph_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/types/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/types/job_state.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/types/job_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/types/operation_metadata.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_cancel_entity_reconciliation_job_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_cancel_entity_reconciliation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_cancel_entity_reconciliation_job_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_cancel_entity_reconciliation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_create_entity_reconciliation_job_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_create_entity_reconciliation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_create_entity_reconciliation_job_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_create_entity_reconciliation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_delete_entity_reconciliation_job_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_delete_entity_reconciliation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_delete_entity_reconciliation_job_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_delete_entity_reconciliation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_get_entity_reconciliation_job_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_get_entity_reconciliation_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_get_entity_reconciliation_job_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_get_entity_reconciliation_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_list_entity_reconciliation_jobs_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_list_entity_reconciliation_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_list_entity_reconciliation_jobs_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_list_entity_reconciliation_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_public_kg_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_public_kg_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_public_kg_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_public_kg_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_lookup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_public_kg_async.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_public_kg_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_public_kg_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_public_kg_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_sync.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/samples/generated_samples/enterpriseknowledgegraph_v1_generated_enterprise_knowledge_graph_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/tests/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/tests/unit/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-enterpriseknowledgegraph/tests/unit/gapic/enterpriseknowledgegraph_v1/__init__.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/tests/unit/gapic/enterpriseknowledgegraph_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/.flake8
+++ b/packages/google-cloud-error-reporting/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/MANIFEST.in
+++ b/packages/google-cloud-error-reporting/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting/gapic_version.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/gapic_version.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/async_client.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/client.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/base.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/grpc.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/rest.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/rest_base.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_group_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/async_client.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/client.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/pagers.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/base.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/grpc.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/rest.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/rest_base.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/error_stats_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/async_client.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/client.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/base.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/grpc.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/rest.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/rest_base.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/services/report_errors_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/__init__.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/common.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/error_group_service.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/error_group_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/error_stats_service.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/error_stats_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/report_errors_service.py
+++ b/packages/google-cloud-error-reporting/google/cloud/errorreporting_v1beta1/types/report_errors_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_get_group_async.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_get_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_get_group_sync.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_get_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_update_group_async.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_update_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_update_group_sync.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_group_service_update_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_delete_events_async.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_delete_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_delete_events_sync.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_delete_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_events_async.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_events_sync.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_group_stats_async.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_group_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_group_stats_sync.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_error_stats_service_list_group_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_report_errors_service_report_error_event_async.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_report_errors_service_report_error_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_report_errors_service_report_error_event_sync.py
+++ b/packages/google-cloud-error-reporting/samples/generated_samples/clouderrorreporting_v1beta1_generated_report_errors_service_report_error_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/tests/__init__.py
+++ b/packages/google-cloud-error-reporting/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/tests/unit/__init__.py
+++ b/packages/google-cloud-error-reporting/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-error-reporting/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-error-reporting/tests/unit/gapic/errorreporting_v1beta1/__init__.py
+++ b/packages/google-cloud-error-reporting/tests/unit/gapic/errorreporting_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/.flake8
+++ b/packages/google-cloud-essential-contacts/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/MANIFEST.in
+++ b/packages/google-cloud-essential-contacts/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts/__init__.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts/gapic_version.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/gapic_version.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/__init__.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/__init__.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/async_client.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/client.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/pagers.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/__init__.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/base.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/grpc.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/rest.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/rest_base.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/services/essential_contacts_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/types/__init__.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/types/enums.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/types/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/types/service.py
+++ b/packages/google-cloud-essential-contacts/google/cloud/essential_contacts_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_compute_contacts_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_compute_contacts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_compute_contacts_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_compute_contacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_create_contact_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_create_contact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_create_contact_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_create_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_delete_contact_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_delete_contact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_delete_contact_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_delete_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_get_contact_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_get_contact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_get_contact_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_get_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_list_contacts_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_list_contacts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_list_contacts_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_list_contacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_send_test_message_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_send_test_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_send_test_message_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_send_test_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_update_contact_async.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_update_contact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_update_contact_sync.py
+++ b/packages/google-cloud-essential-contacts/samples/generated_samples/essentialcontacts_v1_generated_essential_contacts_service_update_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/tests/__init__.py
+++ b/packages/google-cloud-essential-contacts/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/tests/unit/__init__.py
+++ b/packages/google-cloud-essential-contacts/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-essential-contacts/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-essential-contacts/tests/unit/gapic/essential_contacts_v1/__init__.py
+++ b/packages/google-cloud-essential-contacts/tests/unit/gapic/essential_contacts_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/.flake8
+++ b/packages/google-cloud-eventarc-publishing/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/MANIFEST.in
+++ b/packages/google-cloud-eventarc-publishing/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing/gapic_version.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/gapic_version.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/async_client.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/client.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/base.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/grpc.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/grpc_asyncio.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/rest.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/rest_base.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/services/publisher/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/types/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/types/cloud_event.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/types/cloud_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/types/publisher.py
+++ b/packages/google-cloud-eventarc-publishing/google/cloud/eventarc_publishing_v1/types/publisher.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_async.py
+++ b/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_channel_connection_events_async.py
+++ b/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_channel_connection_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_channel_connection_events_sync.py
+++ b/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_channel_connection_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_events_async.py
+++ b/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_events_sync.py
+++ b/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_sync.py
+++ b/packages/google-cloud-eventarc-publishing/samples/generated_samples/eventarcpublishing_v1_generated_publisher_publish_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/tests/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/tests/unit/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc-publishing/tests/unit/gapic/eventarc_publishing_v1/__init__.py
+++ b/packages/google-cloud-eventarc-publishing/tests/unit/gapic/eventarc_publishing_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/.flake8
+++ b/packages/google-cloud-eventarc/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/MANIFEST.in
+++ b/packages/google-cloud-eventarc/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc/__init__.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc/gapic_version.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/gapic_version.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/__init__.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/__init__.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/pagers.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/__init__.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/base.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc_asyncio.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest_base.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/__init__.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/channel.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/channel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/channel_connection.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/channel_connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/discovery.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/discovery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/enrollment.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/enrollment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/eventarc.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/eventarc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/google_api_source.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/google_api_source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/google_channel_config.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/google_channel_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/logging_config.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/logging_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/message_bus.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/message_bus.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/network_config.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/network_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/pipeline.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/pipeline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/trigger.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/types/trigger.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_connection_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_enrollment_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_enrollment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_google_api_source_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_google_api_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_message_bus_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_message_bus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_pipeline_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_trigger_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_connection_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_enrollment_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_enrollment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_google_api_source_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_google_api_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_message_bus_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_message_bus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_pipeline_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_trigger_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_connection_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_connection_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_enrollment_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_enrollment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_enrollment_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_enrollment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_api_source_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_api_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_api_source_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_api_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_channel_config_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_channel_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_channel_config_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_channel_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_message_bus_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_message_bus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_message_bus_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_message_bus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_pipeline_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_pipeline_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_pipeline_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_provider_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_provider_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_provider_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_provider_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_trigger_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_trigger_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_trigger_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channel_connections_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channel_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channel_connections_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channel_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channels_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channels_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_enrollments_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_enrollments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_enrollments_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_enrollments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_google_api_sources_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_google_api_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_google_api_sources_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_google_api_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_bus_enrollments_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_bus_enrollments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_bus_enrollments_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_bus_enrollments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_buses_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_buses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_buses_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_message_buses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_pipelines_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_pipelines_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_pipelines_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_pipelines_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_providers_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_providers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_providers_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_providers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_triggers_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_triggers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_triggers_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_triggers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_channel_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_enrollment_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_enrollment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_api_source_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_api_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_channel_config_async.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_channel_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_channel_config_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_channel_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_message_bus_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_message_bus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_pipeline_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_trigger_sync.py
+++ b/packages/google-cloud-eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_trigger_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/tests/__init__.py
+++ b/packages/google-cloud-eventarc/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/tests/unit/__init__.py
+++ b/packages/google-cloud-eventarc/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-eventarc/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-eventarc/tests/unit/gapic/eventarc_v1/__init__.py
+++ b/packages/google-cloud-eventarc/tests/unit/gapic/eventarc_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/.flake8
+++ b/packages/google-cloud-filestore/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/MANIFEST.in
+++ b/packages/google-cloud-filestore/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore/__init__.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore/gapic_version.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/gapic_version.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/__init__.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/__init__.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/client.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/pagers.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/__init__.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/base.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/grpc.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/rest.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/rest_base.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/services/cloud_filestore_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/types/__init__.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/google/cloud/filestore_v1/types/cloud_filestore_service.py
+++ b/packages/google-cloud-filestore/google/cloud/filestore_v1/types/cloud_filestore_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_create_backup_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_create_instance_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_create_snapshot_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_delete_backup_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_delete_instance_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_delete_snapshot_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_delete_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_backup_async.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_backup_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_instance_async.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_instance_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_snapshot_async.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_snapshot_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_get_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_backups_async.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_backups_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_instances_async.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_instances_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_snapshots_async.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_snapshots_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_snapshots_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_list_snapshots_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_promote_replica_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_promote_replica_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_restore_instance_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_restore_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_revert_instance_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_revert_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_update_backup_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_update_instance_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_update_snapshot_sync.py
+++ b/packages/google-cloud-filestore/samples/generated_samples/file_v1_generated_cloud_filestore_manager_update_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/tests/__init__.py
+++ b/packages/google-cloud-filestore/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/tests/unit/__init__.py
+++ b/packages/google-cloud-filestore/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-filestore/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-filestore/tests/unit/gapic/filestore_v1/__init__.py
+++ b/packages/google-cloud-filestore/tests/unit/gapic/filestore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/.flake8
+++ b/packages/google-cloud-financialservices/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/MANIFEST.in
+++ b/packages/google-cloud-financialservices/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices/__init__.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices/gapic_version.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/gapic_version.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/__init__.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/__init__.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/client.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/pagers.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/__init__.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/base.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/grpc.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/grpc_asyncio.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/rest.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/rest_base.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/__init__.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/backtest_result.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/backtest_result.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/bigquery_destination.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/bigquery_destination.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/dataset.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/engine_config.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/engine_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/engine_version.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/engine_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/instance.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/line_of_business.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/line_of_business.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/model.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/prediction_result.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/prediction_result.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/service.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_backtest_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_backtest_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_dataset_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_engine_config_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_engine_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_instance_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_model_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_prediction_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_create_prediction_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_backtest_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_backtest_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_dataset_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_engine_config_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_engine_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_instance_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_model_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_prediction_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_delete_prediction_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_backtest_result_metadata_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_backtest_result_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_engine_config_metadata_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_engine_config_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_model_metadata_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_model_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_prediction_result_metadata_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_prediction_result_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_registered_parties_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_export_registered_parties_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_backtest_result_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_backtest_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_backtest_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_backtest_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_dataset_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_dataset_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_config_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_config_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_version_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_version_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_engine_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_instance_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_instance_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_model_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_model_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_prediction_result_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_prediction_result_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_prediction_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_get_prediction_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_import_registered_parties_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_import_registered_parties_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_backtest_results_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_backtest_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_backtest_results_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_backtest_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_datasets_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_datasets_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_configs_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_configs_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_versions_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_versions_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_engine_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_instances_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_instances_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_models_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_models_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_prediction_results_async.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_prediction_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_prediction_results_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_list_prediction_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_backtest_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_backtest_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_dataset_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_engine_config_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_engine_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_instance_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_model_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_prediction_result_sync.py
+++ b/packages/google-cloud-financialservices/samples/generated_samples/financialservices_v1_generated_aml_update_prediction_result_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/tests/__init__.py
+++ b/packages/google-cloud-financialservices/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/tests/unit/__init__.py
+++ b/packages/google-cloud-financialservices/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-financialservices/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-financialservices/tests/unit/gapic/financialservices_v1/__init__.py
+++ b/packages/google-cloud-financialservices/tests/unit/gapic/financialservices_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/.flake8
+++ b/packages/google-cloud-firestore/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/MANIFEST.in
+++ b/packages/google-cloud-firestore/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/client.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/pagers.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/base.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/grpc.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/rest.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/rest_base.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/services/firestore_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/backup.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/backup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/database.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/database.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/field.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/field.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/firestore_admin.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/firestore_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/index.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/index.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/location.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/location.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/operation.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/operation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/realtime_updates.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/realtime_updates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/schedule.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/schedule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/snapshot.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/snapshot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/user_creds.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/types/user_creds.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_bundle/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_bundle/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_bundle/services/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_bundle/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_bundle/types/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_bundle/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_bundle/types/bundle.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_bundle/types/bundle.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/async_client.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/client.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/pagers.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/base.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/grpc.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/rest.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/rest_base.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/__init__.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/aggregation_result.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/aggregation_result.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/bloom_filter.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/bloom_filter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/common.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/document.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/document.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/explain_stats.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/explain_stats.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/firestore.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/firestore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/pipeline.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/pipeline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/query.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/query.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/query_profile.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/query_profile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/write.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/write.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_bulk_delete_documents_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_bulk_delete_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_clone_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_clone_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_backup_schedule_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_backup_schedule_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_index_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_user_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_user_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_schedule_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_schedule_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_index_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_index_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_index_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_user_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_user_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_disable_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_disable_user_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_disable_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_disable_user_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_enable_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_enable_user_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_enable_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_enable_user_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_export_documents_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_export_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_schedule_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_schedule_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_database_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_field_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_field_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_field_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_index_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_index_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_index_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_user_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_user_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_import_documents_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_import_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backup_schedules_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backup_schedules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backup_schedules_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backup_schedules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backups_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backups_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_databases_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_databases_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_fields_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_fields_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_fields_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_fields_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_indexes_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_indexes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_indexes_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_indexes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_user_creds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_user_creds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_reset_user_password_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_reset_user_password_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_reset_user_password_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_reset_user_password_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_restore_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_restore_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_backup_schedule_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_backup_schedule_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_field_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_get_documents_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_get_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_get_documents_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_get_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_write_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_write_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_write_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_batch_write_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_begin_transaction_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_begin_transaction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_begin_transaction_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_begin_transaction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_commit_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_commit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_commit_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_commit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_create_document_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_create_document_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_delete_document_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_delete_document_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_execute_pipeline_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_execute_pipeline_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_execute_pipeline_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_execute_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_get_document_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_get_document_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_collection_ids_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_collection_ids_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_collection_ids_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_collection_ids_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_documents_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_documents_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_listen_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_listen_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_listen_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_listen_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_partition_query_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_partition_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_partition_query_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_partition_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_rollback_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_rollback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_rollback_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_rollback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_aggregation_query_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_aggregation_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_aggregation_query_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_aggregation_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_query_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_query_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_run_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_update_document_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_update_document_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_write_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_write_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_write_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_write_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/tests/__init__.py
+++ b/packages/google-cloud-firestore/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/tests/unit/__init__.py
+++ b/packages/google-cloud-firestore/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-firestore/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/tests/unit/gapic/firestore_admin_v1/__init__.py
+++ b/packages/google-cloud-firestore/tests/unit/gapic/firestore_admin_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/tests/unit/gapic/firestore_bundle/__init__.py
+++ b/packages/google-cloud-firestore/tests/unit/gapic/firestore_bundle/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-firestore/tests/unit/gapic/firestore_v1/__init__.py
+++ b/packages/google-cloud-firestore/tests/unit/gapic/firestore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/.flake8
+++ b/packages/google-cloud-functions/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/MANIFEST.in
+++ b/packages/google-cloud-functions/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions/gapic_version.py
+++ b/packages/google-cloud-functions/google/cloud/functions/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/gapic_version.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/client.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/pagers.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/base.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/grpc.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/rest.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/rest_base.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/services/cloud_functions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/types/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/types/functions.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/types/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v1/types/operations.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/gapic_version.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/client.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/pagers.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/base.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/grpc.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/rest.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/rest_base.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/services/function_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/types/__init__.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/google/cloud/functions_v2/types/functions.py
+++ b/packages/google-cloud-functions/google/cloud/functions_v2/types/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_call_function_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_call_function_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_call_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_call_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_create_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_create_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_delete_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_delete_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_download_url_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_download_url_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_download_url_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_download_url_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_upload_url_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_upload_url_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_upload_url_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_generate_upload_url_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_function_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_function_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_iam_policy_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_list_functions_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_list_functions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_list_functions_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_list_functions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_set_iam_policy_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_update_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v1_generated_cloud_functions_service_update_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_create_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_create_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_delete_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_delete_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_download_url_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_download_url_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_download_url_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_download_url_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_upload_url_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_upload_url_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_upload_url_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_generate_upload_url_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_get_function_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_get_function_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_get_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_get_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_functions_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_functions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_functions_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_functions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_runtimes_async.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_runtimes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_runtimes_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_list_runtimes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_update_function_sync.py
+++ b/packages/google-cloud-functions/samples/generated_samples/cloudfunctions_v2_generated_function_service_update_function_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/tests/__init__.py
+++ b/packages/google-cloud-functions/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/tests/unit/__init__.py
+++ b/packages/google-cloud-functions/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-functions/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/tests/unit/gapic/functions_v1/__init__.py
+++ b/packages/google-cloud-functions/tests/unit/gapic/functions_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-functions/tests/unit/gapic/functions_v2/__init__.py
+++ b/packages/google-cloud-functions/tests/unit/gapic/functions_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/.flake8
+++ b/packages/google-cloud-gdchardwaremanagement/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/MANIFEST.in
+++ b/packages/google-cloud-gdchardwaremanagement/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement/gapic_version.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/gapic_version.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/client.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/pagers.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/base.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/grpc.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/rest.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/rest_base.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/services/gdc_hardware_management/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/types/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/types/service.py
+++ b/packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_cancel_order_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_cancel_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_comment_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_hardware_group_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_hardware_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_hardware_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_hardware_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_order_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_site_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_zone_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_create_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_hardware_group_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_hardware_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_hardware_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_hardware_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_order_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_site_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_zone_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_delete_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_change_log_entry_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_change_log_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_change_log_entry_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_change_log_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_comment_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_comment_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_group_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_group_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_hardware_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_order_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_order_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_order_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_site_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_site_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_site_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_sku_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_sku_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_sku_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_sku_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_zone_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_zone_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_zone_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_get_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_change_log_entries_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_change_log_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_change_log_entries_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_change_log_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_comments_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_comments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_comments_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_groups_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_groups_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_hardware_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_orders_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_orders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_orders_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_orders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_sites_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_sites_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_sites_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_skus_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_skus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_skus_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_skus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_zones_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_zones_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_zones_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_list_zones_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_record_action_on_comment_async.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_record_action_on_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_record_action_on_comment_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_record_action_on_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_request_order_date_change_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_request_order_date_change_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_signal_zone_state_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_signal_zone_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_submit_order_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_submit_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_hardware_group_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_hardware_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_hardware_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_hardware_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_order_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_site_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_zone_sync.py
+++ b/packages/google-cloud-gdchardwaremanagement/samples/generated_samples/gdchardwaremanagement_v1alpha_generated_gdc_hardware_management_update_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/tests/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/tests/unit/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gdchardwaremanagement/tests/unit/gapic/gdchardwaremanagement_v1alpha/__init__.py
+++ b/packages/google-cloud-gdchardwaremanagement/tests/unit/gapic/gdchardwaremanagement_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/.flake8
+++ b/packages/google-cloud-geminidataanalytics/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/MANIFEST.in
+++ b/packages/google-cloud-geminidataanalytics/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/pagers.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/grpc.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/rest.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/rest_base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_agent_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/async_client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/pagers.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/grpc.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/rest.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/rest_base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/services/data_chat_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/context.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/conversation.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/credentials.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/credentials.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_agent.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_agent_service.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_agent_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_analytics_agent.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_analytics_agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_chat_service.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/data_chat_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/datasource.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/types/datasource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/pagers.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/grpc.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/rest.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/rest_base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_agent_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/async_client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/pagers.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/grpc.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/rest.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/rest_base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/services/data_chat_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/agent_context.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/agent_context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/context.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/conversation.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/credentials.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/credentials.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_agent.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_agent_service.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_agent_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_analytics_agent.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_analytics_agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_chat_service.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/data_chat_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/datasource.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/types/datasource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/pagers.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/grpc.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/rest.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/rest_base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_agent_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/async_client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/client.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/pagers.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/grpc.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/rest.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/rest_base.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/services/data_chat_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/agent_context.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/agent_context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/context.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/conversation.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/conversation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/credentials.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/credentials.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_agent.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_agent_service.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_agent_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_analytics_agent.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_analytics_agent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_chat_service.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/data_chat_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/datasource.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/types/datasource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_create_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_create_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_create_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_create_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_create_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_create_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_delete_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_delete_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_delete_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_delete_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_delete_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_delete_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_data_agent_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_data_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_iam_policy_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_accessible_data_agents_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_accessible_data_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_accessible_data_agents_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_accessible_data_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_data_agents_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_data_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_data_agents_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_list_data_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_set_iam_policy_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_update_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_update_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_update_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_update_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_update_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_agent_service_update_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_chat_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_chat_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_chat_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_chat_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_create_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_create_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_delete_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_delete_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_get_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_get_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_conversations_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_conversations_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_messages_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_messages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_messages_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1_generated_data_chat_service_list_messages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_create_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_create_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_create_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_create_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_create_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_create_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_delete_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_delete_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_delete_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_delete_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_delete_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_delete_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_data_agent_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_data_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_iam_policy_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_accessible_data_agents_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_accessible_data_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_accessible_data_agents_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_accessible_data_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_data_agents_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_data_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_data_agents_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_list_data_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_set_iam_policy_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_update_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_update_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_update_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_update_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_update_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_agent_service_update_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_chat_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_chat_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_chat_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_chat_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_create_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_create_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_delete_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_delete_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_get_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_get_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_conversations_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_conversations_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_messages_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_messages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_messages_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_list_messages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_query_data_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_query_data_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_query_data_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1alpha_generated_data_chat_service_query_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_create_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_create_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_create_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_create_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_create_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_create_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_delete_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_delete_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_delete_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_delete_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_delete_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_delete_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_data_agent_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_data_agent_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_iam_policy_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_accessible_data_agents_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_accessible_data_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_accessible_data_agents_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_accessible_data_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_data_agents_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_data_agents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_data_agents_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_list_data_agents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_set_iam_policy_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_update_data_agent_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_update_data_agent_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_update_data_agent_sync_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_update_data_agent_sync_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_update_data_agent_sync_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_agent_service_update_data_agent_sync_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_chat_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_chat_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_chat_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_chat_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_create_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_create_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_create_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_create_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_delete_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_delete_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_delete_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_delete_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_get_conversation_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_get_conversation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_get_conversation_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_get_conversation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_conversations_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_conversations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_conversations_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_conversations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_messages_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_messages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_messages_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_list_messages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_query_data_async.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_query_data_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_query_data_sync.py
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/geminidataanalytics_v1beta_generated_data_chat_service_query_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/tests/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/tests/unit/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1alpha/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1beta/__init__.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/.flake8
+++ b/packages/google-cloud-gke-backup/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/MANIFEST.in
+++ b/packages/google-cloud-gke-backup/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup/__init__.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup/gapic_version.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/gapic_version.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/__init__.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/__init__.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/client.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/pagers.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/__init__.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/base.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/grpc.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/rest.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/rest_base.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/services/backup_for_gke/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/__init__.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup_channel.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup_channel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup_plan.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup_plan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup_plan_binding.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/backup_plan_binding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/common.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/gkebackup.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/gkebackup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore_channel.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore_channel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore_plan.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore_plan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore_plan_binding.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/restore_plan_binding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/volume.py
+++ b/packages/google-cloud-gke-backup/google/cloud/gke_backup_v1/types/volume.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_backup_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_backup_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_backup_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_backup_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_restore_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_restore_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_restore_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_restore_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_restore_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_create_restore_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_backup_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_backup_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_backup_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_backup_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_restore_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_restore_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_restore_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_restore_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_restore_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_delete_restore_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_channel_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_index_download_url_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_index_download_url_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_index_download_url_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_index_download_url_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_binding_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_binding_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_channel_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_binding_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_binding_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_restore_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_backup_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_backup_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_restore_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_restore_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_restore_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_get_volume_restore_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_channels_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_channels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_channels_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_channels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plan_bindings_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plan_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plan_bindings_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plan_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plans_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plans_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plans_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backup_plans_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backups_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backups_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_channels_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_channels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_channels_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_channels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plan_bindings_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plan_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plan_bindings_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plan_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plans_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plans_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plans_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restore_plans_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restores_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restores_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_restores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_backups_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_backups_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_restores_async.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_restores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_restores_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_list_volume_restores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_backup_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_backup_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_backup_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_backup_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_backup_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_restore_channel_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_restore_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_restore_plan_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_restore_plan_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_restore_sync.py
+++ b/packages/google-cloud-gke-backup/samples/generated_samples/gkebackup_v1_generated_backup_for_gke_update_restore_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/tests/__init__.py
+++ b/packages/google-cloud-gke-backup/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/tests/unit/__init__.py
+++ b/packages/google-cloud-gke-backup/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gke-backup/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-backup/tests/unit/gapic/gke_backup_v1/__init__.py
+++ b/packages/google-cloud-gke-backup/tests/unit/gapic/gke_backup_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/.flake8
+++ b/packages/google-cloud-gke-connect-gateway/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/MANIFEST.in
+++ b/packages/google-cloud-gke-connect-gateway/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway/gapic_version.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/gapic_version.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/client.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/base.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/rest.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/rest_base.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/services/gateway_control/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/types/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/types/control.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/gapic_version.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/client.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/base.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/rest.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/rest_base.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/services/gateway_control/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/types/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/types/control.py
+++ b/packages/google-cloud-gke-connect-gateway/google/cloud/gkeconnect/gateway_v1beta1/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/samples/generated_samples/connectgateway_v1_generated_gateway_control_generate_credentials_sync.py
+++ b/packages/google-cloud-gke-connect-gateway/samples/generated_samples/connectgateway_v1_generated_gateway_control_generate_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/samples/generated_samples/connectgateway_v1beta1_generated_gateway_control_generate_credentials_sync.py
+++ b/packages/google-cloud-gke-connect-gateway/samples/generated_samples/connectgateway_v1beta1_generated_gateway_control_generate_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/tests/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/tests/unit/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/tests/unit/gapic/gateway_v1/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/tests/unit/gapic/gateway_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-connect-gateway/tests/unit/gapic/gateway_v1beta1/__init__.py
+++ b/packages/google-cloud-gke-connect-gateway/tests/unit/gapic/gateway_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/.flake8
+++ b/packages/google-cloud-gke-hub/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/MANIFEST.in
+++ b/packages/google-cloud-gke-hub/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub/gapic_version.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/gapic_version.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/client.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/pagers.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/base.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/grpc.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/rest.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/rest_base.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/services/gke_hub/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/feature.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/feature.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/fleet.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/fleet.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/membership.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/membership.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/service.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/gapic_version.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/client.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/pagers.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/base.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/grpc.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/rest.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/rest_base.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/services/gke_hub_membership_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/types/__init__.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/types/membership.py
+++ b/packages/google-cloud-gke-hub/google/cloud/gkehub_v1beta1/types/membership.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_feature_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_feature_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_fleet_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_fleet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_membership_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_membership_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_membership_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_membership_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_scope_namespace_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_scope_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_scope_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_scope_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_scope_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_create_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_feature_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_feature_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_fleet_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_fleet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_membership_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_membership_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_membership_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_membership_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_scope_namespace_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_scope_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_scope_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_scope_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_scope_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_delete_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_connect_manifest_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_connect_manifest_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_connect_manifest_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_connect_manifest_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_membership_rbac_role_binding_yaml_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_membership_rbac_role_binding_yaml_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_membership_rbac_role_binding_yaml_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_generate_membership_rbac_role_binding_yaml_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_feature_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_feature_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_feature_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_feature_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_fleet_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_fleet_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_fleet_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_fleet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_binding_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_rbac_role_binding_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_rbac_role_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_namespace_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_namespace_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_rbac_role_binding_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_rbac_role_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_get_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_bound_memberships_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_bound_memberships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_bound_memberships_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_bound_memberships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_features_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_features_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_features_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_features_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_fleets_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_fleets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_fleets_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_fleets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_bindings_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_bindings_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_rbac_role_bindings_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_rbac_role_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_rbac_role_bindings_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_membership_rbac_role_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_memberships_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_memberships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_memberships_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_memberships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_permitted_scopes_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_permitted_scopes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_permitted_scopes_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_permitted_scopes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_namespaces_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_namespaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_namespaces_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_namespaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_rbac_role_bindings_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_rbac_role_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_rbac_role_bindings_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scope_rbac_role_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scopes_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scopes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scopes_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_list_scopes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_feature_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_feature_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_fleet_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_fleet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_membership_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_membership_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_membership_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_membership_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_scope_namespace_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_scope_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_scope_rbac_role_binding_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_scope_rbac_role_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_scope_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1_generated_gke_hub_update_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_create_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_create_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_delete_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_delete_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_connect_manifest_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_connect_manifest_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_connect_manifest_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_connect_manifest_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_exclusivity_manifest_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_exclusivity_manifest_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_exclusivity_manifest_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_generate_exclusivity_manifest_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_get_membership_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_get_membership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_get_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_get_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_list_memberships_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_list_memberships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_list_memberships_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_list_memberships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_update_membership_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_update_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_validate_exclusivity_async.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_validate_exclusivity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_validate_exclusivity_sync.py
+++ b/packages/google-cloud-gke-hub/samples/generated_samples/gkehub_v1beta1_generated_gke_hub_membership_service_validate_exclusivity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/tests/__init__.py
+++ b/packages/google-cloud-gke-hub/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/tests/unit/__init__.py
+++ b/packages/google-cloud-gke-hub/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gke-hub/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/tests/unit/gapic/gkehub_v1/__init__.py
+++ b/packages/google-cloud-gke-hub/tests/unit/gapic/gkehub_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-hub/tests/unit/gapic/gkehub_v1beta1/__init__.py
+++ b/packages/google-cloud-gke-hub/tests/unit/gapic/gkehub_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/.flake8
+++ b/packages/google-cloud-gke-multicloud/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/MANIFEST.in
+++ b/packages/google-cloud-gke-multicloud/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud/gapic_version.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/gapic_version.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/client.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/pagers.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/base.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/grpc.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/rest.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/rest_base.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/attached_clusters/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/client.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/pagers.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/base.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/grpc.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/rest.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/rest_base.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/aws_clusters/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/client.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/pagers.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/base.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/grpc.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/rest.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/rest_base.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/services/azure_clusters/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/__init__.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/attached_resources.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/attached_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/attached_service.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/attached_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/aws_resources.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/aws_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/aws_service.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/aws_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/azure_resources.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/azure_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/azure_service.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/azure_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/common_resources.py
+++ b/packages/google-cloud-gke-multicloud/google/cloud/gke_multicloud_v1/types/common_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_create_attached_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_create_attached_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_delete_attached_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_delete_attached_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_agent_token_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_agent_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_agent_token_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_agent_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_install_manifest_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_install_manifest_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_install_manifest_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_generate_attached_cluster_install_manifest_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_cluster_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_server_config_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_server_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_server_config_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_get_attached_server_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_import_attached_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_import_attached_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_list_attached_clusters_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_list_attached_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_list_attached_clusters_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_list_attached_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_update_attached_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_attached_clusters_update_attached_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_create_aws_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_create_aws_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_create_aws_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_create_aws_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_delete_aws_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_delete_aws_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_delete_aws_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_delete_aws_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_access_token_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_access_token_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_cluster_agent_token_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_cluster_agent_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_cluster_agent_token_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_generate_aws_cluster_agent_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_cluster_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_json_web_keys_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_json_web_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_json_web_keys_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_json_web_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_node_pool_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_open_id_config_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_open_id_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_open_id_config_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_open_id_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_server_config_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_server_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_server_config_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_get_aws_server_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_clusters_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_clusters_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_node_pools_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_node_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_node_pools_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_list_aws_node_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_rollback_aws_node_pool_update_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_rollback_aws_node_pool_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_update_aws_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_update_aws_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_update_aws_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_aws_clusters_update_aws_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_create_azure_client_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_create_azure_client_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_create_azure_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_create_azure_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_create_azure_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_create_azure_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_delete_azure_client_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_delete_azure_client_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_delete_azure_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_delete_azure_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_delete_azure_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_delete_azure_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_access_token_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_access_token_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_cluster_agent_token_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_cluster_agent_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_cluster_agent_token_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_generate_azure_cluster_agent_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_client_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_client_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_client_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_client_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_cluster_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_json_web_keys_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_json_web_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_json_web_keys_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_json_web_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_node_pool_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_node_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_open_id_config_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_open_id_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_open_id_config_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_open_id_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_server_config_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_server_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_server_config_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_get_azure_server_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clients_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clients_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clients_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clients_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clusters_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clusters_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_node_pools_async.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_node_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_node_pools_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_list_azure_node_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_update_azure_cluster_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_update_azure_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_update_azure_node_pool_sync.py
+++ b/packages/google-cloud-gke-multicloud/samples/generated_samples/gkemulticloud_v1_generated_azure_clusters_update_azure_node_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/tests/__init__.py
+++ b/packages/google-cloud-gke-multicloud/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/tests/unit/__init__.py
+++ b/packages/google-cloud-gke-multicloud/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gke-multicloud/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gke-multicloud/tests/unit/gapic/gke_multicloud_v1/__init__.py
+++ b/packages/google-cloud-gke-multicloud/tests/unit/gapic/gke_multicloud_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/.flake8
+++ b/packages/google-cloud-gkerecommender/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/MANIFEST.in
+++ b/packages/google-cloud-gkerecommender/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender/__init__.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender/gapic_version.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/gapic_version.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/__init__.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/__init__.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/async_client.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/client.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/pagers.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/__init__.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/base.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/grpc.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/rest.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/rest_base.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/services/gke_inference_quickstart/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/types/__init__.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/types/gkerecommender.py
+++ b/packages/google-cloud-gkerecommender/google/cloud/gkerecommender_v1/types/gkerecommender.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_benchmarking_data_async.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_benchmarking_data_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_benchmarking_data_sync.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_benchmarking_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_server_versions_async.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_server_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_server_versions_sync.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_server_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_servers_async.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_servers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_servers_sync.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_model_servers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_models_async.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_models_sync.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_profiles_async.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_profiles_sync.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_fetch_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_generate_optimized_manifest_async.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_generate_optimized_manifest_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_generate_optimized_manifest_sync.py
+++ b/packages/google-cloud-gkerecommender/samples/generated_samples/gkerecommender_v1_generated_gke_inference_quickstart_generate_optimized_manifest_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/tests/__init__.py
+++ b/packages/google-cloud-gkerecommender/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/tests/unit/__init__.py
+++ b/packages/google-cloud-gkerecommender/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gkerecommender/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gkerecommender/tests/unit/gapic/gkerecommender_v1/__init__.py
+++ b/packages/google-cloud-gkerecommender/tests/unit/gapic/gkerecommender_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/.flake8
+++ b/packages/google-cloud-gsuiteaddons/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/MANIFEST.in
+++ b/packages/google-cloud-gsuiteaddons/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons/gapic_version.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/gapic_version.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/async_client.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/client.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/pagers.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/base.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/grpc.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/grpc_asyncio.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/rest.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/rest_base.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/services/g_suite_add_ons/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/types/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/types/gsuiteaddons.py
+++ b/packages/google-cloud-gsuiteaddons/google/cloud/gsuiteaddons_v1/types/gsuiteaddons.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_create_deployment_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_create_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_create_deployment_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_delete_deployment_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_delete_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_delete_deployment_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_delete_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_authorization_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_authorization_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_authorization_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_authorization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_deployment_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_deployment_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_install_status_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_install_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_install_status_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_get_install_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_install_deployment_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_install_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_install_deployment_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_install_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_list_deployments_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_list_deployments_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_replace_deployment_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_replace_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_replace_deployment_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_replace_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_uninstall_deployment_async.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_uninstall_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_uninstall_deployment_sync.py
+++ b/packages/google-cloud-gsuiteaddons/samples/generated_samples/gsuiteaddons_v1_generated_g_suite_add_ons_uninstall_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/tests/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/tests/unit/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-gsuiteaddons/tests/unit/gapic/gsuiteaddons_v1/__init__.py
+++ b/packages/google-cloud-gsuiteaddons/tests/unit/gapic/gsuiteaddons_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/.flake8
+++ b/packages/google-cloud-hypercomputecluster/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/MANIFEST.in
+++ b/packages/google-cloud-hypercomputecluster/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster/gapic_version.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/gapic_version.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/client.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/pagers.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/base.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/grpc.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/grpc_asyncio.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/rest.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/rest_base.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/services/hypercompute_cluster/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/types/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/types/hypercompute_cluster.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/types/hypercompute_cluster.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/types/operation_metadata.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/gapic_version.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/client.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/pagers.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/base.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/grpc.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/grpc_asyncio.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/rest.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/rest_base.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/services/hypercompute_cluster/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/types/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/types/hypercompute_cluster.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/types/hypercompute_cluster.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/types/operation_metadata.py
+++ b/packages/google-cloud-hypercomputecluster/google/cloud/hypercomputecluster_v1beta/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_create_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_delete_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_get_cluster_async.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_get_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_list_clusters_async.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_list_clusters_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_update_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1_generated_hypercompute_cluster_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_create_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_delete_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_get_cluster_async.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_get_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_list_clusters_async.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_list_clusters_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_update_cluster_sync.py
+++ b/packages/google-cloud-hypercomputecluster/samples/generated_samples/hypercomputecluster_v1beta_generated_hypercompute_cluster_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/tests/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/tests/unit/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/tests/unit/gapic/hypercomputecluster_v1/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/tests/unit/gapic/hypercomputecluster_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-hypercomputecluster/tests/unit/gapic/hypercomputecluster_v1beta/__init__.py
+++ b/packages/google-cloud-hypercomputecluster/tests/unit/gapic/hypercomputecluster_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/.flake8
+++ b/packages/google-cloud-iam-logging/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/MANIFEST.in
+++ b/packages/google-cloud-iam-logging/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/google/cloud/iam_logging/__init__.py
+++ b/packages/google-cloud-iam-logging/google/cloud/iam_logging/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/google/cloud/iam_logging/gapic_version.py
+++ b/packages/google-cloud-iam-logging/google/cloud/iam_logging/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/gapic_version.py
+++ b/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/services/__init__.py
+++ b/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/types/__init__.py
+++ b/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/types/audit_data.py
+++ b/packages/google-cloud-iam-logging/google/cloud/iam_logging_v1/types/audit_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/tests/__init__.py
+++ b/packages/google-cloud-iam-logging/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/tests/unit/__init__.py
+++ b/packages/google-cloud-iam-logging/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-iam-logging/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam-logging/tests/unit/gapic/iam_logging_v1/__init__.py
+++ b/packages/google-cloud-iam-logging/tests/unit/gapic/iam_logging_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/.flake8
+++ b/packages/google-cloud-iam/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/MANIFEST.in
+++ b/packages/google-cloud-iam/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/async_client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/services/iam/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/types/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/types/audit_data.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/types/audit_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_admin_v1/types/iam.py
+++ b/packages/google-cloud-iam/google/cloud/iam_admin_v1/types/iam.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/async_client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/services/iam_credentials/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/types/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/types/common.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_credentials_v1/types/iamcredentials.py
+++ b/packages/google-cloud-iam/google/cloud/iam_credentials_v1/types/iamcredentials.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/services/policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/types/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/types/deny.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/types/deny.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2/types/policy.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2/types/policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/services/policies/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/types/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/types/deny.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/types/deny.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v2beta/types/policy.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v2beta/types/policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/policy_bindings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/services/principal_access_boundary_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/types/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/types/operation_metadata.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/types/policy_binding_resources.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/types/policy_binding_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/types/policy_bindings_service.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/types/policy_bindings_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/types/principal_access_boundary_policies_service.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/types/principal_access_boundary_policies_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3/types/principal_access_boundary_policy_resources.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3/types/principal_access_boundary_policy_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/gapic_version.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/access_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/policy_bindings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/client.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/pagers.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/grpc.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/rest.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/rest_base.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/services/principal_access_boundary_policies/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/__init__.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/access_policies_service.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/access_policies_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/access_policy_resources.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/access_policy_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/operation_metadata.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/operation_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/policy_binding_resources.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/policy_binding_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/policy_bindings_service.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/policy_bindings_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/principal_access_boundary_policies_service.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/principal_access_boundary_policies_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/google/cloud/iam_v3beta/types/principal_access_boundary_policy_resources.py
+++ b/packages/google-cloud-iam/google/cloud/iam_v3beta/types/principal_access_boundary_policy_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_role_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_role_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_role_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_role_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_key_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_key_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_create_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_role_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_role_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_role_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_role_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_key_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_key_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_delete_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_key_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_key_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_disable_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_key_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_key_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_enable_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_iam_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_iam_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_role_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_role_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_role_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_role_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_key_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_key_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_get_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_lint_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_lint_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_lint_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_lint_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_roles_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_roles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_roles_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_roles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_account_keys_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_account_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_account_keys_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_account_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_accounts_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_accounts_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_list_service_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_patch_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_patch_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_patch_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_patch_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_auditable_services_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_auditable_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_auditable_services_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_auditable_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_grantable_roles_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_grantable_roles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_grantable_roles_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_grantable_roles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_testable_permissions_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_testable_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_testable_permissions_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_query_testable_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_set_iam_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_set_iam_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_blob_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_blob_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_blob_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_blob_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_jwt_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_jwt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_jwt_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_sign_jwt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_test_iam_permissions_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_test_iam_permissions_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_role_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_role_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_role_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_role_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_undelete_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_role_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_role_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_role_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_role_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_service_account_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_service_account_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_update_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_upload_service_account_key_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_upload_service_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_upload_service_account_key_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v1_generated_iam_upload_service_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_create_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_create_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_delete_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_delete_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_get_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_get_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_get_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_get_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_list_policies_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_list_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_list_policies_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_list_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_update_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2_generated_policies_update_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_create_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_create_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_delete_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_delete_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_get_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_get_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_get_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_get_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_list_policies_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_list_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_list_policies_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_list_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_update_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v2beta_generated_policies_update_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_create_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_create_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_delete_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_delete_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_get_policy_binding_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_get_policy_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_get_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_get_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_list_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_list_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_list_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_list_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_search_target_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_search_target_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_search_target_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_search_target_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_update_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_policy_bindings_update_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_create_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_create_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_delete_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_delete_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_update_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3_generated_principal_access_boundary_policies_update_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_create_access_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_create_access_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_delete_access_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_delete_access_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_get_access_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_get_access_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_get_access_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_get_access_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_list_access_policies_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_list_access_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_list_access_policies_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_list_access_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_search_access_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_search_access_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_search_access_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_search_access_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_update_access_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_access_policies_update_access_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_create_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_create_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_delete_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_delete_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_get_policy_binding_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_get_policy_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_get_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_get_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_list_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_list_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_list_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_list_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_search_target_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_search_target_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_search_target_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_search_target_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_update_policy_binding_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_policy_bindings_update_policy_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_create_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_create_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_delete_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_delete_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_get_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_list_principal_access_boundary_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_search_principal_access_boundary_policy_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_update_principal_access_boundary_policy_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iam_v3beta_generated_principal_access_boundary_policies_update_principal_access_boundary_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_access_token_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_access_token_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_id_token_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_id_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_id_token_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_id_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_blob_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_blob_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_blob_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_blob_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_jwt_async.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_jwt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_jwt_sync.py
+++ b/packages/google-cloud-iam/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_jwt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/__init__.py
+++ b/packages/google-cloud-iam/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/iam_admin_v1/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/iam_admin_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/iam_credentials_v1/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/iam_credentials_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/iam_v2/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/iam_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/iam_v2beta/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/iam_v2beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/iam_v3/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/iam_v3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iam/tests/unit/gapic/iam_v3beta/__init__.py
+++ b/packages/google-cloud-iam/tests/unit/gapic/iam_v3beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/.flake8
+++ b/packages/google-cloud-iamconnectorcredentials/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/MANIFEST.in
+++ b/packages/google-cloud-iamconnectorcredentials/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials/gapic_version.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/gapic_version.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/client.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/base.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/grpc.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/rest.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/rest_base.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/services/iam_connector_credentials_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/types/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/types/connector_credentials.py
+++ b/packages/google-cloud-iamconnectorcredentials/google/cloud/iamconnectorcredentials_v1alpha/types/connector_credentials.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/samples/generated_samples/iamconnectorcredentials_v1alpha_generated_iam_connector_credentials_service_finalize_credentials_async.py
+++ b/packages/google-cloud-iamconnectorcredentials/samples/generated_samples/iamconnectorcredentials_v1alpha_generated_iam_connector_credentials_service_finalize_credentials_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/samples/generated_samples/iamconnectorcredentials_v1alpha_generated_iam_connector_credentials_service_finalize_credentials_sync.py
+++ b/packages/google-cloud-iamconnectorcredentials/samples/generated_samples/iamconnectorcredentials_v1alpha_generated_iam_connector_credentials_service_finalize_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/samples/generated_samples/iamconnectorcredentials_v1alpha_generated_iam_connector_credentials_service_retrieve_credentials_sync.py
+++ b/packages/google-cloud-iamconnectorcredentials/samples/generated_samples/iamconnectorcredentials_v1alpha_generated_iam_connector_credentials_service_retrieve_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/tests/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/tests/unit/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iamconnectorcredentials/tests/unit/gapic/iamconnectorcredentials_v1alpha/__init__.py
+++ b/packages/google-cloud-iamconnectorcredentials/tests/unit/gapic/iamconnectorcredentials_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/.flake8
+++ b/packages/google-cloud-iap/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/MANIFEST.in
+++ b/packages/google-cloud-iap/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap/gapic_version.py
+++ b/packages/google-cloud-iap/google/cloud/iap/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/gapic_version.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/async_client.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/client.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/pagers.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/base.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/grpc.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/rest.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/rest_base.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_admin_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/async_client.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/client.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/pagers.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/base.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/grpc.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/rest.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/rest_base.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/services/identity_aware_proxy_o_auth_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/types/__init__.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/google/cloud/iap_v1/types/service.py
+++ b/packages/google-cloud-iap/google/cloud/iap_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_create_tunnel_dest_group_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_create_tunnel_dest_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_create_tunnel_dest_group_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_create_tunnel_dest_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_delete_tunnel_dest_group_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_delete_tunnel_dest_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_delete_tunnel_dest_group_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_delete_tunnel_dest_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iam_policy_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iap_settings_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iap_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iap_settings_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_iap_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_tunnel_dest_group_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_tunnel_dest_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_tunnel_dest_group_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_get_tunnel_dest_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_list_tunnel_dest_groups_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_list_tunnel_dest_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_list_tunnel_dest_groups_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_list_tunnel_dest_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_set_iam_policy_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_iap_settings_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_iap_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_iap_settings_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_iap_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_tunnel_dest_group_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_tunnel_dest_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_tunnel_dest_group_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_update_tunnel_dest_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_validate_iap_attribute_expression_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_validate_iap_attribute_expression_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_validate_iap_attribute_expression_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_admin_service_validate_iap_attribute_expression_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_brand_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_brand_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_brand_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_brand_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_identity_aware_proxy_client_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_identity_aware_proxy_client_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_identity_aware_proxy_client_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_create_identity_aware_proxy_client_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_delete_identity_aware_proxy_client_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_delete_identity_aware_proxy_client_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_delete_identity_aware_proxy_client_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_delete_identity_aware_proxy_client_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_brand_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_brand_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_brand_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_brand_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_identity_aware_proxy_client_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_identity_aware_proxy_client_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_identity_aware_proxy_client_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_get_identity_aware_proxy_client_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_brands_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_brands_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_brands_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_brands_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_identity_aware_proxy_clients_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_identity_aware_proxy_clients_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_identity_aware_proxy_clients_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_list_identity_aware_proxy_clients_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_reset_identity_aware_proxy_client_secret_async.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_reset_identity_aware_proxy_client_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_reset_identity_aware_proxy_client_secret_sync.py
+++ b/packages/google-cloud-iap/samples/generated_samples/iap_v1_generated_identity_aware_proxy_o_auth_service_reset_identity_aware_proxy_client_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/tests/__init__.py
+++ b/packages/google-cloud-iap/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/tests/unit/__init__.py
+++ b/packages/google-cloud-iap/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-iap/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-iap/tests/unit/gapic/iap_v1/__init__.py
+++ b/packages/google-cloud-iap/tests/unit/gapic/iap_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/.flake8
+++ b/packages/google-cloud-ids/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/MANIFEST.in
+++ b/packages/google-cloud-ids/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids/__init__.py
+++ b/packages/google-cloud-ids/google/cloud/ids/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids/gapic_version.py
+++ b/packages/google-cloud-ids/google/cloud/ids/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/gapic_version.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/__init__.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/__init__.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/client.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/pagers.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/__init__.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/base.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/grpc.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/grpc_asyncio.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/rest.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/rest_base.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/types/__init__.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/types/ids.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/types/ids.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_create_endpoint_sync.py
+++ b/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_create_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_delete_endpoint_sync.py
+++ b/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_delete_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_get_endpoint_async.py
+++ b/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_get_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_get_endpoint_sync.py
+++ b/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_get_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_list_endpoints_async.py
+++ b/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_list_endpoints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_list_endpoints_sync.py
+++ b/packages/google-cloud-ids/samples/generated_samples/ids_v1_generated_ids_list_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/tests/__init__.py
+++ b/packages/google-cloud-ids/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/tests/unit/__init__.py
+++ b/packages/google-cloud-ids/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-ids/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-ids/tests/unit/gapic/ids_v1/__init__.py
+++ b/packages/google-cloud-ids/tests/unit/gapic/ids_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/.flake8
+++ b/packages/google-cloud-kms-inventory/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/MANIFEST.in
+++ b/packages/google-cloud-kms-inventory/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory/gapic_version.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/gapic_version.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/async_client.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/client.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/pagers.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/base.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/grpc.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/rest.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/rest_base.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_dashboard_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/async_client.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/client.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/pagers.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/base.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/grpc.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/rest.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/rest_base.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/services/key_tracking_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/types/__init__.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/types/key_dashboard_service.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/types/key_dashboard_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/types/key_tracking_service.py
+++ b/packages/google-cloud-kms-inventory/google/cloud/kms_inventory_v1/types/key_tracking_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_dashboard_service_list_crypto_keys_async.py
+++ b/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_dashboard_service_list_crypto_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_dashboard_service_list_crypto_keys_sync.py
+++ b/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_dashboard_service_list_crypto_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_get_protected_resources_summary_async.py
+++ b/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_get_protected_resources_summary_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_get_protected_resources_summary_sync.py
+++ b/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_get_protected_resources_summary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_search_protected_resources_async.py
+++ b/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_search_protected_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_search_protected_resources_sync.py
+++ b/packages/google-cloud-kms-inventory/samples/generated_samples/kmsinventory_v1_generated_key_tracking_service_search_protected_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/tests/__init__.py
+++ b/packages/google-cloud-kms-inventory/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/tests/unit/__init__.py
+++ b/packages/google-cloud-kms-inventory/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-kms-inventory/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms-inventory/tests/unit/gapic/kms_inventory_v1/__init__.py
+++ b/packages/google-cloud-kms-inventory/tests/unit/gapic/kms_inventory_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/.flake8
+++ b/packages/google-cloud-kms/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/MANIFEST.in
+++ b/packages/google-cloud-kms/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms/gapic_version.py
+++ b/packages/google-cloud-kms/google/cloud/kms/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/gapic_version.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/pagers.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/grpc.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/rest.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/rest_base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/async_client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/grpc.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/rest.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/rest_base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/autokey_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/async_client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/pagers.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/grpc.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/rest.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/rest_base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/ekm_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/pagers.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/grpc.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/rest.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/rest_base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/hsm_management/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/client.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/pagers.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/grpc.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/rest.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/rest_base.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/services/key_management_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/__init__.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/autokey.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/autokey.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/autokey_admin.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/autokey_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/ekm_service.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/ekm_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/hsm_management.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/hsm_management.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/resources.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/google/cloud/kms_v1/types/service.py
+++ b/packages/google-cloud-kms/google/cloud/kms_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_get_autokey_config_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_get_autokey_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_get_autokey_config_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_get_autokey_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_show_effective_autokey_config_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_show_effective_autokey_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_show_effective_autokey_config_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_show_effective_autokey_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_update_autokey_config_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_update_autokey_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_update_autokey_config_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_admin_update_autokey_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_create_key_handle_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_create_key_handle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_get_key_handle_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_get_key_handle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_get_key_handle_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_get_key_handle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_list_key_handles_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_list_key_handles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_list_key_handles_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_autokey_list_key_handles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_create_ekm_connection_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_create_ekm_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_create_ekm_connection_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_create_ekm_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_config_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_config_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_connection_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_connection_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_get_ekm_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_list_ekm_connections_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_list_ekm_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_list_ekm_connections_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_list_ekm_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_config_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_config_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_connection_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_connection_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_update_ekm_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_verify_connectivity_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_verify_connectivity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_verify_connectivity_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_ekm_service_verify_connectivity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_approve_single_tenant_hsm_instance_proposal_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_approve_single_tenant_hsm_instance_proposal_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_approve_single_tenant_hsm_instance_proposal_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_approve_single_tenant_hsm_instance_proposal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_create_single_tenant_hsm_instance_proposal_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_create_single_tenant_hsm_instance_proposal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_create_single_tenant_hsm_instance_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_create_single_tenant_hsm_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_delete_single_tenant_hsm_instance_proposal_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_delete_single_tenant_hsm_instance_proposal_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_delete_single_tenant_hsm_instance_proposal_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_delete_single_tenant_hsm_instance_proposal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_execute_single_tenant_hsm_instance_proposal_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_execute_single_tenant_hsm_instance_proposal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_proposal_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_proposal_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_proposal_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_proposal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_get_single_tenant_hsm_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instance_proposals_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instance_proposals_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instance_proposals_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instance_proposals_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instances_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instances_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_hsm_management_list_single_tenant_hsm_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_decrypt_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_decrypt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_decrypt_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_decrypt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_sign_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_sign_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_sign_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_asymmetric_sign_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_import_job_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_import_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_import_job_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_key_ring_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_key_ring_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_key_ring_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_create_key_ring_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decapsulate_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decapsulate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decapsulate_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decapsulate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decrypt_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decrypt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decrypt_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_decrypt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_delete_crypto_key_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_delete_crypto_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_delete_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_delete_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_destroy_crypto_key_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_destroy_crypto_key_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_destroy_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_destroy_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_encrypt_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_encrypt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_encrypt_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_encrypt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_generate_random_bytes_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_generate_random_bytes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_generate_random_bytes_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_generate_random_bytes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_import_job_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_import_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_import_job_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_key_ring_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_key_ring_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_key_ring_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_key_ring_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_public_key_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_public_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_public_key_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_retired_resource_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_retired_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_retired_resource_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_get_retired_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_import_crypto_key_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_import_crypto_key_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_import_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_import_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_key_versions_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_key_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_key_versions_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_key_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_keys_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_keys_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_crypto_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_import_jobs_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_import_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_import_jobs_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_import_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_key_rings_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_key_rings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_key_rings_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_key_rings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_retired_resources_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_retired_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_retired_resources_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_list_retired_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_sign_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_sign_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_sign_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_sign_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_verify_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_verify_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_verify_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_mac_verify_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_decrypt_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_decrypt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_decrypt_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_decrypt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_encrypt_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_encrypt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_encrypt_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_raw_encrypt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_restore_crypto_key_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_restore_crypto_key_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_restore_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_restore_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_primary_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_primary_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_primary_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_primary_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_version_async.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_version_sync.py
+++ b/packages/google-cloud-kms/samples/generated_samples/cloudkms_v1_generated_key_management_service_update_crypto_key_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/tests/__init__.py
+++ b/packages/google-cloud-kms/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/tests/unit/__init__.py
+++ b/packages/google-cloud-kms/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-kms/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-kms/tests/unit/gapic/kms_v1/__init__.py
+++ b/packages/google-cloud-kms/tests/unit/gapic/kms_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/.flake8
+++ b/packages/google-cloud-language/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/MANIFEST.in
+++ b/packages/google-cloud-language/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language/gapic_version.py
+++ b/packages/google-cloud-language/google/cloud/language/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/gapic_version.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/async_client.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/client.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/base.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/grpc.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/rest.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/rest_base.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/services/language_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/types/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1/types/language_service.py
+++ b/packages/google-cloud-language/google/cloud/language_v1/types/language_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/gapic_version.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/async_client.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/client.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/base.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/grpc.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/rest.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/rest_base.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/services/language_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/types/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v1beta2/types/language_service.py
+++ b/packages/google-cloud-language/google/cloud/language_v1beta2/types/language_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/gapic_version.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/async_client.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/client.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/base.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/grpc.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/rest.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/rest_base.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/services/language_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/types/__init__.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/google/cloud/language_v2/types/language_service.py
+++ b/packages/google-cloud-language/google/cloud/language_v2/types/language_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entities_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entities_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entity_sentiment_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entity_sentiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entity_sentiment_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_entity_sentiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_sentiment_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_sentiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_sentiment_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_sentiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_syntax_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_syntax_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_syntax_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_analyze_syntax_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_annotate_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_annotate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_annotate_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_annotate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_classify_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_classify_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_classify_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_classify_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_moderate_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_moderate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_moderate_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1_generated_language_service_moderate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entities_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entities_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entity_sentiment_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entity_sentiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entity_sentiment_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_entity_sentiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_sentiment_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_sentiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_sentiment_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_sentiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_syntax_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_syntax_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_syntax_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_analyze_syntax_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_annotate_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_annotate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_annotate_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_annotate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_classify_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_classify_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_classify_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_classify_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_moderate_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_moderate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_moderate_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v1beta2_generated_language_service_moderate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_entities_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_entities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_entities_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_entities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_sentiment_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_sentiment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_sentiment_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_analyze_sentiment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_annotate_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_annotate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_annotate_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_annotate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_classify_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_classify_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_classify_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_classify_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_moderate_text_async.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_moderate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_moderate_text_sync.py
+++ b/packages/google-cloud-language/samples/generated_samples/language_v2_generated_language_service_moderate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/tests/__init__.py
+++ b/packages/google-cloud-language/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/tests/unit/__init__.py
+++ b/packages/google-cloud-language/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-language/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/tests/unit/gapic/language_v1/__init__.py
+++ b/packages/google-cloud-language/tests/unit/gapic/language_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/tests/unit/gapic/language_v1beta2/__init__.py
+++ b/packages/google-cloud-language/tests/unit/gapic/language_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-language/tests/unit/gapic/language_v2/__init__.py
+++ b/packages/google-cloud-language/tests/unit/gapic/language_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/.flake8
+++ b/packages/google-cloud-licensemanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/MANIFEST.in
+++ b/packages/google-cloud-licensemanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager/__init__.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager/gapic_version.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/gapic_version.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/__init__.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/__init__.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/client.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/pagers.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/__init__.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/base.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/grpc.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/rest.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/rest_base.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/services/license_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/types/__init__.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/types/api_entities.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/types/api_entities.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/types/licensemanager.py
+++ b/packages/google-cloud-licensemanager/google/cloud/licensemanager_v1/types/licensemanager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_aggregate_usage_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_aggregate_usage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_aggregate_usage_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_aggregate_usage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_create_configuration_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_create_configuration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_deactivate_configuration_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_deactivate_configuration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_delete_configuration_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_delete_configuration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_configuration_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_configuration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_configuration_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_configuration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_instance_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_instance_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_product_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_product_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_configurations_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_configurations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_configurations_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_configurations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_instances_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_instances_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_products_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_products_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_query_configuration_license_usage_async.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_query_configuration_license_usage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_query_configuration_license_usage_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_query_configuration_license_usage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_reactivate_configuration_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_reactivate_configuration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_update_configuration_sync.py
+++ b/packages/google-cloud-licensemanager/samples/generated_samples/licensemanager_v1_generated_license_manager_update_configuration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/tests/__init__.py
+++ b/packages/google-cloud-licensemanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/tests/unit/__init__.py
+++ b/packages/google-cloud-licensemanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-licensemanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-licensemanager/tests/unit/gapic/licensemanager_v1/__init__.py
+++ b/packages/google-cloud-licensemanager/tests/unit/gapic/licensemanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/.flake8
+++ b/packages/google-cloud-life-sciences/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/MANIFEST.in
+++ b/packages/google-cloud-life-sciences/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences/__init__.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences/gapic_version.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/gapic_version.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/__init__.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/__init__.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/client.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/__init__.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/base.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/grpc.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/grpc_asyncio.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/rest.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/rest_base.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/services/workflows_service_v2_beta/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/types/__init__.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/types/workflows.py
+++ b/packages/google-cloud-life-sciences/google/cloud/lifesciences_v2beta/types/workflows.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/samples/generated_samples/lifesciences_v2beta_generated_workflows_service_v2_beta_run_pipeline_sync.py
+++ b/packages/google-cloud-life-sciences/samples/generated_samples/lifesciences_v2beta_generated_workflows_service_v2_beta_run_pipeline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/tests/__init__.py
+++ b/packages/google-cloud-life-sciences/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/tests/unit/__init__.py
+++ b/packages/google-cloud-life-sciences/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-life-sciences/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-life-sciences/tests/unit/gapic/lifesciences_v2beta/__init__.py
+++ b/packages/google-cloud-life-sciences/tests/unit/gapic/lifesciences_v2beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/.flake8
+++ b/packages/google-cloud-locationfinder/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/MANIFEST.in
+++ b/packages/google-cloud-locationfinder/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder/__init__.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder/gapic_version.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/gapic_version.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/__init__.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/__init__.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/async_client.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/client.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/pagers.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/__init__.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/base.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/grpc.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/grpc_asyncio.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/rest.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/rest_base.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/services/cloud_location_finder/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/types/__init__.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/types/cloud_location.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/types/cloud_location.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/types/service.py
+++ b/packages/google-cloud-locationfinder/google/cloud/locationfinder_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_get_cloud_location_async.py
+++ b/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_get_cloud_location_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_get_cloud_location_sync.py
+++ b/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_get_cloud_location_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_list_cloud_locations_async.py
+++ b/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_list_cloud_locations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_list_cloud_locations_sync.py
+++ b/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_list_cloud_locations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_search_cloud_locations_async.py
+++ b/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_search_cloud_locations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_search_cloud_locations_sync.py
+++ b/packages/google-cloud-locationfinder/samples/generated_samples/cloudlocationfinder_v1_generated_cloud_location_finder_search_cloud_locations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/tests/__init__.py
+++ b/packages/google-cloud-locationfinder/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/tests/unit/__init__.py
+++ b/packages/google-cloud-locationfinder/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-locationfinder/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-locationfinder/tests/unit/gapic/locationfinder_v1/__init__.py
+++ b/packages/google-cloud-locationfinder/tests/unit/gapic/locationfinder_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/.flake8
+++ b/packages/google-cloud-logging/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/MANIFEST.in
+++ b/packages/google-cloud-logging/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging/gapic_version.py
+++ b/packages/google-cloud-logging/google/cloud/logging/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/gapic_version.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/pagers.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/pagers.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/pagers.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/types/__init__.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/types/log_entry.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/types/log_entry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/types/logging.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/types/logging.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/types/logging_config.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/types/logging_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/types/logging_metrics.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/types/logging_metrics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_bucket_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_bucket_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_exclusion_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_exclusion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_exclusion_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_exclusion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_sink_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_sink_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_sink_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_sink_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_view_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_view_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_undelete_bucket_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_undelete_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_undelete_bucket_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_undelete_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_delete_log_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_delete_log_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_delete_log_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_delete_log_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_delete_log_metric_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_delete_log_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_delete_log_metric_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_delete_log_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_async.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_sync.py
+++ b/packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/tests/__init__.py
+++ b/packages/google-cloud-logging/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/tests/unit/__init__.py
+++ b/packages/google-cloud-logging/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-logging/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-logging/tests/unit/gapic/logging_v2/__init__.py
+++ b/packages/google-cloud-logging/tests/unit/gapic/logging_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/.flake8
+++ b/packages/google-cloud-lustre/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/MANIFEST.in
+++ b/packages/google-cloud-lustre/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre/__init__.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre/gapic_version.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/gapic_version.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/__init__.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/__init__.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/client.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/pagers.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/__init__.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/base.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/grpc.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/grpc_asyncio.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/rest.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/rest_base.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/services/lustre/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/types/__init__.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/types/instance.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/types/lustre.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/types/lustre.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/google/cloud/lustre_v1/types/transfer.py
+++ b/packages/google-cloud-lustre/google/cloud/lustre_v1/types/transfer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_create_instance_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_delete_instance_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_export_data_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_get_instance_async.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_get_instance_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_import_data_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_list_instances_async.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_list_instances_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_update_instance_sync.py
+++ b/packages/google-cloud-lustre/samples/generated_samples/lustre_v1_generated_lustre_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/tests/__init__.py
+++ b/packages/google-cloud-lustre/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/tests/unit/__init__.py
+++ b/packages/google-cloud-lustre/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-lustre/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-lustre/tests/unit/gapic/lustre_v1/__init__.py
+++ b/packages/google-cloud-lustre/tests/unit/gapic/lustre_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/.flake8
+++ b/packages/google-cloud-maintenance-api/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/MANIFEST.in
+++ b/packages/google-cloud-maintenance-api/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api/gapic_version.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/gapic_version.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/async_client.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/client.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/pagers.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/base.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/grpc.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/grpc_asyncio.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/rest.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/rest_base.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/services/maintenance/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/types/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/types/maintenance_service.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1/types/maintenance_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/gapic_version.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/async_client.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/client.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/pagers.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/base.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/grpc.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/grpc_asyncio.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/rest.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/rest_base.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/services/maintenance/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/types/__init__.py
+++ b/packages/google-cloud-maintenance-api/google/cloud/maintenance_api_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_get_resource_maintenance_async.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_get_resource_maintenance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_get_resource_maintenance_sync.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_get_resource_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_list_resource_maintenances_async.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_list_resource_maintenances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_list_resource_maintenances_sync.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_list_resource_maintenances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_summarize_maintenances_async.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_summarize_maintenances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_summarize_maintenances_sync.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1_generated_maintenance_summarize_maintenances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_get_resource_maintenance_async.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_get_resource_maintenance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_get_resource_maintenance_sync.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_get_resource_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_list_resource_maintenances_async.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_list_resource_maintenances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_list_resource_maintenances_sync.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_list_resource_maintenances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_summarize_maintenances_async.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_summarize_maintenances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_summarize_maintenances_sync.py
+++ b/packages/google-cloud-maintenance-api/samples/generated_samples/maintenance_v1beta_generated_maintenance_summarize_maintenances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/tests/__init__.py
+++ b/packages/google-cloud-maintenance-api/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/tests/unit/__init__.py
+++ b/packages/google-cloud-maintenance-api/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-maintenance-api/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/tests/unit/gapic/maintenance_api_v1/__init__.py
+++ b/packages/google-cloud-maintenance-api/tests/unit/gapic/maintenance_api_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-maintenance-api/tests/unit/gapic/maintenance_api_v1beta/__init__.py
+++ b/packages/google-cloud-maintenance-api/tests/unit/gapic/maintenance_api_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/.flake8
+++ b/packages/google-cloud-managed-identities/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/MANIFEST.in
+++ b/packages/google-cloud-managed-identities/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities/__init__.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities/gapic_version.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/gapic_version.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/__init__.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/__init__.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/client.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/pagers.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/__init__.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/base.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/grpc.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/services/managed_identities_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/types/__init__.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/types/managed_identities_service.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/types/managed_identities_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/types/resource.py
+++ b/packages/google-cloud-managed-identities/google/cloud/managedidentities_v1/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_attach_trust_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_attach_trust_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_create_microsoft_ad_domain_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_create_microsoft_ad_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_delete_domain_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_delete_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_detach_trust_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_detach_trust_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_get_domain_async.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_get_domain_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_get_domain_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_get_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_list_domains_async.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_list_domains_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_list_domains_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_list_domains_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_reconfigure_trust_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_reconfigure_trust_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_reset_admin_password_async.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_reset_admin_password_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_reset_admin_password_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_reset_admin_password_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_update_domain_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_update_domain_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_validate_trust_sync.py
+++ b/packages/google-cloud-managed-identities/samples/generated_samples/managedidentities_v1_generated_managed_identities_service_validate_trust_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/tests/__init__.py
+++ b/packages/google-cloud-managed-identities/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/tests/unit/__init__.py
+++ b/packages/google-cloud-managed-identities/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-managed-identities/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managed-identities/tests/unit/gapic/managedidentities_v1/__init__.py
+++ b/packages/google-cloud-managed-identities/tests/unit/gapic/managedidentities_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/.flake8
+++ b/packages/google-cloud-managedkafka-schemaregistry/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/MANIFEST.in
+++ b/packages/google-cloud-managedkafka-schemaregistry/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry/gapic_version.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/gapic_version.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/async_client.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/client.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/base.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/grpc.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/grpc_asyncio.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/rest.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/rest_base.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/types/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/types/schema_registry.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/types/schema_registry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/types/schema_registry_resources.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/types/schema_registry_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_check_compatibility_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_check_compatibility_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_check_compatibility_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_check_compatibility_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_schema_registry_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_schema_registry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_schema_registry_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_schema_registry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_version_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_version_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_create_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_config_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_config_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_mode_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_mode_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_mode_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_registry_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_registry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_registry_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_schema_registry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_subject_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_subject_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_subject_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_subject_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_version_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_version_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_delete_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_context_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_context_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_context_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_context_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_version_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_version_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_raw_schema_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_config_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_config_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_mode_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_mode_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_mode_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_registry_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_registry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_registry_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_registry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_version_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_version_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_get_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_contexts_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_contexts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_contexts_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_contexts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_referenced_schemas_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_referenced_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_referenced_schemas_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_referenced_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_registries_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_registries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_registries_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_registries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_types_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_types_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_versions_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_versions_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_schema_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_by_schema_id_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_by_schema_id_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_by_schema_id_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_by_schema_id_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_subjects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_versions_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_versions_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_list_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_lookup_version_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_lookup_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_lookup_version_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_lookup_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_config_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_config_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_mode_async.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_mode_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_mode_sync.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/samples/generated_samples/managedkafka_v1_generated_managed_schema_registry_update_schema_mode_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/tests/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/tests/unit/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka-schemaregistry/tests/unit/gapic/managedkafka_schemaregistry_v1/__init__.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/tests/unit/gapic/managedkafka_schemaregistry_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/.flake8
+++ b/packages/google-cloud-managedkafka/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/MANIFEST.in
+++ b/packages/google-cloud-managedkafka/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka/gapic_version.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/gapic_version.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/client.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/pagers.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/base.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/grpc.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/grpc_asyncio.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/rest.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/rest_base.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/client.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/pagers.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/base.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/grpc.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/grpc_asyncio.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/rest.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/rest_base.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka_connect/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/managed_kafka.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/managed_kafka.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/managed_kafka_connect.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/managed_kafka_connect.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/resources.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_add_acl_entry_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_add_acl_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_add_acl_entry_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_add_acl_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_create_connect_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_create_connect_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_create_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_create_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_create_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_create_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_delete_connect_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_delete_connect_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_delete_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_delete_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_delete_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_delete_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connect_cluster_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connect_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connect_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connect_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_get_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connect_clusters_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connect_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connect_clusters_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connect_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connectors_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connectors_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_list_connectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_pause_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_pause_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_pause_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_pause_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_restart_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_restart_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_restart_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_restart_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_resume_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_resume_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_resume_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_resume_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_stop_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_stop_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_stop_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_stop_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_update_connect_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_update_connect_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_update_connector_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_update_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_update_connector_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_connect_update_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_acl_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_acl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_acl_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_acl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_topic_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_topic_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_create_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_acl_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_acl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_acl_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_acl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_consumer_group_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_consumer_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_consumer_group_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_consumer_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_topic_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_topic_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_delete_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_acl_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_acl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_acl_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_acl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_cluster_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_consumer_group_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_consumer_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_consumer_group_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_consumer_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_topic_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_topic_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_get_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_acls_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_acls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_acls_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_acls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_clusters_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_clusters_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_consumer_groups_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_consumer_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_consumer_groups_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_consumer_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_topics_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_topics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_topics_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_list_topics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_remove_acl_entry_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_remove_acl_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_remove_acl_entry_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_remove_acl_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_acl_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_acl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_acl_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_acl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_cluster_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_consumer_group_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_consumer_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_consumer_group_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_consumer_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_topic_async.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_topic_sync.py
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/managedkafka_v1_generated_managed_kafka_update_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/tests/__init__.py
+++ b/packages/google-cloud-managedkafka/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/tests/unit/__init__.py
+++ b/packages/google-cloud-managedkafka/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-managedkafka/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-managedkafka/tests/unit/gapic/managedkafka_v1/__init__.py
+++ b/packages/google-cloud-managedkafka/tests/unit/gapic/managedkafka_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/.flake8
+++ b/packages/google-cloud-media-translation/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/MANIFEST.in
+++ b/packages/google-cloud-media-translation/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation/__init__.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation/gapic_version.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/gapic_version.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/__init__.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/__init__.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/async_client.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/client.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/__init__.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/base.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/grpc.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/services/speech_translation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/types/__init__.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/types/media_translation.py
+++ b/packages/google-cloud-media-translation/google/cloud/mediatranslation_v1beta1/types/media_translation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/samples/generated_samples/mediatranslation_v1beta1_generated_speech_translation_service_streaming_translate_speech_async.py
+++ b/packages/google-cloud-media-translation/samples/generated_samples/mediatranslation_v1beta1_generated_speech_translation_service_streaming_translate_speech_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/samples/generated_samples/mediatranslation_v1beta1_generated_speech_translation_service_streaming_translate_speech_sync.py
+++ b/packages/google-cloud-media-translation/samples/generated_samples/mediatranslation_v1beta1_generated_speech_translation_service_streaming_translate_speech_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/tests/__init__.py
+++ b/packages/google-cloud-media-translation/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/tests/unit/__init__.py
+++ b/packages/google-cloud-media-translation/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-media-translation/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-media-translation/tests/unit/gapic/mediatranslation_v1beta1/__init__.py
+++ b/packages/google-cloud-media-translation/tests/unit/gapic/mediatranslation_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/.flake8
+++ b/packages/google-cloud-memcache/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/MANIFEST.in
+++ b/packages/google-cloud-memcache/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache/gapic_version.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/gapic_version.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/client.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/pagers.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/base.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/grpc.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/grpc_asyncio.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/rest.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/rest_base.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/services/cloud_memcache/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/types/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1/types/cloud_memcache.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1/types/cloud_memcache.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/gapic_version.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/client.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/pagers.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/base.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/grpc.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/grpc_asyncio.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/rest.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/rest_base.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/services/cloud_memcache/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/types/__init__.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/types/cloud_memcache.py
+++ b/packages/google-cloud-memcache/google/cloud/memcache_v1beta2/types/cloud_memcache.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_apply_parameters_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_apply_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_create_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_delete_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_get_instance_async.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_get_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_list_instances_async.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_list_instances_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_reschedule_maintenance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_reschedule_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_update_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_update_parameters_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1_generated_cloud_memcache_update_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_apply_parameters_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_apply_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_apply_software_update_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_apply_software_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_create_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_delete_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_get_instance_async.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_get_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_list_instances_async.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_list_instances_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_reschedule_maintenance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_reschedule_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_update_instance_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_update_parameters_sync.py
+++ b/packages/google-cloud-memcache/samples/generated_samples/memcache_v1beta2_generated_cloud_memcache_update_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/tests/__init__.py
+++ b/packages/google-cloud-memcache/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/tests/unit/__init__.py
+++ b/packages/google-cloud-memcache/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-memcache/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/tests/unit/gapic/memcache_v1/__init__.py
+++ b/packages/google-cloud-memcache/tests/unit/gapic/memcache_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memcache/tests/unit/gapic/memcache_v1beta2/__init__.py
+++ b/packages/google-cloud-memcache/tests/unit/gapic/memcache_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/.flake8
+++ b/packages/google-cloud-memorystore/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/MANIFEST.in
+++ b/packages/google-cloud-memorystore/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore/gapic_version.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/gapic_version.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/client.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/pagers.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/base.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/grpc.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/rest.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/rest_base.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/services/memorystore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/types/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1/types/memorystore.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1/types/memorystore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/gapic_version.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/client.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/pagers.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/base.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/grpc.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/rest.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/rest_base.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/services/memorystore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/types/__init__.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/types/memorystore.py
+++ b/packages/google-cloud-memorystore/google/cloud/memorystore_v1beta/types/memorystore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_backup_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_backup_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_create_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_delete_backup_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_delete_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_export_backup_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_export_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_collection_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_collection_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_certificate_authority_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_certificate_authority_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_instance_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_shared_regional_certificate_authority_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_shared_regional_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_shared_regional_certificate_authority_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_get_shared_regional_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backup_collections_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backup_collections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backup_collections_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backup_collections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backups_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backups_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_instances_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_instances_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_reschedule_maintenance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_reschedule_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_update_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1_generated_memorystore_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_create_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_delete_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_certificate_authority_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_certificate_authority_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_instance_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_shared_regional_certificate_authority_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_shared_regional_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_shared_regional_certificate_authority_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_get_shared_regional_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_list_instances_async.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_list_instances_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_update_instance_sync.py
+++ b/packages/google-cloud-memorystore/samples/generated_samples/memorystore_v1beta_generated_memorystore_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/tests/__init__.py
+++ b/packages/google-cloud-memorystore/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/tests/unit/__init__.py
+++ b/packages/google-cloud-memorystore/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-memorystore/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/tests/unit/gapic/memorystore_v1/__init__.py
+++ b/packages/google-cloud-memorystore/tests/unit/gapic/memorystore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-memorystore/tests/unit/gapic/memorystore_v1beta/__init__.py
+++ b/packages/google-cloud-memorystore/tests/unit/gapic/memorystore_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/.flake8
+++ b/packages/google-cloud-migrationcenter/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/MANIFEST.in
+++ b/packages/google-cloud-migrationcenter/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter/__init__.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter/gapic_version.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/gapic_version.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/__init__.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/__init__.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/client.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/pagers.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/__init__.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/base.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/grpc.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/grpc_asyncio.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/rest.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/rest_base.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/services/migration_center/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/types/__init__.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/types/migrationcenter.py
+++ b/packages/google-cloud-migrationcenter/google/cloud/migrationcenter_v1/types/migrationcenter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_add_assets_to_group_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_add_assets_to_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_aggregate_assets_values_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_aggregate_assets_values_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_aggregate_assets_values_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_aggregate_assets_values_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_delete_assets_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_delete_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_delete_assets_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_delete_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_update_assets_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_update_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_update_assets_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_batch_update_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_group_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_import_data_file_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_import_data_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_import_job_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_preference_set_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_preference_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_report_config_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_report_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_source_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_create_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_asset_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_asset_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_group_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_import_data_file_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_import_data_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_import_job_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_preference_set_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_preference_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_report_config_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_report_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_source_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_delete_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_asset_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_asset_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_error_frame_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_error_frame_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_error_frame_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_error_frame_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_group_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_group_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_data_file_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_data_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_data_file_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_data_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_job_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_job_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_preference_set_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_preference_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_preference_set_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_preference_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_config_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_config_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_settings_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_settings_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_source_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_source_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_get_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_assets_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_assets_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_error_frames_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_error_frames_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_error_frames_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_error_frames_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_groups_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_groups_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_data_files_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_data_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_data_files_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_data_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_jobs_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_jobs_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_import_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_preference_sets_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_preference_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_preference_sets_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_preference_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_report_configs_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_report_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_report_configs_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_report_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_reports_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_reports_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_sources_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_sources_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_list_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_remove_assets_from_group_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_remove_assets_from_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_report_asset_frames_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_report_asset_frames_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_report_asset_frames_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_report_asset_frames_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_run_import_job_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_run_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_asset_async.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_asset_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_group_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_import_job_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_preference_set_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_preference_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_settings_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_source_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_update_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_validate_import_job_sync.py
+++ b/packages/google-cloud-migrationcenter/samples/generated_samples/migrationcenter_v1_generated_migration_center_validate_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/tests/__init__.py
+++ b/packages/google-cloud-migrationcenter/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/tests/unit/__init__.py
+++ b/packages/google-cloud-migrationcenter/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-migrationcenter/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-migrationcenter/tests/unit/gapic/migrationcenter_v1/__init__.py
+++ b/packages/google-cloud-migrationcenter/tests/unit/gapic/migrationcenter_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/.flake8
+++ b/packages/google-cloud-modelarmor/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/MANIFEST.in
+++ b/packages/google-cloud-modelarmor/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor/gapic_version.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/gapic_version.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/async_client.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/client.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/pagers.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/base.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/grpc.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/grpc_asyncio.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/rest.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/rest_base.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/services/model_armor/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/types/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/types/service.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/gapic_version.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/async_client.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/client.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/pagers.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/base.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/grpc.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/grpc_asyncio.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/rest.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/rest_base.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/services/model_armor/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/types/__init__.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/types/service.py
+++ b/packages/google-cloud-modelarmor/google/cloud/modelarmor_v1beta/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_create_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_create_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_create_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_create_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_delete_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_delete_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_delete_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_delete_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_floor_setting_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_floor_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_floor_setting_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_floor_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_get_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_list_templates_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_list_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_list_templates_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_list_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_model_response_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_model_response_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_model_response_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_model_response_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_user_prompt_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_user_prompt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_user_prompt_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_sanitize_user_prompt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_floor_setting_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_floor_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_floor_setting_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_floor_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1_generated_model_armor_update_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_create_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_create_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_create_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_create_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_delete_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_delete_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_delete_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_delete_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_floor_setting_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_floor_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_floor_setting_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_floor_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_get_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_list_templates_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_list_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_list_templates_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_list_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_model_response_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_model_response_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_model_response_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_model_response_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_user_prompt_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_user_prompt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_user_prompt_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_sanitize_user_prompt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_model_response_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_model_response_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_model_response_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_model_response_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_user_prompt_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_user_prompt_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_user_prompt_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_stream_sanitize_user_prompt_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_floor_setting_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_floor_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_floor_setting_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_floor_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_template_async.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_template_sync.py
+++ b/packages/google-cloud-modelarmor/samples/generated_samples/modelarmor_v1beta_generated_model_armor_update_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/tests/__init__.py
+++ b/packages/google-cloud-modelarmor/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/tests/unit/__init__.py
+++ b/packages/google-cloud-modelarmor/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-modelarmor/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/tests/unit/gapic/modelarmor_v1/__init__.py
+++ b/packages/google-cloud-modelarmor/tests/unit/gapic/modelarmor_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-modelarmor/tests/unit/gapic/modelarmor_v1beta/__init__.py
+++ b/packages/google-cloud-modelarmor/tests/unit/gapic/modelarmor_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/.flake8
+++ b/packages/google-cloud-monitoring-dashboards/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/MANIFEST.in
+++ b/packages/google-cloud-monitoring-dashboards/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard/gapic_version.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/gapic_version.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/async_client.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/client.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/pagers.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/base.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/rest.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/rest_base.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/services/dashboards_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/alertchart.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/alertchart.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/collapsible_group.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/collapsible_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/common.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/dashboard.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/dashboard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/dashboard_filter.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/dashboard_filter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/dashboards_service.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/dashboards_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/drilldowns.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/drilldowns.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/error_reporting_panel.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/error_reporting_panel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/incident_list.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/incident_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/layouts.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/layouts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/logs_panel.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/logs_panel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/metrics.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/metrics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/piechart.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/piechart.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/scorecard.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/scorecard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/section_header.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/section_header.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/service.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/single_view_group.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/single_view_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/table.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/table.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/table_display_options.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/table_display_options.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/text.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/text.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/widget.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/widget.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/xychart.py
+++ b/packages/google-cloud-monitoring-dashboards/google/cloud/monitoring_dashboard_v1/types/xychart.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_create_dashboard_async.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_create_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_create_dashboard_sync.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_create_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_delete_dashboard_async.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_delete_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_delete_dashboard_sync.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_delete_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_get_dashboard_async.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_get_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_get_dashboard_sync.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_get_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_list_dashboards_async.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_list_dashboards_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_list_dashboards_sync.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_list_dashboards_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_update_dashboard_async.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_update_dashboard_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_update_dashboard_sync.py
+++ b/packages/google-cloud-monitoring-dashboards/samples/generated_samples/monitoring_v1_generated_dashboards_service_update_dashboard_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/tests/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/tests/unit/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-dashboards/tests/unit/gapic/monitoring_dashboard_v1/__init__.py
+++ b/packages/google-cloud-monitoring-dashboards/tests/unit/gapic/monitoring_dashboard_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/.flake8
+++ b/packages/google-cloud-monitoring-metrics-scopes/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/MANIFEST.in
+++ b/packages/google-cloud-monitoring-metrics-scopes/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope/gapic_version.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/gapic_version.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/client.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/base.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/grpc.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/types/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/types/metrics_scope.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/types/metrics_scope.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/types/metrics_scopes.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/types/metrics_scopes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_create_monitored_project_sync.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_create_monitored_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_delete_monitored_project_sync.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_delete_monitored_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_get_metrics_scope_async.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_get_metrics_scope_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_get_metrics_scope_sync.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_get_metrics_scope_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_list_metrics_scopes_by_monitored_project_async.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_list_metrics_scopes_by_monitored_project_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_list_metrics_scopes_by_monitored_project_sync.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/samples/generated_samples/monitoring_v1_generated_metrics_scopes_list_metrics_scopes_by_monitored_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/tests/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/tests/unit/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring-metrics-scopes/tests/unit/gapic/monitoring_metrics_scope_v1/__init__.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/tests/unit/gapic/monitoring_metrics_scope_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/.flake8
+++ b/packages/google-cloud-monitoring/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/MANIFEST.in
+++ b/packages/google-cloud-monitoring/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring/gapic_version.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/gapic_version.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/alert_policy_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/group_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/metric_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/notification_channel_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/query_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/service_monitoring_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/snooze_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/async_client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/client.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/pagers.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/base.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/grpc.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/services/uptime_check_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/__init__.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/alert.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/alert.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/alert_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/alert_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/common.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/dropped_labels.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/dropped_labels.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/group.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/group_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/group_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/metric.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/metric.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/mutation_record.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/mutation_record.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/notification.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/notification.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/notification_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/notification_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/query_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/query_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/service_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/service_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/snooze.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/snooze.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/snooze_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/snooze_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/span_context.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/span_context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/uptime.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/uptime.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/uptime_service.py
+++ b/packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/uptime_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_create_alert_policy_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_create_alert_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_create_alert_policy_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_create_alert_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_delete_alert_policy_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_delete_alert_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_delete_alert_policy_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_delete_alert_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_get_alert_policy_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_get_alert_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_get_alert_policy_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_get_alert_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_list_alert_policies_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_list_alert_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_list_alert_policies_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_list_alert_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_update_alert_policy_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_update_alert_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_update_alert_policy_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_alert_policy_service_update_alert_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_create_group_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_create_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_create_group_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_create_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_delete_group_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_delete_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_delete_group_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_delete_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_get_group_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_get_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_get_group_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_get_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_group_members_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_group_members_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_group_members_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_group_members_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_groups_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_groups_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_list_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_update_group_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_update_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_update_group_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_group_service_update_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_metric_descriptor_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_metric_descriptor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_metric_descriptor_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_metric_descriptor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_service_time_series_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_service_time_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_service_time_series_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_service_time_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_time_series_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_time_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_time_series_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_create_time_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_delete_metric_descriptor_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_delete_metric_descriptor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_delete_metric_descriptor_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_delete_metric_descriptor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_metric_descriptor_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_metric_descriptor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_metric_descriptor_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_metric_descriptor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_monitored_resource_descriptor_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_monitored_resource_descriptor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_monitored_resource_descriptor_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_get_monitored_resource_descriptor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_metric_descriptors_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_metric_descriptors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_metric_descriptors_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_metric_descriptors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_monitored_resource_descriptors_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_monitored_resource_descriptors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_monitored_resource_descriptors_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_monitored_resource_descriptors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_time_series_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_time_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_time_series_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_metric_service_list_time_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_create_notification_channel_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_create_notification_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_create_notification_channel_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_create_notification_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_delete_notification_channel_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_delete_notification_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_delete_notification_channel_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_delete_notification_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_descriptor_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_descriptor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_descriptor_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_descriptor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_verification_code_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_verification_code_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_verification_code_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_get_notification_channel_verification_code_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channel_descriptors_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channel_descriptors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channel_descriptors_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channel_descriptors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channels_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channels_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_list_notification_channels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_send_notification_channel_verification_code_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_send_notification_channel_verification_code_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_send_notification_channel_verification_code_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_send_notification_channel_verification_code_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_update_notification_channel_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_update_notification_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_update_notification_channel_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_update_notification_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_verify_notification_channel_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_verify_notification_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_verify_notification_channel_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_notification_channel_service_verify_notification_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_query_service_query_time_series_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_query_service_query_time_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_query_service_query_time_series_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_query_service_query_time_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_level_objective_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_level_objective_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_level_objective_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_level_objective_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_level_objective_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_level_objective_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_level_objective_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_level_objective_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_level_objective_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_level_objective_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_level_objective_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_level_objective_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_service_level_objectives_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_service_level_objectives_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_service_level_objectives_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_service_level_objectives_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_services_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_services_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_level_objective_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_level_objective_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_level_objective_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_level_objective_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_service_monitoring_service_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_create_snooze_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_create_snooze_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_create_snooze_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_create_snooze_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_get_snooze_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_get_snooze_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_get_snooze_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_get_snooze_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_list_snoozes_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_list_snoozes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_list_snoozes_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_list_snoozes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_update_snooze_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_update_snooze_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_update_snooze_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_snooze_service_update_snooze_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_create_uptime_check_config_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_create_uptime_check_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_create_uptime_check_config_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_create_uptime_check_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_delete_uptime_check_config_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_delete_uptime_check_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_delete_uptime_check_config_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_delete_uptime_check_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_get_uptime_check_config_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_get_uptime_check_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_get_uptime_check_config_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_get_uptime_check_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_configs_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_configs_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_ips_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_ips_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_ips_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_list_uptime_check_ips_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_update_uptime_check_config_async.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_update_uptime_check_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_update_uptime_check_config_sync.py
+++ b/packages/google-cloud-monitoring/samples/generated_samples/monitoring_v3_generated_uptime_check_service_update_uptime_check_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/tests/__init__.py
+++ b/packages/google-cloud-monitoring/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/tests/unit/__init__.py
+++ b/packages/google-cloud-monitoring/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-monitoring/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-monitoring/tests/unit/gapic/monitoring_v3/__init__.py
+++ b/packages/google-cloud-monitoring/tests/unit/gapic/monitoring_v3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/.flake8
+++ b/packages/google-cloud-netapp/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/MANIFEST.in
+++ b/packages/google-cloud-netapp/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp/__init__.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp/gapic_version.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/gapic_version.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/__init__.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/__init__.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/client.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/pagers.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/__init__.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/base.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/grpc.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/grpc_asyncio.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/rest.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/rest_base.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/services/net_app/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/__init__.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/active_directory.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/active_directory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/backup.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/backup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/backup_policy.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/backup_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/backup_vault.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/backup_vault.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/cloud_netapp_service.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/cloud_netapp_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/common.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/host_group.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/host_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/kms.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/kms.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/ontap.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/ontap.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/quota_rule.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/quota_rule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/replication.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/replication.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/snapshot.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/snapshot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/storage_pool.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/storage_pool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/google/cloud/netapp_v1/types/volume.py
+++ b/packages/google-cloud-netapp/google/cloud/netapp_v1/types/volume.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_active_directory_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_active_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_backup_policy_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_backup_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_backup_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_backup_vault_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_host_group_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_host_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_kms_config_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_kms_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_quota_rule_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_quota_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_snapshot_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_storage_pool_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_storage_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_volume_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_create_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_active_directory_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_active_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_backup_policy_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_backup_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_backup_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_backup_vault_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_host_group_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_host_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_kms_config_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_kms_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_quota_rule_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_quota_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_snapshot_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_storage_pool_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_storage_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_volume_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_delete_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_encrypt_volumes_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_encrypt_volumes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_establish_peering_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_establish_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_establish_volume_peering_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_establish_volume_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_delete_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_delete_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_delete_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_delete_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_get_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_get_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_get_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_get_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_patch_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_patch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_patch_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_patch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_post_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_post_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_post_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_execute_ontap_post_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_active_directory_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_active_directory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_active_directory_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_active_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_policy_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_policy_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_vault_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_vault_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_vault_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_host_group_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_host_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_host_group_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_host_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_kms_config_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_kms_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_kms_config_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_kms_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_quota_rule_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_quota_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_quota_rule_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_quota_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_replication_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_replication_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_snapshot_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_snapshot_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_storage_pool_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_storage_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_storage_pool_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_storage_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_volume_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_volume_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_volume_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_get_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_active_directories_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_active_directories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_active_directories_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_active_directories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_policies_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_policies_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_vaults_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_vaults_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_vaults_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backup_vaults_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backups_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backups_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_host_groups_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_host_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_host_groups_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_host_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_kms_configs_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_kms_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_kms_configs_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_kms_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_quota_rules_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_quota_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_quota_rules_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_quota_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_replications_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_replications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_replications_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_replications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_snapshots_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_snapshots_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_snapshots_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_snapshots_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_storage_pools_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_storage_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_storage_pools_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_storage_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_volumes_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_volumes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_volumes_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_list_volumes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_restore_backup_files_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_restore_backup_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_resume_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_resume_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_reverse_replication_direction_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_reverse_replication_direction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_revert_volume_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_revert_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_stop_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_stop_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_switch_active_replica_zone_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_switch_active_replica_zone_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_sync_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_sync_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_active_directory_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_active_directory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_backup_policy_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_backup_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_backup_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_backup_vault_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_backup_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_host_group_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_host_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_kms_config_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_kms_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_quota_rule_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_quota_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_replication_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_replication_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_snapshot_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_storage_pool_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_storage_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_volume_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_update_volume_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_validate_directory_service_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_validate_directory_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_verify_kms_config_async.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_verify_kms_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_verify_kms_config_sync.py
+++ b/packages/google-cloud-netapp/samples/generated_samples/netapp_v1_generated_net_app_verify_kms_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/tests/__init__.py
+++ b/packages/google-cloud-netapp/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/tests/unit/__init__.py
+++ b/packages/google-cloud-netapp/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-netapp/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-netapp/tests/unit/gapic/netapp_v1/__init__.py
+++ b/packages/google-cloud-netapp/tests/unit/gapic/netapp_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/.flake8
+++ b/packages/google-cloud-network-connectivity/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/MANIFEST.in
+++ b/packages/google-cloud-network-connectivity/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity/gapic_version.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/gapic_version.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/cross_network_automation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/data_transfer_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/hub_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/internal_range_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/services/policy_based_routing_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/common.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/cross_network_automation.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/cross_network_automation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/data_transfer.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/data_transfer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/hub.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/hub.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/internal_range.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/internal_range.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/services/hub_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/types/common.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/types/hub.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1alpha1/types/hub.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/gapic_version.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/data_transfer_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/hub_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/policy_based_routing_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/client.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/pagers.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/base.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/grpc.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/services/transport_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/__init__.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/common.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/data_transfer.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/data_transfer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/hub.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/hub.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/policy_based_routing.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/policy_based_routing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/transport_manager.py
+++ b/packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1beta/types/transport_manager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_create_service_connection_map_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_create_service_connection_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_create_service_connection_policy_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_create_service_connection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_create_service_connection_token_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_create_service_connection_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_class_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_connection_map_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_connection_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_connection_policy_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_connection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_connection_token_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_delete_service_connection_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_class_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_class_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_map_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_map_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_policy_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_policy_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_token_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_token_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_get_service_connection_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_classes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_classes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_classes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_classes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_maps_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_maps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_maps_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_maps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_policies_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_policies_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_tokens_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_tokens_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_list_service_connection_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_update_service_class_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_update_service_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_update_service_connection_map_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_update_service_connection_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_update_service_connection_policy_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_cross_network_automation_service_update_service_connection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_create_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_create_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_create_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_create_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_delete_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_delete_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_delete_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_delete_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_destination_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_destination_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_config_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_destinations_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_destinations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_destinations_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_destinations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_configs_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_configs_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_update_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_update_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_update_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_data_transfer_service_update_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_accept_hub_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_accept_hub_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_accept_spoke_update_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_accept_spoke_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_create_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_create_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_create_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_create_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_delete_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_delete_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_delete_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_delete_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_group_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_group_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_hub_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_hub_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_table_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_table_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_route_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_spoke_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_spoke_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_get_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_groups_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_groups_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hub_spokes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hub_spokes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hub_spokes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hub_spokes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hubs_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hubs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hubs_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_hubs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_route_tables_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_route_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_route_tables_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_route_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_routes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_routes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_spokes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_spokes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_spokes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_list_spokes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_query_hub_status_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_query_hub_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_query_hub_status_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_query_hub_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_reject_hub_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_reject_hub_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_reject_spoke_update_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_reject_spoke_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_update_group_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_update_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_update_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_update_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_update_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_hub_service_update_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_create_internal_range_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_create_internal_range_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_delete_internal_range_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_delete_internal_range_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_get_internal_range_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_get_internal_range_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_get_internal_range_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_get_internal_range_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_list_internal_ranges_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_list_internal_ranges_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_list_internal_ranges_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_list_internal_ranges_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_update_internal_range_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_internal_range_service_update_internal_range_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_create_policy_based_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_create_policy_based_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_delete_policy_based_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_delete_policy_based_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_get_policy_based_route_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_get_policy_based_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_get_policy_based_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_get_policy_based_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_list_policy_based_routes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_list_policy_based_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_list_policy_based_routes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1_generated_policy_based_routing_service_list_policy_based_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_create_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_create_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_create_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_create_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_delete_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_delete_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_delete_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_delete_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_hub_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_hub_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_spoke_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_spoke_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_get_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_hubs_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_hubs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_hubs_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_hubs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_spokes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_spokes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_spokes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_list_spokes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_update_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_update_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_update_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1alpha1_generated_hub_service_update_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_create_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_create_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_create_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_create_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_delete_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_delete_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_delete_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_delete_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_destination_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_destination_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_config_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_get_multicloud_data_transfer_supported_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_destinations_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_destinations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_destinations_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_destinations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_configs_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_configs_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_list_multicloud_data_transfer_supported_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_update_destination_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_update_destination_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_update_multicloud_data_transfer_config_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_data_transfer_service_update_multicloud_data_transfer_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_accept_hub_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_accept_hub_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_accept_spoke_update_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_accept_spoke_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_create_gateway_advertised_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_create_gateway_advertised_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_create_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_create_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_create_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_create_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_delete_gateway_advertised_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_delete_gateway_advertised_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_delete_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_delete_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_delete_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_delete_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_gateway_advertised_route_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_gateway_advertised_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_gateway_advertised_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_gateway_advertised_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_group_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_group_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_hub_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_hub_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_table_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_table_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_route_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_spoke_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_spoke_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_get_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_gateway_advertised_routes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_gateway_advertised_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_gateway_advertised_routes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_gateway_advertised_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_groups_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_groups_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hub_spokes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hub_spokes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hub_spokes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hub_spokes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hubs_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hubs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hubs_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_hubs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_route_tables_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_route_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_route_tables_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_route_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_routes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_routes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_spokes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_spokes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_spokes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_list_spokes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_query_hub_status_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_query_hub_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_query_hub_status_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_query_hub_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_reject_hub_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_reject_hub_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_reject_spoke_update_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_reject_spoke_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_gateway_advertised_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_gateway_advertised_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_group_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_hub_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_hub_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_spoke_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_hub_service_update_spoke_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_create_policy_based_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_create_policy_based_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_delete_policy_based_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_delete_policy_based_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_get_policy_based_route_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_get_policy_based_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_get_policy_based_route_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_get_policy_based_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_list_policy_based_routes_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_list_policy_based_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_list_policy_based_routes_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_policy_based_routing_service_list_policy_based_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_create_transport_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_create_transport_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_delete_transport_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_delete_transport_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_remote_transport_profile_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_remote_transport_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_remote_transport_profile_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_remote_transport_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_status_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_status_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_transport_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_transport_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_transport_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_get_transport_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_remote_transport_profiles_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_remote_transport_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_remote_transport_profiles_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_remote_transport_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_transports_async.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_transports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_transports_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_list_transports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_update_transport_sync.py
+++ b/packages/google-cloud-network-connectivity/samples/generated_samples/networkconnectivity_v1beta_generated_transport_manager_update_transport_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/tests/__init__.py
+++ b/packages/google-cloud-network-connectivity/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/tests/unit/__init__.py
+++ b/packages/google-cloud-network-connectivity/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-network-connectivity/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/tests/unit/gapic/networkconnectivity_v1/__init__.py
+++ b/packages/google-cloud-network-connectivity/tests/unit/gapic/networkconnectivity_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/tests/unit/gapic/networkconnectivity_v1alpha1/__init__.py
+++ b/packages/google-cloud-network-connectivity/tests/unit/gapic/networkconnectivity_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-connectivity/tests/unit/gapic/networkconnectivity_v1beta/__init__.py
+++ b/packages/google-cloud-network-connectivity/tests/unit/gapic/networkconnectivity_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/.flake8
+++ b/packages/google-cloud-network-management/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/MANIFEST.in
+++ b/packages/google-cloud-network-management/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management/gapic_version.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/gapic_version.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/client.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/pagers.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/base.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/grpc.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/rest.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/rest_base.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/organization_vpc_flow_logs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/client.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/pagers.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/base.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/grpc.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/rest.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/rest_base.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/reachability_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/client.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/pagers.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/base.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/grpc.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/rest.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/rest_base.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/services/vpc_flow_logs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/types/__init__.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/types/connectivity_test.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/types/connectivity_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/types/reachability.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/types/reachability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/types/trace.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/types/trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/types/vpc_flow_logs.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/types/vpc_flow_logs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/types/vpc_flow_logs_config.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/types/vpc_flow_logs_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_create_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_create_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_delete_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_delete_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_get_vpc_flow_logs_config_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_get_vpc_flow_logs_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_get_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_get_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_list_vpc_flow_logs_configs_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_list_vpc_flow_logs_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_list_vpc_flow_logs_configs_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_list_vpc_flow_logs_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_update_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_organization_vpc_flow_logs_service_update_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_create_connectivity_test_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_create_connectivity_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_delete_connectivity_test_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_delete_connectivity_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_get_connectivity_test_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_get_connectivity_test_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_get_connectivity_test_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_get_connectivity_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_list_connectivity_tests_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_list_connectivity_tests_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_list_connectivity_tests_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_list_connectivity_tests_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_rerun_connectivity_test_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_rerun_connectivity_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_update_connectivity_test_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_reachability_service_update_connectivity_test_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_create_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_create_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_delete_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_delete_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_get_vpc_flow_logs_config_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_get_vpc_flow_logs_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_get_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_get_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_list_vpc_flow_logs_configs_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_list_vpc_flow_logs_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_list_vpc_flow_logs_configs_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_list_vpc_flow_logs_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_query_org_vpc_flow_logs_configs_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_query_org_vpc_flow_logs_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_query_org_vpc_flow_logs_configs_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_query_org_vpc_flow_logs_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_show_effective_flow_logs_configs_async.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_show_effective_flow_logs_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_show_effective_flow_logs_configs_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_show_effective_flow_logs_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_update_vpc_flow_logs_config_sync.py
+++ b/packages/google-cloud-network-management/samples/generated_samples/networkmanagement_v1_generated_vpc_flow_logs_service_update_vpc_flow_logs_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/tests/__init__.py
+++ b/packages/google-cloud-network-management/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/tests/unit/__init__.py
+++ b/packages/google-cloud-network-management/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-network-management/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-management/tests/unit/gapic/network_management_v1/__init__.py
+++ b/packages/google-cloud-network-management/tests/unit/gapic/network_management_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/.flake8
+++ b/packages/google-cloud-network-security/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/MANIFEST.in
+++ b/packages/google-cloud-network-security/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security/gapic_version.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/gapic_version.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/address_group_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/async_client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/dns_threat_detector_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/firewall_activation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/intercept/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/mirroring/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/network_security/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_address_group_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/services/organization_security_profile_group_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/address_group.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/address_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/authorization_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/authorization_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/authz_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/authz_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/backend_authentication_config.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/backend_authentication_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/client_tls_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/client_tls_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/common.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/dns_threat_detector.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/dns_threat_detector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/firewall_activation.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/firewall_activation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/gateway_security_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/gateway_security_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/gateway_security_policy_rule.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/gateway_security_policy_rule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/intercept.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/intercept.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/mirroring.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/mirroring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/network_security.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/network_security.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_intercept.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_intercept.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_mirroring.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_mirroring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_service.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_threatprevention.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_threatprevention.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_urlfiltering.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/security_profile_group_urlfiltering.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/server_tls_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/server_tls_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/tls.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/tls.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/tls_inspection_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/tls_inspection_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1/types/url_list.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1/types/url_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/async_client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/dns_threat_detector_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/firewall_activation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/intercept/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/mirroring/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/network_security/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/organization_security_profile_group_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_gateway_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/services/sse_realm_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/authorization_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/authorization_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/authz_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/authz_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/backend_authentication_config.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/backend_authentication_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/client_tls_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/client_tls_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/common.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/dns_threat_detector.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/dns_threat_detector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/firewall_activation.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/firewall_activation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/gateway_security_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/gateway_security_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/gateway_security_policy_rule.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/gateway_security_policy_rule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/intercept.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/intercept.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/mirroring.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/mirroring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/network_security.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/network_security.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_intercept.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_intercept.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_mirroring.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_mirroring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_service.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_threatprevention.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_threatprevention.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_urlfiltering.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/security_profile_group_urlfiltering.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/server_tls_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/server_tls_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/sse_gateway.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/sse_gateway.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/sse_realm.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/sse_realm.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/tls.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/tls.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/tls_inspection_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/tls_inspection_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/url_list.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1alpha1/types/url_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/gapic_version.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/async_client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/dns_threat_detector_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/client.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/pagers.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/grpc.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/rest.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/rest_base.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/services/network_security/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/__init__.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/authorization_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/authorization_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/client_tls_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/client_tls_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/common.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/dns_threat_detector.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/dns_threat_detector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/network_security.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/network_security.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/server_tls_policy.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/server_tls_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/tls.py
+++ b/packages/google-cloud-network-security/google/cloud/network_security_v1beta1/types/tls.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_add_address_group_items_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_add_address_group_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_clone_address_group_items_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_clone_address_group_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_create_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_create_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_delete_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_delete_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_get_address_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_get_address_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_get_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_get_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_group_references_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_group_references_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_group_references_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_group_references_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_list_address_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_remove_address_group_items_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_remove_address_group_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_update_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_address_group_service_update_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_create_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_create_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_create_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_create_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_delete_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_delete_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_delete_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_delete_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_get_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_get_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_get_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_get_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_list_dns_threat_detectors_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_list_dns_threat_detectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_list_dns_threat_detectors_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_list_dns_threat_detectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_update_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_update_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_update_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_dns_threat_detector_service_update_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_create_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_create_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_create_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_create_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_delete_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_delete_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_delete_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_delete_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_association_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_get_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoint_associations_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoint_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoint_associations_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoint_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoints_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoints_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_list_firewall_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_update_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_update_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_update_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_firewall_activation_update_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_create_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_delete_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_association_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_get_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployment_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployment_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployment_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployment_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployments_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployments_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_group_associations_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_group_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_group_associations_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_group_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_list_intercept_endpoint_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_intercept_update_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_create_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_delete_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_association_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_get_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployment_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployment_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployment_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployment_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployments_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployments_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_group_associations_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_group_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_group_associations_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_group_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_list_mirroring_endpoint_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_mirroring_update_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_create_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_delete_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authorization_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authorization_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authz_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authz_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_backend_authentication_config_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_backend_authentication_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_client_tls_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_client_tls_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_rule_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_server_tls_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_server_tls_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_tls_inspection_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_tls_inspection_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_url_list_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_url_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_get_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authorization_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authorization_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authorization_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authorization_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authz_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authz_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authz_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_authz_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_backend_authentication_configs_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_backend_authentication_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_backend_authentication_configs_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_backend_authentication_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_client_tls_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_client_tls_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_client_tls_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_client_tls_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policy_rules_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policy_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policy_rules_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_gateway_security_policy_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_server_tls_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_server_tls_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_server_tls_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_server_tls_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_tls_inspection_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_tls_inspection_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_tls_inspection_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_tls_inspection_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_url_lists_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_url_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_url_lists_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_list_url_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_network_security_update_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_add_address_group_items_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_add_address_group_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_clone_address_group_items_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_clone_address_group_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_create_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_create_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_delete_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_delete_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_get_address_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_get_address_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_get_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_get_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_group_references_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_group_references_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_group_references_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_group_references_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_list_address_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_remove_address_group_items_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_remove_address_group_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_update_address_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_address_group_service_update_address_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_create_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_create_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_create_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_create_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_delete_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_delete_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_delete_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_delete_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_get_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profile_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profile_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profile_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profile_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profiles_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profiles_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_list_security_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_update_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_update_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_update_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1_generated_organization_security_profile_group_service_update_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_create_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_create_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_create_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_create_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_delete_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_delete_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_delete_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_delete_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_get_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_get_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_get_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_get_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_list_dns_threat_detectors_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_list_dns_threat_detectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_list_dns_threat_detectors_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_list_dns_threat_detectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_update_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_update_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_update_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_dns_threat_detector_service_update_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_create_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_create_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_create_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_create_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_delete_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_delete_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_delete_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_delete_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_association_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_get_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoint_associations_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoint_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoint_associations_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoint_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoints_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoints_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_list_firewall_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_update_firewall_endpoint_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_update_firewall_endpoint_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_update_firewall_endpoint_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_firewall_activation_update_firewall_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_create_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_delete_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_association_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_get_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployment_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployment_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployment_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployment_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployments_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployments_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_group_associations_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_group_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_group_associations_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_group_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_list_intercept_endpoint_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_intercept_update_intercept_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_create_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_delete_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_association_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_association_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_get_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployment_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployment_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployment_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployment_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployments_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployments_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_group_associations_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_group_associations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_group_associations_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_group_associations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_list_mirroring_endpoint_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_deployment_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_deployment_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_deployment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_endpoint_group_association_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_endpoint_group_association_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_endpoint_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_mirroring_update_mirroring_endpoint_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_create_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_delete_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authorization_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authorization_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authz_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authz_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_backend_authentication_config_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_backend_authentication_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_client_tls_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_client_tls_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_rule_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_server_tls_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_server_tls_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_tls_inspection_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_tls_inspection_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_url_list_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_url_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_get_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authorization_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authorization_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authorization_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authorization_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authz_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authz_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authz_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_authz_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_backend_authentication_configs_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_backend_authentication_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_backend_authentication_configs_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_backend_authentication_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_client_tls_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_client_tls_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_client_tls_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_client_tls_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policy_rules_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policy_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policy_rules_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_gateway_security_policy_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_server_tls_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_server_tls_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_server_tls_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_server_tls_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_tls_inspection_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_tls_inspection_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_tls_inspection_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_tls_inspection_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_url_lists_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_url_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_url_lists_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_list_url_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_authz_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_authz_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_backend_authentication_config_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_backend_authentication_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_gateway_security_policy_rule_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_gateway_security_policy_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_gateway_security_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_gateway_security_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_tls_inspection_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_tls_inspection_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_url_list_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_network_security_update_url_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_create_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_create_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_create_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_create_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_delete_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_delete_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_delete_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_delete_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_group_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_get_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profile_groups_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profile_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profile_groups_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profile_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profiles_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profiles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profiles_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_list_security_profiles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_update_security_profile_group_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_update_security_profile_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_update_security_profile_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_organization_security_profile_group_service_update_security_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_create_partner_sse_gateway_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_create_partner_sse_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_delete_partner_sse_gateway_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_delete_partner_sse_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_partner_sse_gateway_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_partner_sse_gateway_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_partner_sse_gateway_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_partner_sse_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_sse_gateway_reference_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_sse_gateway_reference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_sse_gateway_reference_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_get_sse_gateway_reference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_partner_sse_gateways_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_partner_sse_gateways_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_partner_sse_gateways_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_partner_sse_gateways_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_sse_gateway_references_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_sse_gateway_references_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_sse_gateway_references_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_list_sse_gateway_references_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_update_partner_sse_gateway_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_gateway_service_update_partner_sse_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_create_partner_sse_realm_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_create_partner_sse_realm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_create_sac_attachment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_create_sac_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_create_sac_realm_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_create_sac_realm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_delete_partner_sse_realm_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_delete_partner_sse_realm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_delete_sac_attachment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_delete_sac_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_delete_sac_realm_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_delete_sac_realm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_partner_sse_realm_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_partner_sse_realm_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_partner_sse_realm_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_partner_sse_realm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_attachment_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_attachment_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_realm_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_realm_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_realm_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_get_sac_realm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_partner_sse_realms_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_partner_sse_realms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_partner_sse_realms_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_partner_sse_realms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_attachments_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_attachments_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_realms_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_realms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_realms_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1alpha1_generated_sse_realm_service_list_sac_realms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_create_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_create_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_create_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_create_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_delete_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_delete_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_delete_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_delete_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_get_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_get_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_get_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_get_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_list_dns_threat_detectors_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_list_dns_threat_detectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_list_dns_threat_detectors_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_list_dns_threat_detectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_update_dns_threat_detector_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_update_dns_threat_detector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_update_dns_threat_detector_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_dns_threat_detector_service_update_dns_threat_detector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_create_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_create_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_create_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_create_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_create_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_create_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_delete_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_delete_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_delete_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_delete_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_delete_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_delete_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_authorization_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_authorization_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_client_tls_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_client_tls_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_server_tls_policy_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_server_tls_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_get_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_authorization_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_authorization_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_authorization_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_authorization_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_client_tls_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_client_tls_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_client_tls_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_client_tls_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_server_tls_policies_async.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_server_tls_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_server_tls_policies_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_list_server_tls_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_update_authorization_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_update_authorization_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_update_client_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_update_client_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_update_server_tls_policy_sync.py
+++ b/packages/google-cloud-network-security/samples/generated_samples/networksecurity_v1beta1_generated_network_security_update_server_tls_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/tests/__init__.py
+++ b/packages/google-cloud-network-security/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/tests/unit/__init__.py
+++ b/packages/google-cloud-network-security/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-network-security/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/tests/unit/gapic/network_security_v1/__init__.py
+++ b/packages/google-cloud-network-security/tests/unit/gapic/network_security_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/tests/unit/gapic/network_security_v1alpha1/__init__.py
+++ b/packages/google-cloud-network-security/tests/unit/gapic/network_security_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-security/tests/unit/gapic/network_security_v1beta1/__init__.py
+++ b/packages/google-cloud-network-security/tests/unit/gapic/network_security_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/.flake8
+++ b/packages/google-cloud-network-services/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/MANIFEST.in
+++ b/packages/google-cloud-network-services/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services/gapic_version.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/gapic_version.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/client.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/pagers.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/base.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/grpc.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/rest.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/rest_base.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/dep_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/client.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/pagers.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/base.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/grpc.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/grpc_asyncio.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/rest.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/rest_base.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/services/network_services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/__init__.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/common.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/dep.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/dep.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/endpoint_policy.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/endpoint_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/extensibility.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/extensibility.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/gateway.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/gateway.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/grpc_route.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/grpc_route.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/http_route.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/http_route.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/mesh.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/mesh.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/network_services.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/network_services.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/route_view.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/route_view.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/service_binding.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/service_binding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/tcp_route.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/tcp_route.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/tls_route.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/tls_route.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_authz_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_authz_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_lb_edge_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_lb_edge_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_lb_route_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_lb_route_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_lb_traffic_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_create_lb_traffic_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_authz_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_authz_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_lb_edge_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_lb_edge_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_lb_route_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_lb_route_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_lb_traffic_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_delete_lb_traffic_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_authz_extension_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_authz_extension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_authz_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_authz_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_edge_extension_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_edge_extension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_edge_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_edge_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_route_extension_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_route_extension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_route_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_route_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_traffic_extension_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_traffic_extension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_traffic_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_get_lb_traffic_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_authz_extensions_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_authz_extensions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_authz_extensions_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_authz_extensions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_edge_extensions_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_edge_extensions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_edge_extensions_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_edge_extensions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_route_extensions_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_route_extensions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_route_extensions_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_route_extensions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_traffic_extensions_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_traffic_extensions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_traffic_extensions_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_list_lb_traffic_extensions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_authz_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_authz_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_lb_edge_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_lb_edge_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_lb_route_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_lb_route_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_lb_traffic_extension_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_dep_service_update_lb_traffic_extension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_endpoint_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_endpoint_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_gateway_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_grpc_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_grpc_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_http_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_http_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_mesh_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_mesh_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_service_binding_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_service_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_service_lb_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_service_lb_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_tcp_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_tcp_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_tls_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_tls_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_wasm_plugin_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_wasm_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_wasm_plugin_version_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_create_wasm_plugin_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_endpoint_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_endpoint_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_gateway_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_grpc_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_grpc_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_http_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_http_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_mesh_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_mesh_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_service_binding_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_service_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_service_lb_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_service_lb_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_tcp_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_tcp_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_tls_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_tls_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_wasm_plugin_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_wasm_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_wasm_plugin_version_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_delete_wasm_plugin_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_endpoint_policy_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_endpoint_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_endpoint_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_endpoint_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_route_view_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_route_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_route_view_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_route_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_grpc_route_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_grpc_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_grpc_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_grpc_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_http_route_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_http_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_http_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_http_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_route_view_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_route_view_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_route_view_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_route_view_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_mesh_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_binding_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_binding_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_lb_policy_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_lb_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_lb_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_service_lb_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tcp_route_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tcp_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tcp_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tcp_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tls_route_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tls_route_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tls_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_tls_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_version_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_version_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_get_wasm_plugin_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_endpoint_policies_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_endpoint_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_endpoint_policies_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_endpoint_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateway_route_views_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateway_route_views_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateway_route_views_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateway_route_views_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateways_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateways_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateways_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_gateways_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_grpc_routes_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_grpc_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_grpc_routes_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_grpc_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_http_routes_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_http_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_http_routes_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_http_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_mesh_route_views_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_mesh_route_views_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_mesh_route_views_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_mesh_route_views_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_meshes_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_meshes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_meshes_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_meshes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_bindings_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_bindings_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_lb_policies_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_lb_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_lb_policies_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_service_lb_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tcp_routes_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tcp_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tcp_routes_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tcp_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tls_routes_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tls_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tls_routes_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_tls_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugin_versions_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugin_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugin_versions_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugin_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugins_async.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugins_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugins_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_list_wasm_plugins_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_endpoint_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_endpoint_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_gateway_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_gateway_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_grpc_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_grpc_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_http_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_http_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_mesh_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_mesh_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_service_binding_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_service_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_service_lb_policy_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_service_lb_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_tcp_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_tcp_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_tls_route_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_tls_route_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_wasm_plugin_sync.py
+++ b/packages/google-cloud-network-services/samples/generated_samples/networkservices_v1_generated_network_services_update_wasm_plugin_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/tests/__init__.py
+++ b/packages/google-cloud-network-services/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/tests/unit/__init__.py
+++ b/packages/google-cloud-network-services/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-network-services/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-network-services/tests/unit/gapic/network_services_v1/__init__.py
+++ b/packages/google-cloud-network-services/tests/unit/gapic/network_services_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/.flake8
+++ b/packages/google-cloud-notebooks/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/MANIFEST.in
+++ b/packages/google-cloud-notebooks/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks/gapic_version.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/gapic_version.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/client.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/pagers.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/base.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/grpc.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/managed_notebook_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/client.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/pagers.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/base.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/grpc.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/services/notebook_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/diagnostic_config.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/diagnostic_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/environment.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/environment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/event.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/execution.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/execution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/instance.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/instance_config.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/instance_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/managed_service.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/managed_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/runtime.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/runtime.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/schedule.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/schedule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/service.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/gapic_version.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/client.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/pagers.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/base.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/grpc.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/rest.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/rest_base.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/services/notebook_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/environment.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/environment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/instance.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/service.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/gapic_version.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/client.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/pagers.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/base.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/grpc.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/rest.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/rest_base.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/services/notebook_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/__init__.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/diagnostic_config.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/diagnostic_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/event.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/gce_setup.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/gce_setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/instance.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/service.py
+++ b/packages/google-cloud-notebooks/google/cloud/notebooks_v2/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_create_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_create_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_delete_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_delete_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_diagnose_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_diagnose_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_get_runtime_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_get_runtime_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_get_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_get_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_list_runtimes_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_list_runtimes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_list_runtimes_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_list_runtimes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_refresh_runtime_token_internal_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_refresh_runtime_token_internal_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_refresh_runtime_token_internal_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_refresh_runtime_token_internal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_report_runtime_event_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_report_runtime_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_reset_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_reset_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_start_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_start_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_stop_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_stop_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_switch_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_switch_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_update_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_update_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_upgrade_runtime_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_managed_notebook_service_upgrade_runtime_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_environment_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_execution_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_schedule_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_create_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_environment_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_execution_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_schedule_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_delete_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_diagnose_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_diagnose_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_environment_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_environment_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_execution_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_execution_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_health_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_health_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_health_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_health_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_schedule_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_schedule_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_get_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_is_instance_upgradeable_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_is_instance_upgradeable_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_is_instance_upgradeable_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_is_instance_upgradeable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_environments_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_environments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_environments_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_environments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_executions_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_executions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_executions_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_executions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_instances_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_instances_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_schedules_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_schedules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_schedules_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_list_schedules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_register_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_register_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_report_instance_info_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_report_instance_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_reset_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_reset_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_rollback_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_rollback_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_set_instance_accelerator_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_set_instance_accelerator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_set_instance_labels_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_set_instance_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_set_instance_machine_type_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_set_instance_machine_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_start_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_start_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_stop_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_stop_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_trigger_schedule_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_trigger_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_instance_config_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_instance_metadata_items_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_instance_metadata_items_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_instance_metadata_items_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_instance_metadata_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_shielded_instance_config_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_update_shielded_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_upgrade_instance_internal_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_upgrade_instance_internal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_upgrade_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1_generated_notebook_service_upgrade_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_create_environment_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_create_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_create_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_delete_environment_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_delete_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_delete_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_environment_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_environment_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_instance_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_is_instance_upgradeable_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_is_instance_upgradeable_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_is_instance_upgradeable_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_is_instance_upgradeable_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_environments_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_environments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_environments_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_environments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_instances_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_instances_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_register_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_register_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_report_instance_info_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_report_instance_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_reset_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_reset_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_set_instance_accelerator_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_set_instance_accelerator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_set_instance_labels_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_set_instance_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_set_instance_machine_type_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_set_instance_machine_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_start_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_start_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_stop_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_stop_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_upgrade_instance_internal_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_upgrade_instance_internal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_upgrade_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v1beta1_generated_notebook_service_upgrade_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_check_instance_upgradability_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_check_instance_upgradability_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_check_instance_upgradability_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_check_instance_upgradability_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_create_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_delete_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_diagnose_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_diagnose_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_get_instance_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_get_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_list_instances_async.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_list_instances_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_reset_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_reset_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_rollback_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_rollback_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_start_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_start_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_stop_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_stop_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_update_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_upgrade_instance_sync.py
+++ b/packages/google-cloud-notebooks/samples/generated_samples/notebooks_v2_generated_notebook_service_upgrade_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/tests/__init__.py
+++ b/packages/google-cloud-notebooks/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/tests/unit/__init__.py
+++ b/packages/google-cloud-notebooks/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-notebooks/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/tests/unit/gapic/notebooks_v1/__init__.py
+++ b/packages/google-cloud-notebooks/tests/unit/gapic/notebooks_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/tests/unit/gapic/notebooks_v1beta1/__init__.py
+++ b/packages/google-cloud-notebooks/tests/unit/gapic/notebooks_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-notebooks/tests/unit/gapic/notebooks_v2/__init__.py
+++ b/packages/google-cloud-notebooks/tests/unit/gapic/notebooks_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/.flake8
+++ b/packages/google-cloud-optimization/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/MANIFEST.in
+++ b/packages/google-cloud-optimization/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization/__init__.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization/gapic_version.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/gapic_version.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/__init__.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/__init__.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/client.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/__init__.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/base.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/grpc.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/grpc_asyncio.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/rest.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/rest_base.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/types/__init__.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/types/async_model.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/types/async_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/types/fleet_routing.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/types/fleet_routing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/samples/generated_samples/cloudoptimization_v1_generated_fleet_routing_batch_optimize_tours_sync.py
+++ b/packages/google-cloud-optimization/samples/generated_samples/cloudoptimization_v1_generated_fleet_routing_batch_optimize_tours_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/samples/generated_samples/cloudoptimization_v1_generated_fleet_routing_optimize_tours_async.py
+++ b/packages/google-cloud-optimization/samples/generated_samples/cloudoptimization_v1_generated_fleet_routing_optimize_tours_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/samples/generated_samples/cloudoptimization_v1_generated_fleet_routing_optimize_tours_sync.py
+++ b/packages/google-cloud-optimization/samples/generated_samples/cloudoptimization_v1_generated_fleet_routing_optimize_tours_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/tests/__init__.py
+++ b/packages/google-cloud-optimization/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/tests/unit/__init__.py
+++ b/packages/google-cloud-optimization/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-optimization/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/tests/unit/gapic/optimization_v1/__init__.py
+++ b/packages/google-cloud-optimization/tests/unit/gapic/optimization_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/.flake8
+++ b/packages/google-cloud-oracledatabase/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/MANIFEST.in
+++ b/packages/google-cloud-oracledatabase/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase/__init__.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase/gapic_version.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/gapic_version.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/__init__.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/__init__.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/client.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/pagers.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/__init__.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/base.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/grpc.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/grpc_asyncio.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/rest.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/rest_base.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/__init__.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_database.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_database.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_database_character_set.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_database_character_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_db_backup.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_db_backup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_db_version.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_db_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/common.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/database.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/database.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/database_character_set.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/database_character_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_node.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_node.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_server.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_server.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_system.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_system.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_system_initial_storage_size.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_system_initial_storage_size.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_system_shape.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_system_shape.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_version.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/entitlement.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/entitlement.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/exadb_vm_cluster.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/exadb_vm_cluster.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/exascale_db_storage_vault.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/exascale_db_storage_vault.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/gi_version.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/gi_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/location_metadata.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/location_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/minor_version.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/minor_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/odb_network.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/odb_network.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/odb_subnet.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/odb_subnet.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/oracledatabase.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/oracledatabase.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/pluggable_database.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/pluggable_database.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/vm_cluster.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/vm_cluster.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_cloud_exadata_infrastructure_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_cloud_exadata_infrastructure_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_cloud_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_cloud_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_db_system_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_db_system_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_exadb_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_exadb_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_exascale_db_storage_vault_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_exascale_db_storage_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_odb_network_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_odb_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_odb_subnet_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_odb_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_cloud_exadata_infrastructure_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_cloud_exadata_infrastructure_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_cloud_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_cloud_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_db_system_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_db_system_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_exadb_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_exadb_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_exascale_db_storage_vault_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_exascale_db_storage_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_odb_network_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_odb_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_odb_subnet_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_odb_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_failover_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_failover_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_generate_autonomous_database_wallet_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_generate_autonomous_database_wallet_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_generate_autonomous_database_wallet_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_generate_autonomous_database_wallet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_autonomous_database_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_autonomous_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_exadata_infrastructure_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_exadata_infrastructure_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_exadata_infrastructure_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_exadata_infrastructure_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_vm_cluster_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_vm_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_database_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_db_system_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_db_system_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_db_system_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_db_system_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exadb_vm_cluster_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exadb_vm_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exadb_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exadb_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exascale_db_storage_vault_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exascale_db_storage_vault_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exascale_db_storage_vault_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exascale_db_storage_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_network_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_network_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_network_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_subnet_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_subnet_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_subnet_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_pluggable_database_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_pluggable_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_pluggable_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_pluggable_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_backups_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_backups_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_character_sets_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_character_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_character_sets_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_character_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_databases_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_databases_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_db_versions_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_db_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_db_versions_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_db_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_exadata_infrastructures_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_exadata_infrastructures_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_exadata_infrastructures_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_exadata_infrastructures_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_vm_clusters_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_vm_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_vm_clusters_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_vm_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_database_character_sets_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_database_character_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_database_character_sets_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_database_character_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_databases_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_databases_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_nodes_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_nodes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_nodes_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_servers_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_servers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_servers_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_servers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_initial_storage_sizes_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_initial_storage_sizes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_initial_storage_sizes_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_initial_storage_sizes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_shapes_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_shapes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_shapes_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_shapes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_systems_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_systems_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_systems_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_systems_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_versions_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_versions_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_entitlements_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_entitlements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_entitlements_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_entitlements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exadb_vm_clusters_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exadb_vm_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exadb_vm_clusters_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exadb_vm_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exascale_db_storage_vaults_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exascale_db_storage_vaults_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exascale_db_storage_vaults_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exascale_db_storage_vaults_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_gi_versions_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_gi_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_gi_versions_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_gi_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_minor_versions_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_minor_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_minor_versions_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_minor_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_networks_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_networks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_networks_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_networks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_subnets_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_subnets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_subnets_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_subnets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_pluggable_databases_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_pluggable_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_pluggable_databases_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_pluggable_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_remove_virtual_machine_exadb_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_remove_virtual_machine_exadb_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_restart_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_restart_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_restore_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_restore_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_start_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_start_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_stop_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_stop_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_switchover_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_switchover_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_update_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_update_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_update_exadb_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_update_exadb_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/tests/__init__.py
+++ b/packages/google-cloud-oracledatabase/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/tests/unit/__init__.py
+++ b/packages/google-cloud-oracledatabase/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-oracledatabase/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/tests/unit/gapic/oracledatabase_v1/__init__.py
+++ b/packages/google-cloud-oracledatabase/tests/unit/gapic/oracledatabase_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/.flake8
+++ b/packages/google-cloud-orchestration-airflow/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/MANIFEST.in
+++ b/packages/google-cloud-orchestration-airflow/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service/gapic_version.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/gapic_version.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/client.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/pagers.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/grpc.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/rest.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/rest_base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/async_client.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/client.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/pagers.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/grpc.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/rest.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/rest_base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/types/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/types/image_versions.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/types/image_versions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/types/operations.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/gapic_version.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/client.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/pagers.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/grpc.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/rest.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/rest_base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/async_client.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/client.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/pagers.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/grpc.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/rest.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/rest_base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/types/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/types/image_versions.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/types/image_versions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/types/operations.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_check_upgrade_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_check_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_database_failover_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_database_failover_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_execute_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_execute_airflow_command_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_execute_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_execute_airflow_command_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_fetch_database_properties_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_fetch_database_properties_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_fetch_database_properties_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_fetch_database_properties_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_environment_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_environments_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_environments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_environments_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_environments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_config_maps_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_config_maps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_config_maps_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_config_maps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_secrets_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_secrets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_secrets_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_secrets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_workloads_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_workloads_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_load_snapshot_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_load_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_poll_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_poll_airflow_command_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_poll_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_poll_airflow_command_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_save_snapshot_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_save_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_stop_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_stop_airflow_command_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_stop_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_stop_airflow_command_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_image_versions_list_image_versions_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_image_versions_list_image_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_image_versions_list_image_versions_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_image_versions_list_image_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_check_upgrade_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_check_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_database_failover_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_database_failover_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_execute_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_execute_airflow_command_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_execute_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_execute_airflow_command_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_fetch_database_properties_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_fetch_database_properties_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_fetch_database_properties_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_fetch_database_properties_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_environment_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_environments_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_environments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_environments_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_environments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_config_maps_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_config_maps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_config_maps_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_config_maps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_secrets_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_secrets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_secrets_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_secrets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_workloads_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_workloads_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_load_snapshot_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_load_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_poll_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_poll_airflow_command_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_poll_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_poll_airflow_command_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_restart_web_server_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_restart_web_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_save_snapshot_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_save_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_stop_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_stop_airflow_command_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_stop_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_stop_airflow_command_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_image_versions_list_image_versions_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_image_versions_list_image_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_image_versions_list_image_versions_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_image_versions_list_image_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/tests/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/tests/unit/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/tests/unit/gapic/service_v1/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/tests/unit/gapic/service_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/tests/unit/gapic/service_v1beta1/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/tests/unit/gapic/service_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/.flake8
+++ b/packages/google-cloud-org-policy/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/MANIFEST.in
+++ b/packages/google-cloud-org-policy/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy/__init__.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy/gapic_version.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/gapic_version.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/__init__.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/__init__.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/async_client.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/client.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/pagers.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/__init__.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/base.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/grpc.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/grpc_asyncio.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/rest.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/rest_base.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/types/__init__.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/types/constraint.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/types/constraint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/types/orgpolicy.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/types/orgpolicy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_custom_constraint_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_custom_constraint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_custom_constraint_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_custom_constraint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_policy_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_policy_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_custom_constraint_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_custom_constraint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_custom_constraint_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_custom_constraint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_policy_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_policy_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_custom_constraint_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_custom_constraint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_custom_constraint_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_custom_constraint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_effective_policy_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_effective_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_effective_policy_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_effective_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_policy_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_policy_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_constraints_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_constraints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_constraints_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_constraints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_custom_constraints_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_custom_constraints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_custom_constraints_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_custom_constraints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_policies_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_policies_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_custom_constraint_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_custom_constraint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_custom_constraint_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_custom_constraint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_policy_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_policy_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/tests/__init__.py
+++ b/packages/google-cloud-org-policy/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/tests/unit/__init__.py
+++ b/packages/google-cloud-org-policy/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-org-policy/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/tests/unit/gapic/orgpolicy_v2/__init__.py
+++ b/packages/google-cloud-org-policy/tests/unit/gapic/orgpolicy_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/.flake8
+++ b/packages/google-cloud-os-config/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/MANIFEST.in
+++ b/packages/google-cloud-os-config/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig/gapic_version.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/gapic_version.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/async_client.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/client.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/pagers.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/base.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/grpc.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/rest.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/rest_base.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/client.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/pagers.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/base.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/grpc.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/rest.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/rest_base.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/inventory.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/inventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/os_policy.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/os_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/os_policy_assignment_reports.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/os_policy_assignment_reports.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/os_policy_assignments.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/os_policy_assignments.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/osconfig_common.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/osconfig_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/osconfig_service.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/osconfig_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/osconfig_zonal_service.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/osconfig_zonal_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/patch_deployments.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/patch_deployments.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/patch_jobs.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/patch_jobs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/vulnerability.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/vulnerability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/gapic_version.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/client.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/pagers.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/base.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/grpc.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/rest.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/rest_base.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/config_common.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/config_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/instance_os_policies_compliance.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/instance_os_policies_compliance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/inventory.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/inventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/os_policy.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/os_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/os_policy_assignment_reports.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/os_policy_assignment_reports.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/os_policy_assignments.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/os_policy_assignments.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/osconfig_common.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/osconfig_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/osconfig_zonal_service.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/osconfig_zonal_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/vulnerability.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/vulnerability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_cancel_patch_job_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_cancel_patch_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_cancel_patch_job_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_cancel_patch_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_create_patch_deployment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_create_patch_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_create_patch_deployment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_create_patch_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_delete_patch_deployment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_delete_patch_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_delete_patch_deployment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_delete_patch_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_execute_patch_job_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_execute_patch_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_execute_patch_job_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_execute_patch_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_deployment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_deployment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_job_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_job_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_deployments_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_deployments_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_job_instance_details_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_job_instance_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_job_instance_details_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_job_instance_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_jobs_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_jobs_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_pause_patch_deployment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_pause_patch_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_pause_patch_deployment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_pause_patch_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_resume_patch_deployment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_resume_patch_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_resume_patch_deployment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_resume_patch_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_update_patch_deployment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_update_patch_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_update_patch_deployment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_update_patch_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_create_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_create_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_delete_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_delete_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_inventory_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_inventory_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_report_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_report_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_vulnerability_report_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_vulnerability_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_vulnerability_report_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_vulnerability_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_inventories_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_inventories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_inventories_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_reports_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_reports_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_revisions_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_revisions_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignments_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignments_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_vulnerability_reports_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_vulnerability_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_vulnerability_reports_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_vulnerability_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_update_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_update_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_create_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_create_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_delete_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_delete_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_instance_os_policies_compliance_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_instance_os_policies_compliance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_instance_os_policies_compliance_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_instance_os_policies_compliance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_inventory_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_inventory_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_report_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_report_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_vulnerability_report_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_vulnerability_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_vulnerability_report_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_vulnerability_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_instance_os_policies_compliances_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_instance_os_policies_compliances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_instance_os_policies_compliances_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_instance_os_policies_compliances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_inventories_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_inventories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_inventories_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_reports_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_reports_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_revisions_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_revisions_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignments_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignments_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_vulnerability_reports_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_vulnerability_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_vulnerability_reports_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_vulnerability_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_update_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_update_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/tests/__init__.py
+++ b/packages/google-cloud-os-config/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/tests/unit/__init__.py
+++ b/packages/google-cloud-os-config/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-os-config/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/tests/unit/gapic/osconfig_v1/__init__.py
+++ b/packages/google-cloud-os-config/tests/unit/gapic/osconfig_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/tests/unit/gapic/osconfig_v1alpha/__init__.py
+++ b/packages/google-cloud-os-config/tests/unit/gapic/osconfig_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/.flake8
+++ b/packages/google-cloud-os-login/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/MANIFEST.in
+++ b/packages/google-cloud-os-login/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin/__init__.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin/gapic_version.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/gapic_version.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/__init__.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/__init__.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/async_client.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/client.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/__init__.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/base.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/grpc.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/rest.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/rest_base.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/types/__init__.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/types/oslogin.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/types/oslogin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_create_ssh_public_key_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_create_ssh_public_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_create_ssh_public_key_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_create_ssh_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_posix_account_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_posix_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_posix_account_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_posix_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_ssh_public_key_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_ssh_public_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_ssh_public_key_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_ssh_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_login_profile_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_login_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_login_profile_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_login_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_ssh_public_key_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_ssh_public_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_ssh_public_key_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_ssh_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_import_ssh_public_key_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_import_ssh_public_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_import_ssh_public_key_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_import_ssh_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_update_ssh_public_key_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_update_ssh_public_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_update_ssh_public_key_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_update_ssh_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/tests/__init__.py
+++ b/packages/google-cloud-os-login/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/tests/unit/__init__.py
+++ b/packages/google-cloud-os-login/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-os-login/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/tests/unit/gapic/oslogin_v1/__init__.py
+++ b/packages/google-cloud-os-login/tests/unit/gapic/oslogin_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/.flake8
+++ b/packages/google-cloud-parallelstore/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/MANIFEST.in
+++ b/packages/google-cloud-parallelstore/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore/gapic_version.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/gapic_version.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/client.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/pagers.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/base.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/grpc.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/rest.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/rest_base.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/types/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/types/parallelstore.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/types/parallelstore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/gapic_version.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/client.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/pagers.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/base.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/grpc.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/rest.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/rest_base.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/types/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/types/parallelstore.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/types/parallelstore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_create_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_delete_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_export_data_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_get_instance_async.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_get_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_import_data_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_list_instances_async.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_list_instances_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_update_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_create_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_delete_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_export_data_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_get_instance_async.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_get_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_import_data_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_list_instances_async.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_list_instances_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_update_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/tests/__init__.py
+++ b/packages/google-cloud-parallelstore/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/tests/unit/__init__.py
+++ b/packages/google-cloud-parallelstore/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-parallelstore/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/tests/unit/gapic/parallelstore_v1/__init__.py
+++ b/packages/google-cloud-parallelstore/tests/unit/gapic/parallelstore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/tests/unit/gapic/parallelstore_v1beta/__init__.py
+++ b/packages/google-cloud-parallelstore/tests/unit/gapic/parallelstore_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/.flake8
+++ b/packages/google-cloud-parametermanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/MANIFEST.in
+++ b/packages/google-cloud-parametermanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager/__init__.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager/gapic_version.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/gapic_version.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/__init__.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/__init__.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/async_client.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/client.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/pagers.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/__init__.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/base.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/grpc.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/rest.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/rest_base.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/types/__init__.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/types/service.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_version_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_version_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_version_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_version_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_version_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_version_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameter_versions_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameter_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameter_versions_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameter_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameters_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameters_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_render_parameter_version_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_render_parameter_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_render_parameter_version_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_render_parameter_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_version_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_version_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/tests/__init__.py
+++ b/packages/google-cloud-parametermanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/tests/unit/__init__.py
+++ b/packages/google-cloud-parametermanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-parametermanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/tests/unit/gapic/parametermanager_v1/__init__.py
+++ b/packages/google-cloud-parametermanager/tests/unit/gapic/parametermanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/.flake8
+++ b/packages/google-cloud-phishing-protection/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/MANIFEST.in
+++ b/packages/google-cloud-phishing-protection/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection/__init__.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection/gapic_version.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/gapic_version.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/__init__.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/__init__.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/async_client.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/client.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/__init__.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/base.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/grpc.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/rest.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/rest_base.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/types/__init__.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/types/phishingprotection.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/types/phishingprotection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/samples/generated_samples/phishingprotection_v1beta1_generated_phishing_protection_service_v1_beta1_report_phishing_async.py
+++ b/packages/google-cloud-phishing-protection/samples/generated_samples/phishingprotection_v1beta1_generated_phishing_protection_service_v1_beta1_report_phishing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/samples/generated_samples/phishingprotection_v1beta1_generated_phishing_protection_service_v1_beta1_report_phishing_sync.py
+++ b/packages/google-cloud-phishing-protection/samples/generated_samples/phishingprotection_v1beta1_generated_phishing_protection_service_v1_beta1_report_phishing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/tests/__init__.py
+++ b/packages/google-cloud-phishing-protection/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/tests/unit/__init__.py
+++ b/packages/google-cloud-phishing-protection/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-phishing-protection/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/tests/unit/gapic/phishingprotection_v1beta1/__init__.py
+++ b/packages/google-cloud-phishing-protection/tests/unit/gapic/phishingprotection_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/.flake8
+++ b/packages/google-cloud-policy-troubleshooter/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/MANIFEST.in
+++ b/packages/google-cloud-policy-troubleshooter/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter/gapic_version.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/gapic_version.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/async_client.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/client.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/base.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/grpc.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/grpc_asyncio.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/rest.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/rest_base.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/types/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/types/checker.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/types/checker.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/types/explanations.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/types/explanations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/samples/generated_samples/policytroubleshooter_v1_generated_iam_checker_troubleshoot_iam_policy_async.py
+++ b/packages/google-cloud-policy-troubleshooter/samples/generated_samples/policytroubleshooter_v1_generated_iam_checker_troubleshoot_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/samples/generated_samples/policytroubleshooter_v1_generated_iam_checker_troubleshoot_iam_policy_sync.py
+++ b/packages/google-cloud-policy-troubleshooter/samples/generated_samples/policytroubleshooter_v1_generated_iam_checker_troubleshoot_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/tests/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/tests/unit/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/tests/unit/gapic/policytroubleshooter_v1/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/tests/unit/gapic/policytroubleshooter_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/.flake8
+++ b/packages/google-cloud-policysimulator/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/MANIFEST.in
+++ b/packages/google-cloud-policysimulator/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator/gapic_version.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/gapic_version.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/client.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/pagers.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/base.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/grpc.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/rest.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/rest_base.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/client.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/pagers.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/base.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/grpc.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/grpc_asyncio.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/rest.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/rest_base.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/explanations.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/explanations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/orgpolicy.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/orgpolicy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/simulator.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/simulator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_create_org_policy_violations_preview_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_create_org_policy_violations_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_get_org_policy_violations_preview_async.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_get_org_policy_violations_preview_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_get_org_policy_violations_preview_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_get_org_policy_violations_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_async.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_previews_async.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_previews_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_previews_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_previews_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_create_replay_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_create_replay_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_get_replay_async.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_get_replay_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_get_replay_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_get_replay_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_list_replay_results_async.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_list_replay_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_list_replay_results_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_list_replay_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/tests/__init__.py
+++ b/packages/google-cloud-policysimulator/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/tests/unit/__init__.py
+++ b/packages/google-cloud-policysimulator/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-policysimulator/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/tests/unit/gapic/policysimulator_v1/__init__.py
+++ b/packages/google-cloud-policysimulator/tests/unit/gapic/policysimulator_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/.flake8
+++ b/packages/google-cloud-policytroubleshooter-iam/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/MANIFEST.in
+++ b/packages/google-cloud-policytroubleshooter-iam/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam/gapic_version.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/gapic_version.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/async_client.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/client.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/base.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/grpc.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/grpc_asyncio.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/rest.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/rest_base.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/types/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/types/troubleshooter.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/types/troubleshooter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/samples/generated_samples/policytroubleshooter_v3_generated_policy_troubleshooter_troubleshoot_iam_policy_async.py
+++ b/packages/google-cloud-policytroubleshooter-iam/samples/generated_samples/policytroubleshooter_v3_generated_policy_troubleshooter_troubleshoot_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/samples/generated_samples/policytroubleshooter_v3_generated_policy_troubleshooter_troubleshoot_iam_policy_sync.py
+++ b/packages/google-cloud-policytroubleshooter-iam/samples/generated_samples/policytroubleshooter_v3_generated_policy_troubleshooter_troubleshoot_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/tests/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/tests/unit/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/tests/unit/gapic/policytroubleshooter_iam_v3/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/tests/unit/gapic/policytroubleshooter_iam_v3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/.flake8
+++ b/packages/google-cloud-private-ca/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/MANIFEST.in
+++ b/packages/google-cloud-private-ca/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca/gapic_version.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/gapic_version.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/client.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/pagers.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/base.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/grpc.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/rest.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/rest_base.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/resources.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/service.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/gapic_version.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/client.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/pagers.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/base.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/grpc.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/rest.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/rest_base.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/types/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/types/resources.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/types/service.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_activate_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_activate_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_ca_pool_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_ca_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_template_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_delete_ca_pool_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_delete_ca_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_delete_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_delete_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_delete_certificate_template_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_delete_certificate_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_disable_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_disable_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_enable_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_enable_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_ca_certs_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_ca_certs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_ca_certs_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_ca_certs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_certificate_authority_csr_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_certificate_authority_csr_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_certificate_authority_csr_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_certificate_authority_csr_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_ca_pool_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_ca_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_ca_pool_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_ca_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_authority_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_revocation_list_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_revocation_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_revocation_list_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_revocation_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_template_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_template_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_ca_pools_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_ca_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_ca_pools_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_ca_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_authorities_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_authorities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_authorities_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_authorities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_revocation_lists_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_revocation_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_revocation_lists_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_revocation_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_templates_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_templates_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificates_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificates_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_revoke_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_revoke_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_revoke_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_revoke_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_undelete_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_undelete_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_ca_pool_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_ca_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_revocation_list_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_revocation_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_template_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_activate_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_activate_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_create_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_create_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_create_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_create_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_create_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_create_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_disable_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_disable_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_enable_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_enable_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_fetch_certificate_authority_csr_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_fetch_certificate_authority_csr_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_fetch_certificate_authority_csr_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_fetch_certificate_authority_csr_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_authority_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_revocation_list_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_revocation_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_revocation_list_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_revocation_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_reusable_config_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_reusable_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_reusable_config_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_reusable_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_authorities_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_authorities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_authorities_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_authorities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_revocation_lists_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_revocation_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_revocation_lists_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_revocation_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificates_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificates_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_reusable_configs_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_reusable_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_reusable_configs_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_reusable_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_restore_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_restore_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_revoke_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_revoke_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_revoke_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_revoke_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_schedule_delete_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_schedule_delete_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_revocation_list_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_revocation_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/tests/__init__.py
+++ b/packages/google-cloud-private-ca/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/tests/unit/__init__.py
+++ b/packages/google-cloud-private-ca/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-private-ca/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/tests/unit/gapic/privateca_v1/__init__.py
+++ b/packages/google-cloud-private-ca/tests/unit/gapic/privateca_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/tests/unit/gapic/privateca_v1beta1/__init__.py
+++ b/packages/google-cloud-private-ca/tests/unit/gapic/privateca_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/.flake8
+++ b/packages/google-cloud-private-catalog/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/MANIFEST.in
+++ b/packages/google-cloud-private-catalog/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog/__init__.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog/gapic_version.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/gapic_version.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/__init__.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/__init__.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/async_client.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/client.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/pagers.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/__init__.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/base.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/grpc.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/grpc_asyncio.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/rest.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/rest_base.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/types/__init__.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/types/private_catalog.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/types/private_catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_catalogs_async.py
+++ b/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_catalogs_sync.py
+++ b/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_products_async.py
+++ b/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_products_sync.py
+++ b/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_versions_async.py
+++ b/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_versions_sync.py
+++ b/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/tests/__init__.py
+++ b/packages/google-cloud-private-catalog/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/tests/unit/__init__.py
+++ b/packages/google-cloud-private-catalog/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-private-catalog/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/tests/unit/gapic/privatecatalog_v1beta1/__init__.py
+++ b/packages/google-cloud-private-catalog/tests/unit/gapic/privatecatalog_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/.flake8
+++ b/packages/google-cloud-privilegedaccessmanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/MANIFEST.in
+++ b/packages/google-cloud-privilegedaccessmanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager/gapic_version.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/gapic_version.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/client.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/pagers.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/base.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/grpc.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/rest.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/rest_base.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/types/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/types/privilegedaccessmanager.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/types/privilegedaccessmanager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_approve_grant_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_approve_grant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_approve_grant_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_approve_grant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_check_onboarding_status_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_check_onboarding_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_check_onboarding_status_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_check_onboarding_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_create_entitlement_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_create_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_create_grant_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_create_grant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_create_grant_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_create_grant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_delete_entitlement_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_delete_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_deny_grant_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_deny_grant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_deny_grant_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_deny_grant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_entitlement_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_entitlement_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_entitlement_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_grant_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_grant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_grant_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_grant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_entitlements_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_entitlements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_entitlements_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_entitlements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_grants_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_grants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_grants_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_grants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_revoke_grant_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_revoke_grant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_entitlements_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_entitlements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_entitlements_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_entitlements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_grants_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_grants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_grants_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_grants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_update_entitlement_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_update_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/tests/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/tests/unit/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/tests/unit/gapic/privilegedaccessmanager_v1/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/tests/unit/gapic/privilegedaccessmanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/.flake8
+++ b/packages/google-cloud-pubsub/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/MANIFEST.in
+++ b/packages/google-cloud-pubsub/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub/gapic_version.py
+++ b/packages/google-cloud-pubsub/google/pubsub/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/gapic_version.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/async_client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/pagers.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/base.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/grpc.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/grpc_asyncio.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/rest.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/rest_base.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/async_client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/pagers.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/base.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/grpc.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/rest.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/rest_base.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/async_client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/pagers.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/base.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/grpc.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/grpc_asyncio.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/rest.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/rest_base.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/types/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/types/pubsub.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/types/pubsub.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/types/schema.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_create_topic_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_create_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_create_topic_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_create_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_delete_topic_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_delete_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_delete_topic_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_delete_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_detach_subscription_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_detach_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_detach_subscription_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_detach_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_get_topic_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_get_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_get_topic_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_get_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_snapshots_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_snapshots_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_snapshots_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_snapshots_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_subscriptions_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_subscriptions_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topics_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topics_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_publish_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_publish_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_publish_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_publish_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_update_topic_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_update_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_update_topic_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_update_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_commit_schema_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_commit_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_commit_schema_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_commit_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_create_schema_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_create_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_create_schema_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_create_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_revision_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_revision_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_get_schema_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_get_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_get_schema_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_get_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schema_revisions_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schema_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schema_revisions_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schema_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schemas_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schemas_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_rollback_schema_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_rollback_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_rollback_schema_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_rollback_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_message_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_message_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_schema_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_schema_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_acknowledge_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_acknowledge_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_acknowledge_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_acknowledge_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_snapshot_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_snapshot_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_subscription_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_subscription_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_snapshot_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_snapshot_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_subscription_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_subscription_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_snapshot_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_snapshot_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_subscription_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_subscription_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_snapshots_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_snapshots_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_snapshots_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_snapshots_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_subscriptions_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_subscriptions_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_ack_deadline_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_ack_deadline_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_ack_deadline_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_ack_deadline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_push_config_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_push_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_push_config_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_push_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_pull_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_pull_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_pull_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_pull_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_seek_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_seek_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_seek_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_seek_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_streaming_pull_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_streaming_pull_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_streaming_pull_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_streaming_pull_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_snapshot_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_snapshot_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_subscription_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_subscription_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/tests/__init__.py
+++ b/packages/google-cloud-pubsub/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/tests/unit/__init__.py
+++ b/packages/google-cloud-pubsub/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-pubsub/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/tests/unit/gapic/pubsub_v1/__init__.py
+++ b/packages/google-cloud-pubsub/tests/unit/gapic/pubsub_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/.flake8
+++ b/packages/google-cloud-quotas/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/MANIFEST.in
+++ b/packages/google-cloud-quotas/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas/gapic_version.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/gapic_version.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/async_client.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/client.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/pagers.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/base.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/grpc.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/grpc_asyncio.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/rest.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/rest_base.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/types/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/types/cloudquotas.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/types/cloudquotas.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/types/resources.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/gapic_version.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/async_client.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/client.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/pagers.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/base.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/grpc.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/grpc_asyncio.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/rest.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/rest_base.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/async_client.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/client.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/base.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/grpc.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/rest.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/rest_base.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/cloudquotas.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/cloudquotas.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/quota_adjuster_settings.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/quota_adjuster_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/resources.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_create_quota_preference_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_create_quota_preference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_create_quota_preference_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_create_quota_preference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_info_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_info_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_preference_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_preference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_preference_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_preference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_infos_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_infos_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_infos_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_infos_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_preferences_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_preferences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_preferences_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_preferences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_update_quota_preference_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_update_quota_preference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_update_quota_preference_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_update_quota_preference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_create_quota_preference_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_create_quota_preference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_create_quota_preference_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_create_quota_preference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_info_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_info_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_preference_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_preference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_preference_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_preference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_infos_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_infos_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_infos_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_infos_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_preferences_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_preferences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_preferences_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_preferences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_update_quota_preference_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_update_quota_preference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_update_quota_preference_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_update_quota_preference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_get_quota_adjuster_settings_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_get_quota_adjuster_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_get_quota_adjuster_settings_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_get_quota_adjuster_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_update_quota_adjuster_settings_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_update_quota_adjuster_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_update_quota_adjuster_settings_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_update_quota_adjuster_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/tests/__init__.py
+++ b/packages/google-cloud-quotas/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/tests/unit/__init__.py
+++ b/packages/google-cloud-quotas/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-quotas/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/tests/unit/gapic/cloudquotas_v1/__init__.py
+++ b/packages/google-cloud-quotas/tests/unit/gapic/cloudquotas_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/tests/unit/gapic/cloudquotas_v1beta/__init__.py
+++ b/packages/google-cloud-quotas/tests/unit/gapic/cloudquotas_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/.flake8
+++ b/packages/google-cloud-rapidmigrationassessment/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/MANIFEST.in
+++ b/packages/google-cloud-rapidmigrationassessment/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment/gapic_version.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/gapic_version.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/client.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/pagers.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/base.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/grpc.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/grpc_asyncio.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/rest.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/rest_base.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/types/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/types/api_entities.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/types/api_entities.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/types/rapidmigrationassessment.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/types/rapidmigrationassessment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_create_annotation_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_create_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_create_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_create_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_delete_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_delete_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_annotation_async.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_annotation_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_collector_async.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_collector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_list_collectors_async.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_list_collectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_list_collectors_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_list_collectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_pause_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_pause_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_register_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_register_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_resume_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_resume_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_update_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_update_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/tests/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/tests/unit/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/tests/unit/gapic/rapidmigrationassessment_v1/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/tests/unit/gapic/rapidmigrationassessment_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/.flake8
+++ b/packages/google-cloud-recaptcha-enterprise/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/MANIFEST.in
+++ b/packages/google-cloud-recaptcha-enterprise/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise/gapic_version.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/gapic_version.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/async_client.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/client.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/pagers.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/base.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/grpc.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/types/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/types/recaptchaenterprise.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/types/recaptchaenterprise.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_add_ip_override_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_add_ip_override_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_add_ip_override_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_add_ip_override_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_annotate_assessment_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_annotate_assessment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_annotate_assessment_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_annotate_assessment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_assessment_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_assessment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_assessment_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_assessment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_firewall_policy_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_firewall_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_firewall_policy_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_firewall_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_key_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_key_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_firewall_policy_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_firewall_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_firewall_policy_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_firewall_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_key_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_key_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_firewall_policy_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_firewall_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_firewall_policy_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_firewall_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_key_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_key_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_metrics_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_metrics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_metrics_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_firewall_policies_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_firewall_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_firewall_policies_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_firewall_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_ip_overrides_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_ip_overrides_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_ip_overrides_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_ip_overrides_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_keys_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_keys_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_group_memberships_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_group_memberships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_group_memberships_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_group_memberships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_groups_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_groups_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_migrate_key_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_migrate_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_migrate_key_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_migrate_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_remove_ip_override_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_remove_ip_override_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_remove_ip_override_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_remove_ip_override_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_reorder_firewall_policies_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_reorder_firewall_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_reorder_firewall_policies_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_reorder_firewall_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_retrieve_legacy_secret_key_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_retrieve_legacy_secret_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_retrieve_legacy_secret_key_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_retrieve_legacy_secret_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_search_related_account_group_memberships_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_search_related_account_group_memberships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_search_related_account_group_memberships_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_search_related_account_group_memberships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_firewall_policy_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_firewall_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_firewall_policy_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_firewall_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_key_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_key_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/tests/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/tests/unit/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/tests/unit/gapic/recaptchaenterprise_v1/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/tests/unit/gapic/recaptchaenterprise_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/.flake8
+++ b/packages/google-cloud-recommendations-ai/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/MANIFEST.in
+++ b/packages/google-cloud-recommendations-ai/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine/gapic_version.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/gapic_version.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/client.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/pagers.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/grpc.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/rest.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/rest_base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/async_client.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/client.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/pagers.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/grpc.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/rest.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/rest_base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/async_client.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/client.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/pagers.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/grpc.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/rest.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/rest_base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/client.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/pagers.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/catalog.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/catalog_service.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/catalog_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/common.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/import_.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/import_.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/prediction_apikey_registry_service.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/prediction_apikey_registry_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/prediction_service.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/recommendationengine_resources.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/recommendationengine_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/user_event.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/user_event_service.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_create_catalog_item_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_create_catalog_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_create_catalog_item_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_create_catalog_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_delete_catalog_item_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_delete_catalog_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_delete_catalog_item_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_delete_catalog_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_get_catalog_item_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_get_catalog_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_get_catalog_item_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_get_catalog_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_import_catalog_items_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_import_catalog_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_list_catalog_items_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_list_catalog_items_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_list_catalog_items_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_list_catalog_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_update_catalog_item_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_update_catalog_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_update_catalog_item_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_update_catalog_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_create_prediction_api_key_registration_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_create_prediction_api_key_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_create_prediction_api_key_registration_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_create_prediction_api_key_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_delete_prediction_api_key_registration_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_delete_prediction_api_key_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_delete_prediction_api_key_registration_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_delete_prediction_api_key_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_list_prediction_api_key_registrations_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_list_prediction_api_key_registrations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_list_prediction_api_key_registrations_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_list_prediction_api_key_registrations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_service_predict_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_service_predict_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_list_user_events_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_list_user_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_list_user_events_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_list_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/tests/__init__.py
+++ b/packages/google-cloud-recommendations-ai/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/tests/unit/__init__.py
+++ b/packages/google-cloud-recommendations-ai/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-recommendations-ai/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/tests/unit/gapic/recommendationengine_v1beta1/__init__.py
+++ b/packages/google-cloud-recommendations-ai/tests/unit/gapic/recommendationengine_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/.flake8
+++ b/packages/google-cloud-recommender/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/MANIFEST.in
+++ b/packages/google-cloud-recommender/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender/gapic_version.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/gapic_version.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/async_client.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/client.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/pagers.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/base.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/grpc.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/rest.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/rest_base.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/types/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/types/insight.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/types/insight.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/types/insight_type_config.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/types/insight_type_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/types/recommendation.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/types/recommendation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/types/recommender_config.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/types/recommender_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/types/recommender_service.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/types/recommender_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/gapic_version.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/async_client.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/client.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/pagers.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/base.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/grpc.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/rest.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/rest_base.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/insight.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/insight.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/insight_type_config.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/insight_type_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/recommendation.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/recommendation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/recommender_config.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/recommender_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/recommender_service.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/recommender_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_type_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_type_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_type_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_type_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommendation_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommendation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommendation_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommendation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommender_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommender_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommender_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommender_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_insights_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_insights_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_insights_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_insights_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_recommendations_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_recommendations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_recommendations_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_recommendations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_insight_accepted_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_insight_accepted_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_insight_accepted_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_insight_accepted_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_claimed_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_claimed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_claimed_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_claimed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_dismissed_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_dismissed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_dismissed_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_dismissed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_failed_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_failed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_failed_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_failed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_succeeded_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_succeeded_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_succeeded_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_succeeded_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_insight_type_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_insight_type_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_insight_type_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_insight_type_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_recommender_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_recommender_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_recommender_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_recommender_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_type_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_type_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_type_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_type_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommendation_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommendation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommendation_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommendation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommender_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommender_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommender_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommender_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insight_types_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insight_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insight_types_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insight_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insights_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insights_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insights_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insights_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommendations_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommendations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommendations_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommendations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommenders_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommenders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommenders_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommenders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_insight_accepted_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_insight_accepted_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_insight_accepted_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_insight_accepted_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_claimed_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_claimed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_claimed_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_claimed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_failed_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_failed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_failed_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_failed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_succeeded_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_succeeded_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_succeeded_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_succeeded_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_insight_type_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_insight_type_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_insight_type_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_insight_type_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_recommender_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_recommender_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_recommender_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_recommender_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/tests/__init__.py
+++ b/packages/google-cloud-recommender/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/tests/unit/__init__.py
+++ b/packages/google-cloud-recommender/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-recommender/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/tests/unit/gapic/recommender_v1/__init__.py
+++ b/packages/google-cloud-recommender/tests/unit/gapic/recommender_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/tests/unit/gapic/recommender_v1beta1/__init__.py
+++ b/packages/google-cloud-recommender/tests/unit/gapic/recommender_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/.flake8
+++ b/packages/google-cloud-redis-cluster/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/MANIFEST.in
+++ b/packages/google-cloud-redis-cluster/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster/gapic_version.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/gapic_version.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/client.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/pagers.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/base.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/grpc.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/grpc_asyncio.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/rest.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/rest_base.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/types/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/types/cloud_redis_cluster.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/types/cloud_redis_cluster.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/gapic_version.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/client.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/pagers.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/base.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/grpc.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/grpc_asyncio.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/rest.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/rest_base.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/types/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/types/cloud_redis_cluster.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/types/cloud_redis_cluster.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_backup_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_backup_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_create_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_delete_backup_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_delete_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_export_backup_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_export_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_collection_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_collection_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_certificate_authority_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_certificate_authority_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backup_collections_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backup_collections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backup_collections_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backup_collections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backups_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backups_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_clusters_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_clusters_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_reschedule_cluster_maintenance_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_reschedule_cluster_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_update_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_backup_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_backup_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_create_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_delete_backup_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_delete_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_export_backup_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_export_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_collection_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_collection_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_certificate_authority_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_certificate_authority_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backup_collections_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backup_collections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backup_collections_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backup_collections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backups_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backups_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_clusters_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_clusters_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_reschedule_cluster_maintenance_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_reschedule_cluster_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_update_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/tests/__init__.py
+++ b/packages/google-cloud-redis-cluster/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/tests/unit/__init__.py
+++ b/packages/google-cloud-redis-cluster/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-redis-cluster/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/tests/unit/gapic/redis_cluster_v1/__init__.py
+++ b/packages/google-cloud-redis-cluster/tests/unit/gapic/redis_cluster_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/tests/unit/gapic/redis_cluster_v1beta1/__init__.py
+++ b/packages/google-cloud-redis-cluster/tests/unit/gapic/redis_cluster_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/.flake8
+++ b/packages/google-cloud-redis/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/MANIFEST.in
+++ b/packages/google-cloud-redis/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis/gapic_version.py
+++ b/packages/google-cloud-redis/google/cloud/redis/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/gapic_version.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/pagers.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_base.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/types/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/types/cloud_redis.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/types/cloud_redis.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/gapic_version.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/client.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/pagers.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/base.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/grpc.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/grpc_asyncio.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/rest.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/rest_base.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/types/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/types/cloud_redis.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/types/cloud_redis.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_export_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_export_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_failover_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_failover_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_async.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_auth_string_async.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_auth_string_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_auth_string_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_auth_string_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_import_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_import_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_async.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_reschedule_maintenance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_reschedule_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_upgrade_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_upgrade_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_create_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_delete_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_export_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_export_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_failover_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_failover_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_async.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_auth_string_async.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_auth_string_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_auth_string_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_auth_string_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_import_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_import_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_list_instances_async.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_list_instances_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_reschedule_maintenance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_reschedule_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_update_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_upgrade_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_upgrade_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/tests/__init__.py
+++ b/packages/google-cloud-redis/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/tests/unit/__init__.py
+++ b/packages/google-cloud-redis/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-redis/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/tests/unit/gapic/redis_v1/__init__.py
+++ b/packages/google-cloud-redis/tests/unit/gapic/redis_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/tests/unit/gapic/redis_v1beta1/__init__.py
+++ b/packages/google-cloud-redis/tests/unit/gapic/redis_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/.flake8
+++ b/packages/google-cloud-resource-manager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/MANIFEST.in
+++ b/packages/google-cloud-resource-manager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager/gapic_version.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/gapic_version.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/async_client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/folders.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/folders.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/organizations.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/organizations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/projects.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/projects.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_bindings.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_bindings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_holds.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_holds.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_keys.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_keys.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_values.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_values.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_create_folder_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_create_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_delete_folder_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_delete_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_folder_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_folder_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_list_folders_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_list_folders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_list_folders_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_list_folders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_move_folder_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_move_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_search_folders_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_search_folders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_search_folders_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_search_folders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_set_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_set_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_test_iam_permissions_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_test_iam_permissions_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_undelete_folder_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_undelete_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_update_folder_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_update_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_organization_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_organization_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_organization_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_organization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_search_organizations_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_search_organizations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_search_organizations_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_search_organizations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_set_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_set_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_test_iam_permissions_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_test_iam_permissions_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_create_project_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_create_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_delete_project_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_delete_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_project_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_project_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_project_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_list_projects_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_list_projects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_list_projects_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_list_projects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_move_project_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_move_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_search_projects_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_search_projects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_search_projects_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_search_projects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_set_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_set_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_test_iam_permissions_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_test_iam_permissions_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_undelete_project_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_undelete_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_update_project_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_update_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_create_tag_binding_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_create_tag_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_delete_tag_binding_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_delete_tag_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_effective_tags_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_effective_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_effective_tags_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_effective_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_tag_bindings_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_tag_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_tag_bindings_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_tag_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_create_tag_hold_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_create_tag_hold_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_delete_tag_hold_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_delete_tag_hold_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_list_tag_holds_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_list_tag_holds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_list_tag_holds_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_list_tag_holds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_create_tag_key_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_create_tag_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_delete_tag_key_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_delete_tag_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_namespaced_tag_key_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_namespaced_tag_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_namespaced_tag_key_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_namespaced_tag_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_tag_key_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_tag_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_tag_key_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_tag_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_list_tag_keys_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_list_tag_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_list_tag_keys_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_list_tag_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_set_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_set_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_test_iam_permissions_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_test_iam_permissions_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_update_tag_key_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_update_tag_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_create_tag_value_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_create_tag_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_delete_tag_value_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_delete_tag_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_namespaced_tag_value_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_namespaced_tag_value_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_namespaced_tag_value_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_namespaced_tag_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_tag_value_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_tag_value_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_tag_value_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_tag_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_list_tag_values_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_list_tag_values_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_list_tag_values_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_list_tag_values_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_set_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_set_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_test_iam_permissions_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_test_iam_permissions_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_update_tag_value_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_update_tag_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/tests/__init__.py
+++ b/packages/google-cloud-resource-manager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/tests/unit/__init__.py
+++ b/packages/google-cloud-resource-manager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-resource-manager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/tests/unit/gapic/resourcemanager_v3/__init__.py
+++ b/packages/google-cloud-resource-manager/tests/unit/gapic/resourcemanager_v3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/.flake8
+++ b/packages/google-cloud-retail/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/MANIFEST.in
+++ b/packages/google-cloud-retail/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail/gapic_version.py
+++ b/packages/google-cloud-retail/google/cloud/retail/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/gapic_version.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/analytics_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/analytics_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/catalog.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/catalog_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/catalog_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/common.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/completion_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/control.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/control_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/control_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/conversational_search_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/conversational_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/export_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/export_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/generative_question.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/generative_question.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/generative_question_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/generative_question_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/import_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/import_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/model.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/model_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/prediction_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/product.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/product.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/product_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/product_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/promotion.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/promotion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/purge_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/purge_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/safety.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/search_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/serving_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/serving_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/serving_config_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/serving_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/user_event.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/user_event_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/gapic_version.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/analytics_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/analytics_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/branch.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/branch.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/branch_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/branch_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/catalog.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/catalog_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/catalog_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/common.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/completion_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/control.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/control_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/control_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/conversational_search_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/conversational_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/export_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/export_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/generative_question.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/generative_question.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/generative_question_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/generative_question_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/import_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/import_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/merchant_center_account_link.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/merchant_center_account_link.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/merchant_center_account_link_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/merchant_center_account_link_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/model.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/model_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/prediction_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/product.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/product.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/product_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/product_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/promotion.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/promotion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/purge_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/purge_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/safety.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/search_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/serving_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/serving_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/serving_config_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/serving_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/user_event.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/user_event_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/gapic_version.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/analytics_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/analytics_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/catalog.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/catalog_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/catalog_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/common.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/completion_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/control.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/control_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/control_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/conversational_search_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/conversational_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/export_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/export_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/generative_question.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/generative_question.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/generative_question_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/generative_question_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/import_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/import_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/model.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/model_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/prediction_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/product.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/product.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/product_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/product_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/project.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/project.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/project_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/project_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/promotion.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/promotion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/purge_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/purge_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/safety.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/search_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/serving_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/serving_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/serving_config_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/serving_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/user_event.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/user_event_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_analytics_service_export_analytics_metrics_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_analytics_service_export_analytics_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_add_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_add_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_add_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_add_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_attributes_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_attributes_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_attributes_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_attributes_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_completion_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_completion_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_completion_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_completion_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_default_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_default_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_default_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_default_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_list_catalogs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_list_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_list_catalogs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_list_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_remove_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_remove_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_remove_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_remove_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_replace_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_replace_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_replace_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_replace_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_set_default_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_set_default_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_set_default_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_set_default_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_attributes_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_attributes_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_attributes_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_attributes_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_catalog_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_catalog_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_completion_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_completion_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_completion_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_completion_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_completion_service_complete_query_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_completion_service_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_completion_service_complete_query_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_completion_service_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_completion_service_import_completion_data_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_completion_service_import_completion_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_create_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_create_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_create_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_create_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_delete_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_delete_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_delete_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_delete_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_get_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_get_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_get_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_get_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_list_controls_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_list_controls_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_update_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_update_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_update_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_update_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_conversational_search_service_conversational_search_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_conversational_search_service_conversational_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_conversational_search_service_conversational_search_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_conversational_search_service_conversational_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_batch_update_generative_question_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_batch_update_generative_question_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_batch_update_generative_question_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_batch_update_generative_question_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_get_generative_questions_feature_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_get_generative_questions_feature_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_get_generative_questions_feature_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_get_generative_questions_feature_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_list_generative_question_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_list_generative_question_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_list_generative_question_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_list_generative_question_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_question_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_question_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_question_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_question_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_questions_feature_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_questions_feature_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_questions_feature_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_questions_feature_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_create_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_delete_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_delete_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_delete_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_get_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_get_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_list_models_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_list_models_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_pause_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_pause_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_pause_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_pause_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_resume_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_resume_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_resume_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_resume_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_tune_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_tune_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_update_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_update_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_update_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_update_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_prediction_service_predict_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_prediction_service_predict_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_add_fulfillment_places_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_add_fulfillment_places_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_add_local_inventories_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_add_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_create_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_create_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_create_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_create_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_delete_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_delete_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_delete_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_delete_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_get_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_get_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_import_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_import_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_list_products_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_list_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_purge_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_purge_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_remove_fulfillment_places_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_remove_fulfillment_places_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_remove_local_inventories_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_remove_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_set_inventory_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_set_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_update_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_update_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_update_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_update_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_search_service_search_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_search_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_search_service_search_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_search_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_add_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_add_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_add_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_add_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_create_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_create_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_create_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_create_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_delete_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_delete_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_delete_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_delete_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_get_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_get_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_get_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_get_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_list_serving_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_list_serving_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_list_serving_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_list_serving_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_remove_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_remove_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_remove_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_remove_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_update_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_update_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_update_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_update_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_rejoin_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_rejoin_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_analytics_service_export_analytics_metrics_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_analytics_service_export_analytics_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_get_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_get_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_get_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_get_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_list_branches_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_list_branches_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_list_branches_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_list_branches_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_add_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_add_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_add_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_add_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_batch_remove_catalog_attributes_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_batch_remove_catalog_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_batch_remove_catalog_attributes_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_batch_remove_catalog_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_attributes_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_attributes_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_attributes_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_attributes_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_completion_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_completion_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_completion_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_completion_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_default_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_default_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_default_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_default_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_list_catalogs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_list_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_list_catalogs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_list_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_remove_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_remove_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_remove_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_remove_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_replace_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_replace_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_replace_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_replace_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_set_default_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_set_default_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_set_default_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_set_default_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_attributes_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_attributes_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_attributes_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_attributes_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_catalog_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_catalog_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_completion_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_completion_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_completion_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_completion_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_completion_service_complete_query_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_completion_service_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_completion_service_complete_query_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_completion_service_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_completion_service_import_completion_data_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_completion_service_import_completion_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_create_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_create_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_create_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_create_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_delete_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_delete_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_delete_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_delete_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_get_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_get_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_get_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_get_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_list_controls_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_list_controls_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_update_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_update_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_update_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_update_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_conversational_search_service_conversational_search_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_conversational_search_service_conversational_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_conversational_search_service_conversational_search_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_conversational_search_service_conversational_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_batch_update_generative_question_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_batch_update_generative_question_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_batch_update_generative_question_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_batch_update_generative_question_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_get_generative_questions_feature_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_get_generative_questions_feature_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_get_generative_questions_feature_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_get_generative_questions_feature_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_list_generative_question_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_list_generative_question_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_list_generative_question_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_list_generative_question_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_question_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_question_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_question_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_question_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_questions_feature_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_questions_feature_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_questions_feature_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_questions_feature_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_create_merchant_center_account_link_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_create_merchant_center_account_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_delete_merchant_center_account_link_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_delete_merchant_center_account_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_delete_merchant_center_account_link_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_delete_merchant_center_account_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_list_merchant_center_account_links_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_list_merchant_center_account_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_list_merchant_center_account_links_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_list_merchant_center_account_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_create_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_delete_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_delete_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_delete_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_get_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_get_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_list_models_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_list_models_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_pause_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_pause_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_pause_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_pause_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_resume_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_resume_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_resume_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_resume_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_tune_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_tune_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_update_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_update_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_update_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_update_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_prediction_service_predict_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_prediction_service_predict_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_add_fulfillment_places_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_add_fulfillment_places_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_add_local_inventories_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_add_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_create_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_create_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_create_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_create_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_delete_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_delete_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_delete_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_delete_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_export_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_export_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_get_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_get_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_import_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_import_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_list_products_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_list_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_purge_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_purge_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_remove_fulfillment_places_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_remove_fulfillment_places_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_remove_local_inventories_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_remove_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_set_inventory_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_set_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_update_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_update_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_update_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_update_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_accept_terms_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_accept_terms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_accept_terms_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_accept_terms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_enroll_solution_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_enroll_solution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_alert_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_alert_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_alert_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_alert_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_logging_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_logging_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_logging_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_logging_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_project_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_project_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_project_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_list_enrolled_solutions_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_list_enrolled_solutions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_list_enrolled_solutions_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_list_enrolled_solutions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_alert_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_alert_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_alert_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_alert_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_logging_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_logging_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_logging_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_logging_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_search_service_search_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_search_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_search_service_search_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_search_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_add_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_add_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_add_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_add_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_create_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_create_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_create_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_create_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_delete_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_delete_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_delete_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_delete_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_get_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_get_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_get_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_get_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_list_serving_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_list_serving_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_list_serving_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_list_serving_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_remove_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_remove_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_remove_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_remove_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_update_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_update_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_update_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_update_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_export_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_export_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_rejoin_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_rejoin_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_analytics_service_export_analytics_metrics_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_analytics_service_export_analytics_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_add_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_add_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_add_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_add_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_batch_remove_catalog_attributes_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_batch_remove_catalog_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_batch_remove_catalog_attributes_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_batch_remove_catalog_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_attributes_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_attributes_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_attributes_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_attributes_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_completion_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_completion_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_completion_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_completion_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_default_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_default_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_default_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_default_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_list_catalogs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_list_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_list_catalogs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_list_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_remove_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_remove_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_remove_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_remove_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_replace_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_replace_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_replace_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_replace_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_set_default_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_set_default_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_set_default_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_set_default_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_attributes_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_attributes_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_attributes_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_attributes_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_catalog_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_catalog_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_completion_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_completion_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_completion_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_completion_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_completion_service_complete_query_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_completion_service_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_completion_service_complete_query_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_completion_service_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_completion_service_import_completion_data_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_completion_service_import_completion_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_create_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_create_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_create_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_create_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_delete_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_delete_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_delete_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_delete_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_get_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_get_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_get_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_get_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_list_controls_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_list_controls_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_update_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_update_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_update_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_update_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_conversational_search_service_conversational_search_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_conversational_search_service_conversational_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_conversational_search_service_conversational_search_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_conversational_search_service_conversational_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_batch_update_generative_question_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_batch_update_generative_question_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_batch_update_generative_question_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_batch_update_generative_question_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_get_generative_questions_feature_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_get_generative_questions_feature_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_get_generative_questions_feature_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_get_generative_questions_feature_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_list_generative_question_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_list_generative_question_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_list_generative_question_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_list_generative_question_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_question_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_question_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_question_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_question_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_questions_feature_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_questions_feature_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_questions_feature_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_questions_feature_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_create_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_delete_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_delete_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_delete_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_get_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_get_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_list_models_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_list_models_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_pause_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_pause_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_pause_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_pause_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_resume_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_resume_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_resume_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_resume_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_tune_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_tune_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_update_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_update_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_update_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_update_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_prediction_service_predict_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_prediction_service_predict_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_add_fulfillment_places_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_add_fulfillment_places_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_add_local_inventories_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_add_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_create_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_create_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_create_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_create_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_delete_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_delete_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_delete_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_delete_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_export_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_export_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_get_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_get_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_import_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_import_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_list_products_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_list_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_purge_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_purge_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_remove_fulfillment_places_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_remove_fulfillment_places_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_remove_local_inventories_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_remove_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_set_inventory_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_set_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_update_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_update_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_update_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_update_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_get_alert_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_get_alert_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_get_alert_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_get_alert_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_update_alert_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_update_alert_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_update_alert_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_update_alert_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_search_service_search_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_search_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_search_service_search_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_search_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_add_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_add_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_add_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_add_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_create_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_create_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_create_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_create_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_delete_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_delete_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_delete_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_delete_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_get_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_get_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_get_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_get_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_list_serving_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_list_serving_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_list_serving_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_list_serving_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_remove_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_remove_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_remove_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_remove_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_update_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_update_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_update_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_update_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_export_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_export_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_rejoin_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_rejoin_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/tests/__init__.py
+++ b/packages/google-cloud-retail/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/tests/unit/__init__.py
+++ b/packages/google-cloud-retail/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-retail/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/tests/unit/gapic/retail_v2/__init__.py
+++ b/packages/google-cloud-retail/tests/unit/gapic/retail_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/tests/unit/gapic/retail_v2alpha/__init__.py
+++ b/packages/google-cloud-retail/tests/unit/gapic/retail_v2alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/tests/unit/gapic/retail_v2beta/__init__.py
+++ b/packages/google-cloud-retail/tests/unit/gapic/retail_v2beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/.flake8
+++ b/packages/google-cloud-run/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/MANIFEST.in
+++ b/packages/google-cloud-run/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run/gapic_version.py
+++ b/packages/google-cloud-run/google/cloud/run/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/gapic_version.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/async_client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/async_client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/build.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/build.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/condition.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/condition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/container_status.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/container_status.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/execution.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/execution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/execution_template.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/execution_template.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/instance.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/instance_split.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/instance_split.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/job.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/k8s_min.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/k8s_min.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/revision.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/revision.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/revision_template.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/revision_template.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/service.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/status.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/status.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/task.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/task_template.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/task_template.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/traffic_target.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/traffic_target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/vendor_settings.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/vendor_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/worker_pool.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/worker_pool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/worker_pool_revision_template.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/worker_pool_revision_template.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_builds_submit_build_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_builds_submit_build_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_builds_submit_build_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_builds_submit_build_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_cancel_execution_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_cancel_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_delete_execution_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_delete_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_get_execution_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_get_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_get_execution_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_get_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_list_executions_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_list_executions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_list_executions_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_list_executions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_create_instance_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_delete_instance_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_get_instance_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_get_instance_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_list_instances_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_list_instances_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_start_instance_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_start_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_stop_instance_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_stop_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_create_job_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_delete_job_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_iam_policy_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_iam_policy_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_job_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_job_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_list_jobs_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_list_jobs_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_run_job_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_run_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_set_iam_policy_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_set_iam_policy_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_test_iam_permissions_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_test_iam_permissions_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_update_job_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_delete_revision_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_delete_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_get_revision_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_get_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_get_revision_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_get_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_list_revisions_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_list_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_list_revisions_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_list_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_create_service_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_delete_service_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_iam_policy_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_iam_policy_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_service_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_service_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_list_services_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_list_services_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_set_iam_policy_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_set_iam_policy_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_test_iam_permissions_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_update_service_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_get_task_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_get_task_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_list_tasks_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_list_tasks_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_create_worker_pool_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_create_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_delete_worker_pool_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_delete_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_iam_policy_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_iam_policy_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_worker_pool_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_worker_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_worker_pool_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_list_worker_pools_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_list_worker_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_list_worker_pools_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_list_worker_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_set_iam_policy_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_set_iam_policy_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_test_iam_permissions_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_test_iam_permissions_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_update_worker_pool_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_update_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/tests/__init__.py
+++ b/packages/google-cloud-run/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/tests/unit/__init__.py
+++ b/packages/google-cloud-run/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-run/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/tests/unit/gapic/run_v2/__init__.py
+++ b/packages/google-cloud-run/tests/unit/gapic/run_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/.flake8
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/MANIFEST.in
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt/gapic_version.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/gapic_version.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/async_client.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/client.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/pagers.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/base.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/grpc.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/rest.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/rest_base.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/async_client.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/client.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/pagers.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/base.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/grpc.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/grpc_asyncio.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/rest.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/rest_base.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/common.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/deployments_resources.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/deployments_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/deployments_service.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/deployments_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/rollouts_resources.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/rollouts_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/rollouts_service.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/rollouts_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_release_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_release_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_saas_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_saas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_saas_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_saas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_tenant_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_tenant_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_operation_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_operation_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_release_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_release_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_saas_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_saas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_saas_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_saas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_tenant_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_tenant_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_operation_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_operation_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_release_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_release_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_saas_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_saas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_saas_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_saas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_tenant_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_tenant_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_operation_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_operation_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_releases_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_releases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_releases_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_releases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_saas_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_saas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_saas_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_saas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_tenants_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_tenants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_tenants_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_tenants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_kinds_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_kinds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_kinds_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_kinds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_operations_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_operations_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_units_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_units_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_units_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_release_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_release_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_saas_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_saas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_saas_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_saas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_tenant_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_tenant_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_operation_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_operation_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollout_kinds_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollout_kinds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollout_kinds_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollout_kinds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollouts_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollouts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollouts_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollouts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/tests/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/tests/unit/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/tests/unit/gapic/saasplatform_saasservicemgmt_v1beta1/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/tests/unit/gapic/saasplatform_saasservicemgmt_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/.flake8
+++ b/packages/google-cloud-scheduler/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/MANIFEST.in
+++ b/packages/google-cloud-scheduler/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler/gapic_version.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/gapic_version.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/async_client.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/client.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/pagers.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/base.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/grpc.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/grpc_asyncio.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/rest.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/rest_base.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/cloudscheduler.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/cloudscheduler.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/job.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/target.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/gapic_version.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/async_client.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/client.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/pagers.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/base.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/grpc.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/grpc_asyncio.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/rest.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/rest_base.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/cloudscheduler.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/cloudscheduler.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/job.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/target.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_create_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_create_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_delete_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_delete_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_get_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_get_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_list_jobs_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_list_jobs_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_pause_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_pause_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_pause_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_pause_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_resume_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_resume_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_resume_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_resume_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_run_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_run_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_run_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_run_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_update_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_update_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_create_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_create_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_delete_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_delete_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_get_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_get_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_list_jobs_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_list_jobs_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_pause_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_pause_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_pause_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_pause_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_resume_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_resume_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_resume_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_resume_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_run_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_run_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_run_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_run_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_update_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_update_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/tests/__init__.py
+++ b/packages/google-cloud-scheduler/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/tests/unit/__init__.py
+++ b/packages/google-cloud-scheduler/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-scheduler/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/tests/unit/gapic/scheduler_v1/__init__.py
+++ b/packages/google-cloud-scheduler/tests/unit/gapic/scheduler_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/tests/unit/gapic/scheduler_v1beta1/__init__.py
+++ b/packages/google-cloud-scheduler/tests/unit/gapic/scheduler_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/.flake8
+++ b/packages/google-cloud-secret-manager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/MANIFEST.in
+++ b/packages/google-cloud-secret-manager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager/gapic_version.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/gapic_version.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/async_client.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/client.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/pagers.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/base.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/grpc.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/rest.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/rest_base.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/types/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/types/resources.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/types/service.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/gapic_version.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/async_client.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/client.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/pagers.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/base.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/grpc.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/rest.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/rest_base.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/types/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/types/resources.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/types/service.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/gapic_version.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/async_client.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/client.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/pagers.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/base.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/grpc.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/rest.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/rest_base.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/types/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/types/resources.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/types/service.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_access_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_access_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_access_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_access_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_add_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_add_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_add_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_add_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_create_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_create_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_create_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_create_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_delete_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_delete_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_delete_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_delete_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_destroy_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_destroy_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_destroy_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_destroy_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_disable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_disable_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_disable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_disable_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_enable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_enable_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_enable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_enable_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secret_versions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secret_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secret_versions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secret_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_set_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_update_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_update_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_update_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_update_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_access_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_access_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_access_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_access_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_add_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_add_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_add_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_add_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_create_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_create_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_create_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_create_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_delete_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_delete_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_delete_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_delete_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_destroy_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_destroy_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_destroy_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_destroy_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_disable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_disable_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_disable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_disable_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_enable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_enable_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_enable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_enable_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secret_versions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secret_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secret_versions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secret_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secrets_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secrets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secrets_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secrets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_set_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_update_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_update_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_update_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_update_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_access_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_access_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_access_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_access_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_add_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_add_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_add_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_add_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_create_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_create_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_create_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_create_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_delete_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_delete_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_delete_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_delete_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_destroy_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_destroy_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_destroy_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_destroy_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_disable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_disable_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_disable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_disable_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_enable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_enable_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_enable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_enable_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secret_versions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secret_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secret_versions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secret_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secrets_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secrets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secrets_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secrets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_set_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_update_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_update_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_update_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_update_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/tests/__init__.py
+++ b/packages/google-cloud-secret-manager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/tests/unit/__init__.py
+++ b/packages/google-cloud-secret-manager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-secret-manager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/tests/unit/gapic/secretmanager_v1/__init__.py
+++ b/packages/google-cloud-secret-manager/tests/unit/gapic/secretmanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/tests/unit/gapic/secretmanager_v1beta1/__init__.py
+++ b/packages/google-cloud-secret-manager/tests/unit/gapic/secretmanager_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/tests/unit/gapic/secretmanager_v1beta2/__init__.py
+++ b/packages/google-cloud-secret-manager/tests/unit/gapic/secretmanager_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/.flake8
+++ b/packages/google-cloud-securesourcemanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/MANIFEST.in
+++ b/packages/google-cloud-securesourcemanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager/__init__.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager/gapic_version.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/gapic_version.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/__init__.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/__init__.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/client.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/pagers.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/__init__.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/base.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/grpc.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/rest.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/rest_base.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/types/__init__.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/types/secure_source_manager.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/types/secure_source_manager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_batch_create_pull_request_comments_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_batch_create_pull_request_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_close_issue_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_close_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_close_pull_request_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_close_pull_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_branch_rule_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_branch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_hook_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_hook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_instance_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_issue_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_issue_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_issue_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_pull_request_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_pull_request_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_pull_request_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_pull_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_repository_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_branch_rule_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_branch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_hook_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_hook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_instance_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_issue_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_issue_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_issue_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_pull_request_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_pull_request_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_repository_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_blob_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_blob_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_blob_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_blob_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_tree_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_tree_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_tree_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_tree_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_branch_rule_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_branch_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_branch_rule_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_branch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_hook_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_hook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_hook_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_hook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_iam_policy_repo_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_iam_policy_repo_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_iam_policy_repo_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_iam_policy_repo_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_instance_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_instance_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_comment_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_comment_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_repository_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_repository_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_branch_rules_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_branch_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_branch_rules_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_branch_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_hooks_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_hooks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_hooks_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_hooks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_instances_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_instances_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issue_comments_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issue_comments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issue_comments_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issue_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issues_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issues_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_comments_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_comments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_comments_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_file_diffs_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_file_diffs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_file_diffs_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_file_diffs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_requests_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_requests_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_requests_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_requests_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_repositories_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_repositories_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_merge_pull_request_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_merge_pull_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_open_issue_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_open_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_open_pull_request_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_open_pull_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_resolve_pull_request_comments_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_resolve_pull_request_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_set_iam_policy_repo_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_set_iam_policy_repo_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_set_iam_policy_repo_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_set_iam_policy_repo_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_test_iam_permissions_repo_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_test_iam_permissions_repo_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_test_iam_permissions_repo_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_test_iam_permissions_repo_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_unresolve_pull_request_comments_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_unresolve_pull_request_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_branch_rule_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_branch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_hook_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_hook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_issue_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_issue_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_issue_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_pull_request_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_pull_request_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_pull_request_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_pull_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_repository_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/tests/__init__.py
+++ b/packages/google-cloud-securesourcemanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/tests/unit/__init__.py
+++ b/packages/google-cloud-securesourcemanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-securesourcemanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/tests/unit/gapic/securesourcemanager_v1/__init__.py
+++ b/packages/google-cloud-securesourcemanager/tests/unit/gapic/securesourcemanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/.flake8
+++ b/packages/google-cloud-security-publicca/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/MANIFEST.in
+++ b/packages/google-cloud-security-publicca/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca/gapic_version.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/gapic_version.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/async_client.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/client.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/base.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/grpc.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/rest.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/rest_base.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/types/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/types/resources.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/types/service.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/gapic_version.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/async_client.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/client.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/base.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/grpc.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/rest.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/rest_base.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/types/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/types/resources.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/types/service.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1_generated_public_certificate_authority_service_create_external_account_key_async.py
+++ b/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1_generated_public_certificate_authority_service_create_external_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1_generated_public_certificate_authority_service_create_external_account_key_sync.py
+++ b/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1_generated_public_certificate_authority_service_create_external_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1beta1_generated_public_certificate_authority_service_create_external_account_key_async.py
+++ b/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1beta1_generated_public_certificate_authority_service_create_external_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1beta1_generated_public_certificate_authority_service_create_external_account_key_sync.py
+++ b/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1beta1_generated_public_certificate_authority_service_create_external_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/tests/__init__.py
+++ b/packages/google-cloud-security-publicca/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/tests/unit/__init__.py
+++ b/packages/google-cloud-security-publicca/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-security-publicca/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/tests/unit/gapic/publicca_v1/__init__.py
+++ b/packages/google-cloud-security-publicca/tests/unit/gapic/publicca_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/tests/unit/gapic/publicca_v1beta1/__init__.py
+++ b/packages/google-cloud-security-publicca/tests/unit/gapic/publicca_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/.flake8
+++ b/packages/google-cloud-securitycenter/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/MANIFEST.in
+++ b/packages/google-cloud-securitycenter/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter/gapic_version.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/gapic_version.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/client.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/pagers.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/grpc.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/grpc_asyncio.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/rest.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/rest_base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/access.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/access.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/application.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/application.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/asset.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/asset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/attack_exposure.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/attack_exposure.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/attack_path.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/attack_path.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/backup_disaster_recovery.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/backup_disaster_recovery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/bigquery_export.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/bigquery_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/chokepoint.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/chokepoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/cloud_armor.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/cloud_armor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/cloud_dlp_data_profile.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/cloud_dlp_data_profile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/cloud_dlp_inspection.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/cloud_dlp_inspection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/compliance.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/compliance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/connection.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/contact_details.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/contact_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/container.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/container.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/database.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/database.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/effective_event_threat_detection_custom_module.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/effective_event_threat_detection_custom_module.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/effective_security_health_analytics_custom_module.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/effective_security_health_analytics_custom_module.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/event_threat_detection_custom_module.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/event_threat_detection_custom_module.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/event_threat_detection_custom_module_validation_errors.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/event_threat_detection_custom_module_validation_errors.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/exfiltration.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/exfiltration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/external_exposure.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/external_exposure.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/external_system.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/external_system.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/file.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/finding.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/folder.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/folder.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/group_membership.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/group_membership.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/iam_binding.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/iam_binding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/indicator.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/indicator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/kernel_rootkit.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/kernel_rootkit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/kubernetes.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/kubernetes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/label.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/label.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/load_balancer.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/load_balancer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/log_entry.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/log_entry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/mitre_attack.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/mitre_attack.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/mute_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/mute_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/notebook.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/notebook.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/notification_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/notification_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/notification_message.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/notification_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/org_policy.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/org_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/organization_settings.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/organization_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/process.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/process.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/resource.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/resource_value_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/resource_value_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/run_asset_discovery_response.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/run_asset_discovery_response.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_health_analytics_custom_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_health_analytics_custom_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_health_analytics_custom_module.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_health_analytics_custom_module.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_marks.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_marks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_posture.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_posture.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/securitycenter_service.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/securitycenter_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/simulation.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/simulation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/source.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/toxic_combination.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/toxic_combination.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/valued_resource.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/valued_resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/vulnerability.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/vulnerability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/gapic_version.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/client.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/pagers.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/grpc.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/grpc_asyncio.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/rest.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/rest_base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/asset.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/asset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/finding.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/organization_settings.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/organization_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/run_asset_discovery_response.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/run_asset_discovery_response.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/security_marks.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/security_marks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/securitycenter_service.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/securitycenter_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/source.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/gapic_version.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/client.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/pagers.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/grpc.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/grpc_asyncio.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/rest.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/rest_base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/asset.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/asset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/finding.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/folder.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/folder.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/notification_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/notification_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/notification_message.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/notification_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/organization_settings.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/organization_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/resource.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/run_asset_discovery_response.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/run_asset_discovery_response.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/security_marks.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/security_marks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/securitycenter_service.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/securitycenter_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/source.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/gapic_version.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/client.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/pagers.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/grpc.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/grpc_asyncio.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/rest.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/rest_base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/access.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/access.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/affected_resources.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/affected_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/ai_model.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/ai_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/application.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/application.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/attack_exposure.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/attack_exposure.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/attack_path.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/attack_path.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/backup_disaster_recovery.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/backup_disaster_recovery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/bigquery_export.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/bigquery_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/chokepoint.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/chokepoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/cloud_armor.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/cloud_armor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/cloud_dlp_data_profile.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/cloud_dlp_data_profile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/cloud_dlp_inspection.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/cloud_dlp_inspection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/compliance.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/compliance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/connection.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/contact_details.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/contact_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/container.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/container.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/data_access_event.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/data_access_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/data_flow_event.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/data_flow_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/data_retention_deletion_event.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/data_retention_deletion_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/database.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/database.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/disk.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/disk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/exfiltration.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/exfiltration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/external_system.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/external_system.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/file.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/finding.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/folder.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/folder.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/group_membership.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/group_membership.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/iam_binding.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/iam_binding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/indicator.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/indicator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/ip_rules.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/ip_rules.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/job.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/kernel_rootkit.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/kernel_rootkit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/kubernetes.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/kubernetes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/label.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/label.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/load_balancer.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/load_balancer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/log_entry.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/log_entry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/mitre_attack.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/mitre_attack.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/mute_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/mute_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/network.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/network.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/notebook.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/notebook.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/notification_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/notification_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/notification_message.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/notification_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/org_policy.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/org_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/process.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/process.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/resource.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/resource_value_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/resource_value_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/security_marks.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/security_marks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/security_posture.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/security_posture.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/securitycenter_service.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/securitycenter_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/simulation.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/simulation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/source.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/toxic_combination.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/toxic_combination.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/valued_resource.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/valued_resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/vertex_ai.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/vertex_ai.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/vulnerability.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/vulnerability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_batch_create_resource_value_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_batch_create_resource_value_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_batch_create_resource_value_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_batch_create_resource_value_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_bulk_mute_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_bulk_mute_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_resource_value_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_resource_value_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_resource_value_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_resource_value_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_organization_settings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_organization_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_organization_settings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_organization_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_resource_value_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_resource_value_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_resource_value_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_resource_value_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_simulation_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_simulation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_simulation_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_simulation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_valued_resource_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_valued_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_valued_resource_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_valued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_assets_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_assets_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_assets_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_assets_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_attack_paths_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_attack_paths_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_attack_paths_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_attack_paths_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_big_query_exports_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_big_query_exports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_big_query_exports_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_big_query_exports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_event_threat_detection_custom_modules_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_event_threat_detection_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_event_threat_detection_custom_modules_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_event_threat_detection_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_security_health_analytics_custom_modules_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_security_health_analytics_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_security_health_analytics_custom_modules_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_security_health_analytics_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_event_threat_detection_custom_modules_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_event_threat_detection_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_event_threat_detection_custom_modules_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_event_threat_detection_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_security_health_analytics_custom_modules_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_security_health_analytics_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_security_health_analytics_custom_modules_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_security_health_analytics_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_event_threat_detection_custom_modules_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_event_threat_detection_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_event_threat_detection_custom_modules_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_event_threat_detection_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_mute_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_mute_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_mute_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_mute_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_notification_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_notification_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_notification_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_notification_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_resource_value_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_resource_value_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_resource_value_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_resource_value_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_security_health_analytics_custom_modules_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_security_health_analytics_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_security_health_analytics_custom_modules_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_security_health_analytics_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_sources_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_sources_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_valued_resources_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_valued_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_valued_resources_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_valued_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_run_asset_discovery_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_run_asset_discovery_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_finding_state_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_finding_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_finding_state_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_finding_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_mute_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_mute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_mute_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_mute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_simulate_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_simulate_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_simulate_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_simulate_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_test_iam_permissions_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_test_iam_permissions_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_external_system_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_external_system_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_external_system_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_external_system_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_organization_settings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_organization_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_organization_settings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_organization_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_resource_value_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_resource_value_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_resource_value_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_resource_value_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_marks_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_marks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_marks_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_marks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_validate_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_validate_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_validate_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_validate_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_organization_settings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_organization_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_organization_settings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_organization_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_assets_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_assets_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_assets_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_assets_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_sources_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_sources_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_run_asset_discovery_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_run_asset_discovery_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_finding_state_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_finding_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_finding_state_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_finding_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_test_iam_permissions_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_test_iam_permissions_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_organization_settings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_organization_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_organization_settings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_organization_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_security_marks_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_security_marks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_security_marks_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_security_marks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_delete_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_delete_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_delete_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_delete_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_organization_settings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_organization_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_organization_settings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_organization_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_assets_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_assets_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_assets_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_assets_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_notification_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_notification_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_notification_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_notification_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_sources_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_sources_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_run_asset_discovery_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_run_asset_discovery_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_finding_state_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_finding_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_finding_state_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_finding_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_test_iam_permissions_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_test_iam_permissions_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_organization_settings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_organization_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_organization_settings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_organization_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_security_marks_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_security_marks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_security_marks_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_security_marks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_batch_create_resource_value_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_batch_create_resource_value_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_batch_create_resource_value_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_batch_create_resource_value_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_bulk_mute_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_bulk_mute_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_resource_value_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_resource_value_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_resource_value_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_resource_value_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_resource_value_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_resource_value_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_resource_value_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_resource_value_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_simulation_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_simulation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_simulation_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_simulation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_valued_resource_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_valued_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_valued_resource_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_valued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_group_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_group_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_group_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_group_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_attack_paths_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_attack_paths_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_attack_paths_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_attack_paths_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_big_query_exports_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_big_query_exports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_big_query_exports_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_big_query_exports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_mute_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_mute_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_mute_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_mute_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_notification_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_notification_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_notification_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_notification_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_resource_value_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_resource_value_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_resource_value_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_resource_value_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_sources_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_sources_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_valued_resources_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_valued_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_valued_resources_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_valued_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_finding_state_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_finding_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_finding_state_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_finding_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_mute_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_mute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_mute_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_mute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_test_iam_permissions_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_test_iam_permissions_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_external_system_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_external_system_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_external_system_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_external_system_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_resource_value_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_resource_value_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_resource_value_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_resource_value_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_security_marks_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_security_marks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_security_marks_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_security_marks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/unit/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v1/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v1beta1/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v1p1beta1/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v1p1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v2/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/.flake8
+++ b/packages/google-cloud-securitycentermanagement/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/MANIFEST.in
+++ b/packages/google-cloud-securitycentermanagement/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement/gapic_version.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/gapic_version.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/async_client.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/client.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/pagers.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/base.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/grpc.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/grpc_asyncio.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/rest.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/rest_base.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_center_service_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_center_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_center_service_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_center_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_event_threat_detection_custom_modules_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_event_threat_detection_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_event_threat_detection_custom_modules_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_event_threat_detection_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_security_health_analytics_custom_modules_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_security_health_analytics_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_security_health_analytics_custom_modules_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_security_health_analytics_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_event_threat_detection_custom_modules_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_event_threat_detection_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_event_threat_detection_custom_modules_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_event_threat_detection_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_security_health_analytics_custom_modules_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_security_health_analytics_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_security_health_analytics_custom_modules_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_security_health_analytics_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_event_threat_detection_custom_modules_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_event_threat_detection_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_event_threat_detection_custom_modules_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_event_threat_detection_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_center_services_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_center_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_center_services_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_center_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_health_analytics_custom_modules_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_health_analytics_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_health_analytics_custom_modules_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_health_analytics_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_simulate_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_simulate_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_simulate_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_simulate_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_center_service_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_center_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_center_service_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_center_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_validate_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_validate_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_validate_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_validate_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/tests/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/tests/unit/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/tests/unit/gapic/securitycentermanagement_v1/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/tests/unit/gapic/securitycentermanagement_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/.flake8
+++ b/packages/google-cloud-service-control/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/MANIFEST.in
+++ b/packages/google-cloud-service-control/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol/gapic_version.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/gapic_version.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/async_client.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/client.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/base.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/grpc.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/rest.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/rest_base.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/async_client.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/client.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/base.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/grpc.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/rest.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/rest_base.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/check_error.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/check_error.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/distribution.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/distribution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/http_request.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/http_request.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/log_entry.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/log_entry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/metric_value.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/metric_value.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/operation.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/operation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/quota_controller.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/quota_controller.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/gapic_version.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/async_client.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/client.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/base.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/grpc.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/rest.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/rest_base.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/types/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/types/service_controller.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/types/service_controller.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_quota_controller_allocate_quota_async.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_quota_controller_allocate_quota_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_quota_controller_allocate_quota_sync.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_quota_controller_allocate_quota_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_check_async.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_check_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_check_sync.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_report_async.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_report_sync.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_check_async.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_check_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_check_sync.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_report_async.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_report_sync.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/tests/__init__.py
+++ b/packages/google-cloud-service-control/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/tests/unit/__init__.py
+++ b/packages/google-cloud-service-control/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-service-control/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/tests/unit/gapic/servicecontrol_v1/__init__.py
+++ b/packages/google-cloud-service-control/tests/unit/gapic/servicecontrol_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/tests/unit/gapic/servicecontrol_v2/__init__.py
+++ b/packages/google-cloud-service-control/tests/unit/gapic/servicecontrol_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/.flake8
+++ b/packages/google-cloud-service-directory/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/MANIFEST.in
+++ b/packages/google-cloud-service-directory/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory/gapic_version.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/gapic_version.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/async_client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/grpc.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/rest.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/rest_base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/async_client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/pagers.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/grpc.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/rest.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/rest_base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/endpoint.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/endpoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/lookup_service.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/lookup_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/namespace.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/namespace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/registration_service.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/registration_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/service.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/gapic_version.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/async_client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/grpc.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/rest.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/rest_base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/async_client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/pagers.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/grpc.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/rest.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/rest_base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/endpoint.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/endpoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/lookup_service.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/lookup_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/namespace.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/namespace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/registration_service.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/registration_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/service.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_lookup_service_resolve_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_lookup_service_resolve_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_lookup_service_resolve_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_lookup_service_resolve_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_iam_policy_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_endpoints_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_endpoints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_endpoints_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_namespaces_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_namespaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_namespaces_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_namespaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_services_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_services_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_set_iam_policy_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_lookup_service_resolve_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_lookup_service_resolve_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_lookup_service_resolve_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_lookup_service_resolve_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_iam_policy_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_endpoints_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_endpoints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_endpoints_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_namespaces_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_namespaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_namespaces_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_namespaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_services_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_services_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_set_iam_policy_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/tests/__init__.py
+++ b/packages/google-cloud-service-directory/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/tests/unit/__init__.py
+++ b/packages/google-cloud-service-directory/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-service-directory/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/tests/unit/gapic/servicedirectory_v1/__init__.py
+++ b/packages/google-cloud-service-directory/tests/unit/gapic/servicedirectory_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/tests/unit/gapic/servicedirectory_v1beta1/__init__.py
+++ b/packages/google-cloud-service-directory/tests/unit/gapic/servicedirectory_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/.flake8
+++ b/packages/google-cloud-service-management/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/MANIFEST.in
+++ b/packages/google-cloud-service-management/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement/__init__.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement/gapic_version.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/gapic_version.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/__init__.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/__init__.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/client.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/pagers.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/__init__.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/base.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/grpc.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/rest.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/rest_base.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/types/__init__.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/types/resources.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/types/servicemanager.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/types/servicemanager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_config_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_config_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_rollout_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_delete_service_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_generate_config_report_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_generate_config_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_generate_config_report_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_generate_config_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_config_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_config_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_rollout_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_rollout_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_configs_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_configs_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_rollouts_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_rollouts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_rollouts_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_rollouts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_services_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_services_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_submit_config_source_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_submit_config_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_undelete_service_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_undelete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/tests/__init__.py
+++ b/packages/google-cloud-service-management/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/tests/unit/__init__.py
+++ b/packages/google-cloud-service-management/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-service-management/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/tests/unit/gapic/servicemanagement_v1/__init__.py
+++ b/packages/google-cloud-service-management/tests/unit/gapic/servicemanagement_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/.flake8
+++ b/packages/google-cloud-service-usage/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/MANIFEST.in
+++ b/packages/google-cloud-service-usage/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage/__init__.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage/gapic_version.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/gapic_version.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/__init__.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/__init__.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/client.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/pagers.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/__init__.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/base.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/grpc.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/rest.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/rest_base.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/types/__init__.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/types/resources.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/types/serviceusage.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/types/serviceusage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_batch_enable_services_sync.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_batch_enable_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_batch_get_services_async.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_batch_get_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_batch_get_services_sync.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_batch_get_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_disable_service_sync.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_disable_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_enable_service_sync.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_enable_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_get_service_async.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_get_service_sync.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_list_services_async.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_list_services_sync.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/tests/__init__.py
+++ b/packages/google-cloud-service-usage/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/tests/unit/__init__.py
+++ b/packages/google-cloud-service-usage/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-service-usage/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/tests/unit/gapic/service_usage_v1/__init__.py
+++ b/packages/google-cloud-service-usage/tests/unit/gapic/service_usage_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/.flake8
+++ b/packages/google-cloud-servicehealth/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/MANIFEST.in
+++ b/packages/google-cloud-servicehealth/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth/__init__.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth/gapic_version.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/gapic_version.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/__init__.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/__init__.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/async_client.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/client.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/pagers.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/__init__.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/base.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/grpc.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/grpc_asyncio.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/rest.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/rest_base.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/types/__init__.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/types/event_resources.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/types/event_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/types/event_service.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/types/event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_event_async.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_event_sync.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_event_async.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_event_sync.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_impact_async.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_impact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_impact_sync.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_impact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_events_async.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_events_sync.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_events_async.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_events_sync.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_impacts_async.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_impacts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_impacts_sync.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_impacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/tests/__init__.py
+++ b/packages/google-cloud-servicehealth/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/tests/unit/__init__.py
+++ b/packages/google-cloud-servicehealth/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-servicehealth/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/tests/unit/gapic/servicehealth_v1/__init__.py
+++ b/packages/google-cloud-servicehealth/tests/unit/gapic/servicehealth_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/.flake8
+++ b/packages/google-cloud-shell/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/MANIFEST.in
+++ b/packages/google-cloud-shell/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell/__init__.py
+++ b/packages/google-cloud-shell/google/cloud/shell/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell/gapic_version.py
+++ b/packages/google-cloud-shell/google/cloud/shell/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/gapic_version.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/__init__.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/__init__.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/client.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/__init__.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/base.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/grpc.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/rest.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/rest_base.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/types/__init__.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/types/cloudshell.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/types/cloudshell.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_add_public_key_sync.py
+++ b/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_add_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_authorize_environment_sync.py
+++ b/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_authorize_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_get_environment_async.py
+++ b/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_get_environment_sync.py
+++ b/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_remove_public_key_sync.py
+++ b/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_remove_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_start_environment_sync.py
+++ b/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_start_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/tests/__init__.py
+++ b/packages/google-cloud-shell/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/tests/unit/__init__.py
+++ b/packages/google-cloud-shell/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-shell/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/tests/unit/gapic/shell_v1/__init__.py
+++ b/packages/google-cloud-shell/tests/unit/gapic/shell_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/.flake8
+++ b/packages/google-cloud-source-context/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/MANIFEST.in
+++ b/packages/google-cloud-source-context/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/google/cloud/source_context/__init__.py
+++ b/packages/google-cloud-source-context/google/cloud/source_context/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/google/cloud/source_context/gapic_version.py
+++ b/packages/google-cloud-source-context/google/cloud/source_context/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/google/cloud/source_context_v1/gapic_version.py
+++ b/packages/google-cloud-source-context/google/cloud/source_context_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/google/cloud/source_context_v1/services/__init__.py
+++ b/packages/google-cloud-source-context/google/cloud/source_context_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/google/cloud/source_context_v1/types/__init__.py
+++ b/packages/google-cloud-source-context/google/cloud/source_context_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/google/cloud/source_context_v1/types/source_context.py
+++ b/packages/google-cloud-source-context/google/cloud/source_context_v1/types/source_context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/tests/__init__.py
+++ b/packages/google-cloud-source-context/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/tests/unit/__init__.py
+++ b/packages/google-cloud-source-context/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-source-context/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/tests/unit/gapic/source_context_v1/__init__.py
+++ b/packages/google-cloud-source-context/tests/unit/gapic/source_context_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/.flake8
+++ b/packages/google-cloud-spanner/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/MANIFEST.in
+++ b/packages/google-cloud-spanner/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/client.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/pagers.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/base.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/grpc.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/rest.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/rest_base.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/backup.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/backup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/backup_schedule.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/backup_schedule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/common.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/spanner_database_admin.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/spanner_database_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/client.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/pagers.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/base.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/grpc.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/rest.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/rest_base.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/types/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/types/common.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/types/spanner_instance_admin.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/types/spanner_instance_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/async_client.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/client.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/pagers.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/base.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/grpc.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/grpc_asyncio.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/rest.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/rest_base.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/change_stream.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/change_stream.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/commit_response.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/commit_response.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/keys.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/keys.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/location.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/location.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/mutation.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/mutation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/query_plan.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/query_plan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/result_set.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/result_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/spanner.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/spanner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/transaction.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/transaction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/type.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_add_split_points_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_add_split_points_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_add_split_points_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_add_split_points_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_copy_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_copy_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_schedule_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_schedule_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_schedule_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_schedule_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_drop_database_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_drop_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_drop_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_drop_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_schedule_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_schedule_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_ddl_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_ddl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_ddl_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_ddl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_iam_policy_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_iam_policy_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_internal_update_graph_operation_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_internal_update_graph_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_internal_update_graph_operation_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_internal_update_graph_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_operations_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_operations_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_schedules_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_schedules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_schedules_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_schedules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backups_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backups_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_operations_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_operations_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_roles_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_roles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_roles_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_roles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_databases_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_databases_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_restore_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_restore_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_set_iam_policy_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_set_iam_policy_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_test_iam_permissions_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_test_iam_permissions_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_schedule_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_schedule_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_ddl_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_ddl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_config_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_partition_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_config_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_config_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_partition_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_partition_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_partition_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_iam_policy_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_iam_policy_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_config_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_config_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_partition_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_partition_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_partition_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_config_operations_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_config_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_config_operations_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_config_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_configs_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_configs_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partition_operations_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partition_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partition_operations_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partition_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partitions_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partitions_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instances_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instances_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_move_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_move_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_set_iam_policy_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_set_iam_policy_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_test_iam_permissions_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_test_iam_permissions_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_config_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_partition_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_create_sessions_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_create_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_create_sessions_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_create_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_write_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_write_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_write_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_write_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_begin_transaction_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_begin_transaction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_begin_transaction_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_begin_transaction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_commit_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_commit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_commit_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_commit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_create_session_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_create_session_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_delete_session_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_delete_session_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_batch_dml_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_batch_dml_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_batch_dml_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_batch_dml_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_sql_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_sql_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_sql_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_streaming_sql_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_streaming_sql_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_streaming_sql_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_streaming_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_fetch_cache_update_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_fetch_cache_update_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_fetch_cache_update_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_fetch_cache_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_get_session_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_get_session_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_list_sessions_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_list_sessions_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_query_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_query_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_read_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_read_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_read_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_read_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_read_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_read_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_read_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_read_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_rollback_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_rollback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_rollback_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_rollback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_streaming_read_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_streaming_read_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_streaming_read_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_streaming_read_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/tests/__init__.py
+++ b/packages/google-cloud-spanner/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/tests/unit/__init__.py
+++ b/packages/google-cloud-spanner/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-spanner/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/tests/unit/gapic/spanner_admin_database_v1/__init__.py
+++ b/packages/google-cloud-spanner/tests/unit/gapic/spanner_admin_database_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/tests/unit/gapic/spanner_admin_instance_v1/__init__.py
+++ b/packages/google-cloud-spanner/tests/unit/gapic/spanner_admin_instance_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/tests/unit/gapic/spanner_v1/__init__.py
+++ b/packages/google-cloud-spanner/tests/unit/gapic/spanner_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/.flake8
+++ b/packages/google-cloud-speech/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/MANIFEST.in
+++ b/packages/google-cloud-speech/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech/gapic_version.py
+++ b/packages/google-cloud-speech/google/cloud/speech/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/gapic_version.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/async_client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/pagers.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/grpc.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/rest.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/rest_base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/grpc.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/grpc_asyncio.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/rest.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/rest_base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/types/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/types/cloud_speech.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/types/cloud_speech.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/types/cloud_speech_adaptation.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/types/cloud_speech_adaptation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/types/resource.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/gapic_version.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/async_client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/pagers.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/grpc.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/rest.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/rest_base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/grpc.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/grpc_asyncio.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/rest.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/rest_base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/cloud_speech.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/cloud_speech.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/cloud_speech_adaptation.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/cloud_speech_adaptation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/resource.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/gapic_version.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/pagers.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/grpc.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/grpc_asyncio.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/rest.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/rest_base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/types/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/types/cloud_speech.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/types/cloud_speech.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/types/locations_metadata.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/types/locations_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_custom_classes_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_custom_classes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_custom_classes_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_custom_classes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_long_running_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_long_running_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_recognize_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_recognize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_streaming_recognize_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_streaming_recognize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_streaming_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_streaming_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_custom_classes_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_custom_classes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_custom_classes_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_custom_classes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_long_running_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_long_running_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_recognize_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_recognize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_streaming_recognize_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_streaming_recognize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_streaming_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_streaming_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_batch_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_batch_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_create_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_create_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_create_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_create_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_create_recognizer_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_create_recognizer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_delete_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_delete_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_delete_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_delete_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_delete_recognizer_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_delete_recognizer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_config_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_config_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_recognizer_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_recognizer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_recognizer_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_recognizer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_custom_classes_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_custom_classes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_custom_classes_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_custom_classes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_phrase_sets_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_phrase_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_phrase_sets_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_phrase_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_recognizers_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_recognizers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_recognizers_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_recognizers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_recognize_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_recognize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_streaming_recognize_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_streaming_recognize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_streaming_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_streaming_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_undelete_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_undelete_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_undelete_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_undelete_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_undelete_recognizer_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_undelete_recognizer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_config_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_config_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_recognizer_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_recognizer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/tests/__init__.py
+++ b/packages/google-cloud-speech/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/tests/unit/__init__.py
+++ b/packages/google-cloud-speech/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-speech/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/tests/unit/gapic/speech_v1/__init__.py
+++ b/packages/google-cloud-speech/tests/unit/gapic/speech_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/tests/unit/gapic/speech_v1p1beta1/__init__.py
+++ b/packages/google-cloud-speech/tests/unit/gapic/speech_v1p1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/tests/unit/gapic/speech_v2/__init__.py
+++ b/packages/google-cloud-speech/tests/unit/gapic/speech_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/.flake8
+++ b/packages/google-cloud-storage-control/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/MANIFEST.in
+++ b/packages/google-cloud-storage-control/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control/__init__.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control/gapic_version.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/gapic_version.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/__init__.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/__init__.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/client.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/pagers.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/__init__.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/base.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/grpc.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/grpc_asyncio.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/rest.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/rest_base.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/types/__init__.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/types/storage_control.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/types/storage_control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_anywhere_cache_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_anywhere_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_folder_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_managed_folder_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_managed_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_managed_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_managed_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_folder_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_folder_recursive_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_folder_recursive_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_managed_folder_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_managed_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_managed_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_managed_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_disable_anywhere_cache_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_disable_anywhere_cache_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_disable_anywhere_cache_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_disable_anywhere_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_anywhere_cache_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_anywhere_cache_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_anywhere_cache_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_anywhere_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_intelligence_config_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_intelligence_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_intelligence_config_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_intelligence_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_iam_policy_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_iam_policy_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_managed_folder_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_managed_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_managed_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_managed_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_organization_intelligence_config_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_organization_intelligence_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_organization_intelligence_config_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_organization_intelligence_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_project_intelligence_config_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_project_intelligence_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_project_intelligence_config_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_project_intelligence_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_storage_layout_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_storage_layout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_storage_layout_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_storage_layout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_anywhere_caches_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_anywhere_caches_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_anywhere_caches_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_anywhere_caches_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_folders_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_folders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_folders_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_folders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_managed_folders_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_managed_folders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_managed_folders_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_managed_folders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_pause_anywhere_cache_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_pause_anywhere_cache_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_pause_anywhere_cache_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_pause_anywhere_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_rename_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_rename_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_resume_anywhere_cache_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_resume_anywhere_cache_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_resume_anywhere_cache_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_resume_anywhere_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_set_iam_policy_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_set_iam_policy_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_test_iam_permissions_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_test_iam_permissions_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_anywhere_cache_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_anywhere_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_folder_intelligence_config_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_folder_intelligence_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_folder_intelligence_config_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_folder_intelligence_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_organization_intelligence_config_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_organization_intelligence_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_organization_intelligence_config_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_organization_intelligence_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_project_intelligence_config_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_project_intelligence_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_project_intelligence_config_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_project_intelligence_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/tests/__init__.py
+++ b/packages/google-cloud-storage-control/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/tests/unit/__init__.py
+++ b/packages/google-cloud-storage-control/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-storage-control/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/tests/unit/gapic/storage_control_v2/__init__.py
+++ b/packages/google-cloud-storage-control/tests/unit/gapic/storage_control_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/.flake8
+++ b/packages/google-cloud-storage-transfer/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/MANIFEST.in
+++ b/packages/google-cloud-storage-transfer/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer/__init__.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer/gapic_version.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/gapic_version.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/__init__.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/__init__.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/client.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/pagers.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/__init__.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/base.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/grpc.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/rest.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/rest_base.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/types/__init__.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/types/transfer.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/types/transfer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/types/transfer_types.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/types/transfer_types.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_agent_pool_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_agent_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_agent_pool_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_agent_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_transfer_job_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_transfer_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_transfer_job_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_transfer_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_agent_pool_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_agent_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_agent_pool_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_agent_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_transfer_job_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_transfer_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_transfer_job_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_transfer_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_agent_pool_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_agent_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_agent_pool_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_agent_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_google_service_account_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_google_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_google_service_account_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_google_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_transfer_job_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_transfer_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_transfer_job_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_transfer_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_agent_pools_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_agent_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_agent_pools_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_agent_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_transfer_jobs_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_transfer_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_transfer_jobs_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_transfer_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_pause_transfer_operation_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_pause_transfer_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_pause_transfer_operation_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_pause_transfer_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_resume_transfer_operation_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_resume_transfer_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_resume_transfer_operation_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_resume_transfer_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_run_transfer_job_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_run_transfer_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_agent_pool_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_agent_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_agent_pool_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_agent_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_transfer_job_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_transfer_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_transfer_job_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_transfer_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/tests/__init__.py
+++ b/packages/google-cloud-storage-transfer/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/tests/unit/__init__.py
+++ b/packages/google-cloud-storage-transfer/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-storage-transfer/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/tests/unit/gapic/storage_transfer_v1/__init__.py
+++ b/packages/google-cloud-storage-transfer/tests/unit/gapic/storage_transfer_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/.flake8
+++ b/packages/google-cloud-storage/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/MANIFEST.in
+++ b/packages/google-cloud-storage/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage/__init__.py
+++ b/packages/google-cloud-storage/google/cloud/_storage/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage/gapic_version.py
+++ b/packages/google-cloud-storage/google/cloud/_storage/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/gapic_version.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/__init__.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/__init__.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/async_client.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/client.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/pagers.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/__init__.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/base.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/grpc.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/grpc_asyncio.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/types/__init__.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/types/storage.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/types/storage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_read_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_read_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_read_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_read_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_write_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_write_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_write_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_write_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_cancel_resumable_write_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_cancel_resumable_write_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_cancel_resumable_write_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_cancel_resumable_write_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_compose_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_compose_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_compose_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_compose_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_create_bucket_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_create_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_create_bucket_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_create_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_bucket_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_bucket_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_bucket_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_bucket_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_iam_policy_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_iam_policy_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_buckets_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_buckets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_buckets_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_buckets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_objects_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_objects_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_lock_bucket_retention_policy_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_lock_bucket_retention_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_lock_bucket_retention_policy_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_lock_bucket_retention_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_move_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_move_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_move_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_move_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_query_write_status_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_query_write_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_query_write_status_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_query_write_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_read_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_read_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_read_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_read_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_restore_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_restore_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_restore_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_restore_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_rewrite_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_rewrite_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_rewrite_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_rewrite_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_set_iam_policy_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_set_iam_policy_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_start_resumable_write_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_start_resumable_write_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_start_resumable_write_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_start_resumable_write_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_test_iam_permissions_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_test_iam_permissions_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_bucket_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_bucket_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_write_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_write_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_write_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_write_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/tests/__init__.py
+++ b/packages/google-cloud-storage/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/tests/unit/__init__.py
+++ b/packages/google-cloud-storage/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-storage/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/tests/unit/gapic/_storage_v2/__init__.py
+++ b/packages/google-cloud-storage/tests/unit/gapic/_storage_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/.flake8
+++ b/packages/google-cloud-storagebatchoperations/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/MANIFEST.in
+++ b/packages/google-cloud-storagebatchoperations/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations/gapic_version.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/gapic_version.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/client.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/pagers.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/base.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/grpc.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/grpc_asyncio.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/rest.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/rest_base.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/types/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/types/storage_batch_operations.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/types/storage_batch_operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/types/storage_batch_operations_types.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/types/storage_batch_operations_types.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_cancel_job_async.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_cancel_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_cancel_job_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_cancel_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_create_job_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_delete_job_async.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_delete_job_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_bucket_operation_async.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_bucket_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_bucket_operation_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_bucket_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_job_async.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_job_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_bucket_operations_async.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_bucket_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_bucket_operations_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_bucket_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_jobs_async.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_jobs_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/tests/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/tests/unit/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/.flake8
+++ b/packages/google-cloud-storageinsights/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/MANIFEST.in
+++ b/packages/google-cloud-storageinsights/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights/__init__.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights/gapic_version.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/gapic_version.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/__init__.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/__init__.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/client.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/pagers.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/__init__.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/base.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/grpc.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/grpc_asyncio.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/rest.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/rest_base.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/types/__init__.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/types/storageinsights.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/types/storageinsights.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_create_dataset_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_create_dataset_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_create_report_config_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_create_report_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_create_report_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_create_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_delete_dataset_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_delete_dataset_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_delete_report_config_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_delete_report_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_delete_report_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_delete_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_dataset_config_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_dataset_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_dataset_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_dataset_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_config_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_detail_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_detail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_detail_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_detail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_link_dataset_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_link_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_dataset_configs_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_dataset_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_dataset_configs_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_dataset_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_configs_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_configs_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_details_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_details_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_unlink_dataset_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_unlink_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_update_dataset_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_update_dataset_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_update_report_config_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_update_report_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_update_report_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_update_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/tests/__init__.py
+++ b/packages/google-cloud-storageinsights/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/tests/unit/__init__.py
+++ b/packages/google-cloud-storageinsights/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-storageinsights/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/tests/unit/gapic/storageinsights_v1/__init__.py
+++ b/packages/google-cloud-storageinsights/tests/unit/gapic/storageinsights_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/.flake8
+++ b/packages/google-cloud-support/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/MANIFEST.in
+++ b/packages/google-cloud-support/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support/gapic_version.py
+++ b/packages/google-cloud-support/google/cloud/support/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/gapic_version.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/actor.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/actor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/attachment.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/attachment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/attachment_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/attachment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/case.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/case.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/case_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/case_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/comment.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/comment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/comment_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/comment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/escalation.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/escalation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/gapic_version.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/actor.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/actor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/attachment.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/attachment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/attachment_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/attachment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/case.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/case.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/case_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/case_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/comment.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/comment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/comment_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/comment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/content.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/email_message.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/email_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/escalation.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/escalation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/feed_item.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/feed_item.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/feed_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/feed_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_attachment_service_list_attachments_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_attachment_service_list_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_attachment_service_list_attachments_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_attachment_service_list_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_close_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_close_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_close_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_close_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_create_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_create_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_create_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_create_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_escalate_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_escalate_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_escalate_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_escalate_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_get_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_get_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_get_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_get_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_list_cases_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_list_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_list_cases_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_list_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_case_classifications_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_case_classifications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_case_classifications_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_case_classifications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_cases_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_cases_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_update_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_update_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_update_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_update_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_create_comment_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_create_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_create_comment_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_create_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_list_comments_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_list_comments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_list_comments_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_list_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_get_attachment_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_get_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_get_attachment_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_get_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_list_attachments_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_list_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_list_attachments_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_list_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_close_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_close_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_close_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_close_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_create_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_create_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_create_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_create_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_escalate_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_escalate_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_escalate_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_escalate_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_get_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_get_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_get_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_get_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_list_cases_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_list_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_list_cases_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_list_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_case_classifications_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_case_classifications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_case_classifications_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_case_classifications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_cases_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_cases_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_update_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_update_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_update_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_update_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_create_comment_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_create_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_create_comment_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_create_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_get_comment_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_get_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_get_comment_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_get_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_list_comments_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_list_comments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_list_comments_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_list_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_feed_service_show_feed_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_feed_service_show_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_feed_service_show_feed_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_feed_service_show_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/tests/__init__.py
+++ b/packages/google-cloud-support/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/tests/unit/__init__.py
+++ b/packages/google-cloud-support/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-support/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/tests/unit/gapic/support_v2/__init__.py
+++ b/packages/google-cloud-support/tests/unit/gapic/support_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/tests/unit/gapic/support_v2beta/__init__.py
+++ b/packages/google-cloud-support/tests/unit/gapic/support_v2beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/.flake8
+++ b/packages/google-cloud-talent/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/MANIFEST.in
+++ b/packages/google-cloud-talent/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent/gapic_version.py
+++ b/packages/google-cloud-talent/google/cloud/talent/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/gapic_version.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/pagers.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/pagers.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/pagers.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/common.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/company.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/company.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/company_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/company_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/completion_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/event.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/event_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/filters.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/filters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/histogram.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/histogram.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/job.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/job_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/job_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/tenant.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/tenant.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/tenant_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/tenant_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/gapic_version.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/pagers.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/pagers.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/pagers.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/batch.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/batch.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/common.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/company.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/company.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/company_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/company_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/completion_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/event.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/event_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/filters.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/filters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/histogram.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/histogram.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/job.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/job_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/job_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/tenant.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/tenant.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/tenant_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/tenant_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_create_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_create_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_create_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_create_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_delete_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_delete_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_delete_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_delete_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_get_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_get_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_get_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_get_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_list_companies_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_list_companies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_list_companies_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_list_companies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_update_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_update_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_update_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_update_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_completion_complete_query_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_completion_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_completion_complete_query_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_completion_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_event_service_create_client_event_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_event_service_create_client_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_event_service_create_client_event_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_event_service_create_client_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_batch_create_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_batch_create_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_batch_delete_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_batch_delete_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_batch_update_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_batch_update_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_create_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_create_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_delete_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_delete_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_get_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_get_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_list_jobs_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_list_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_for_alert_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_for_alert_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_for_alert_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_for_alert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_update_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_update_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_create_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_create_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_create_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_create_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_delete_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_delete_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_delete_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_delete_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_get_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_get_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_get_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_get_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_list_tenants_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_list_tenants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_list_tenants_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_list_tenants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_update_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_update_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_update_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_update_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_create_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_create_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_create_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_create_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_delete_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_delete_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_delete_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_delete_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_get_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_get_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_get_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_get_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_list_companies_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_list_companies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_list_companies_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_list_companies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_update_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_update_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_update_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_update_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_completion_complete_query_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_completion_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_completion_complete_query_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_completion_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_event_service_create_client_event_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_event_service_create_client_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_event_service_create_client_event_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_event_service_create_client_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_create_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_create_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_delete_jobs_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_delete_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_delete_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_delete_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_update_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_update_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_create_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_create_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_delete_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_delete_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_get_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_get_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_list_jobs_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_list_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_for_alert_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_for_alert_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_for_alert_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_for_alert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_update_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_update_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_create_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_create_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_create_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_create_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_delete_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_delete_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_delete_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_delete_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_get_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_get_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_get_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_get_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_list_tenants_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_list_tenants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_list_tenants_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_list_tenants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_update_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_update_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_update_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_update_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/tests/__init__.py
+++ b/packages/google-cloud-talent/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/tests/unit/__init__.py
+++ b/packages/google-cloud-talent/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-talent/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/tests/unit/gapic/talent_v4/__init__.py
+++ b/packages/google-cloud-talent/tests/unit/gapic/talent_v4/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/tests/unit/gapic/talent_v4beta1/__init__.py
+++ b/packages/google-cloud-talent/tests/unit/gapic/talent_v4beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/.flake8
+++ b/packages/google-cloud-tasks/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/MANIFEST.in
+++ b/packages/google-cloud-tasks/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks/gapic_version.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/gapic_version.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/async_client.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/client.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/pagers.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/base.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/grpc.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/rest.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/rest_base.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/types/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/types/cloudtasks.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/types/cloudtasks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/types/queue.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/types/queue.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/types/target.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/types/target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/types/task.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/types/task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/gapic_version.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/async_client.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/client.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/pagers.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/base.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/grpc.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/rest.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/rest_base.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/cloudtasks.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/cloudtasks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/old_target.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/old_target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/queue.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/queue.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/target.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/task.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/gapic_version.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/async_client.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/client.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/pagers.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/base.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/grpc.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/rest.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/rest_base.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/cloudtasks.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/cloudtasks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/queue.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/queue.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/target.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/task.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_iam_policy_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_iam_policy_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_queues_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_queues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_queues_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_queues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_tasks_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_tasks_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_pause_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_pause_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_pause_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_pause_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_purge_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_purge_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_purge_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_purge_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_resume_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_resume_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_resume_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_resume_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_run_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_run_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_run_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_run_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_set_iam_policy_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_set_iam_policy_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_test_iam_permissions_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_update_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_update_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_update_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_update_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_acknowledge_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_acknowledge_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_acknowledge_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_acknowledge_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_cancel_lease_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_cancel_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_cancel_lease_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_cancel_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_iam_policy_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_iam_policy_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_lease_tasks_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_lease_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_lease_tasks_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_lease_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_queues_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_queues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_queues_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_queues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_tasks_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_tasks_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_pause_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_pause_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_pause_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_pause_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_purge_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_purge_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_purge_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_purge_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_renew_lease_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_renew_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_renew_lease_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_renew_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_resume_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_resume_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_resume_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_resume_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_run_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_run_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_run_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_run_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_set_iam_policy_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_set_iam_policy_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_test_iam_permissions_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_update_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_update_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_update_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_update_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_upload_queue_yaml_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_upload_queue_yaml_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_upload_queue_yaml_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_upload_queue_yaml_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_iam_policy_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_iam_policy_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_queues_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_queues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_queues_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_queues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_tasks_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_tasks_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_pause_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_pause_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_pause_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_pause_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_purge_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_purge_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_purge_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_purge_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_resume_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_resume_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_resume_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_resume_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_run_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_run_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_run_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_run_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_set_iam_policy_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_set_iam_policy_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_test_iam_permissions_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_update_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_update_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_update_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_update_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/tests/__init__.py
+++ b/packages/google-cloud-tasks/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/tests/unit/__init__.py
+++ b/packages/google-cloud-tasks/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-tasks/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/tests/unit/gapic/tasks_v2/__init__.py
+++ b/packages/google-cloud-tasks/tests/unit/gapic/tasks_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/tests/unit/gapic/tasks_v2beta2/__init__.py
+++ b/packages/google-cloud-tasks/tests/unit/gapic/tasks_v2beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/tests/unit/gapic/tasks_v2beta3/__init__.py
+++ b/packages/google-cloud-tasks/tests/unit/gapic/tasks_v2beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/.flake8
+++ b/packages/google-cloud-telcoautomation/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/MANIFEST.in
+++ b/packages/google-cloud-telcoautomation/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation/gapic_version.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/gapic_version.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/client.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/pagers.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/base.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/grpc.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/rest.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/rest_base.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/types/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/types/telcoautomation.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/types/telcoautomation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/client.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/pagers.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/base.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/grpc.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/rest.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/rest_base.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/types/telcoautomation.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/types/telcoautomation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_hydrated_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_hydrated_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_hydrated_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_hydrated_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_approve_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_approve_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_approve_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_approve_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_compute_deployment_status_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_compute_deployment_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_compute_deployment_status_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_compute_deployment_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_edge_slm_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_edge_slm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_orchestration_cluster_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_orchestration_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_edge_slm_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_edge_slm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_orchestration_cluster_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_orchestration_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_blueprint_changes_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_blueprint_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_blueprint_changes_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_blueprint_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_deployment_changes_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_deployment_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_deployment_changes_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_deployment_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_edge_slm_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_edge_slm_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_edge_slm_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_edge_slm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_hydrated_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_hydrated_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_hydrated_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_hydrated_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_orchestration_cluster_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_orchestration_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_orchestration_cluster_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_orchestration_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_public_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_public_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_public_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_public_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprint_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprint_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprint_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprint_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprints_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprints_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployment_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployment_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployments_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployments_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_edge_slms_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_edge_slms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_edge_slms_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_edge_slms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_hydrated_deployments_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_hydrated_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_hydrated_deployments_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_hydrated_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_orchestration_clusters_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_orchestration_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_orchestration_clusters_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_orchestration_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_public_blueprints_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_public_blueprints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_public_blueprints_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_public_blueprints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_propose_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_propose_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_propose_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_propose_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_reject_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_reject_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_reject_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_reject_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_remove_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_remove_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_remove_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_remove_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_rollback_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_rollback_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_rollback_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_rollback_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_blueprint_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_blueprint_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_blueprint_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_blueprint_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_deployment_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_deployment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_deployment_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_deployment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_hydrated_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_hydrated_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_hydrated_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_hydrated_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_hydrated_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_hydrated_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_hydrated_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_hydrated_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_approve_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_approve_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_approve_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_approve_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_compute_deployment_status_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_compute_deployment_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_compute_deployment_status_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_compute_deployment_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_edge_slm_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_edge_slm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_orchestration_cluster_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_orchestration_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_edge_slm_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_edge_slm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_orchestration_cluster_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_orchestration_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_blueprint_changes_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_blueprint_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_blueprint_changes_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_blueprint_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_deployment_changes_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_deployment_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_deployment_changes_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_deployment_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_edge_slm_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_edge_slm_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_edge_slm_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_edge_slm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_hydrated_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_hydrated_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_hydrated_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_hydrated_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_orchestration_cluster_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_orchestration_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_orchestration_cluster_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_orchestration_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_public_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_public_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_public_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_public_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprint_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprint_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprint_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprint_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprints_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprints_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployment_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployment_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployments_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployments_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_edge_slms_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_edge_slms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_edge_slms_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_edge_slms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_hydrated_deployments_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_hydrated_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_hydrated_deployments_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_hydrated_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_orchestration_clusters_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_orchestration_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_orchestration_clusters_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_orchestration_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_public_blueprints_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_public_blueprints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_public_blueprints_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_public_blueprints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_propose_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_propose_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_propose_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_propose_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_reject_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_reject_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_reject_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_reject_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_remove_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_remove_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_remove_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_remove_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_rollback_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_rollback_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_rollback_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_rollback_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_blueprint_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_blueprint_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_blueprint_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_blueprint_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_deployment_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_deployment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_deployment_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_deployment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_hydrated_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_hydrated_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_hydrated_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_hydrated_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/tests/__init__.py
+++ b/packages/google-cloud-telcoautomation/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/tests/unit/__init__.py
+++ b/packages/google-cloud-telcoautomation/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-telcoautomation/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/tests/unit/gapic/telcoautomation_v1/__init__.py
+++ b/packages/google-cloud-telcoautomation/tests/unit/gapic/telcoautomation_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/tests/unit/gapic/telcoautomation_v1alpha1/__init__.py
+++ b/packages/google-cloud-telcoautomation/tests/unit/gapic/telcoautomation_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/.flake8
+++ b/packages/google-cloud-texttospeech/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/MANIFEST.in
+++ b/packages/google-cloud-texttospeech/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech/gapic_version.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/gapic_version.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/client.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/grpc.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/grpc_asyncio.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/rest.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/rest_base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/client.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/grpc.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/grpc_asyncio.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/rest.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/rest_base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/types/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/types/cloud_tts.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/types/cloud_tts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/types/cloud_tts_lrs.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/types/cloud_tts_lrs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/gapic_version.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/grpc.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/grpc_asyncio.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/rest.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/rest_base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/client.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/grpc.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/grpc_asyncio.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/rest.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/rest_base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/types/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/types/cloud_tts_lrs.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/types/cloud_tts_lrs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_list_voices_async.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_list_voices_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_list_voices_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_list_voices_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_long_audio_synthesize_synthesize_long_audio_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_long_audio_synthesize_synthesize_long_audio_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_streaming_synthesize_async.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_streaming_synthesize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_streaming_synthesize_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_streaming_synthesize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_synthesize_speech_async.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_synthesize_speech_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_synthesize_speech_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_synthesize_speech_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_list_voices_async.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_list_voices_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_list_voices_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_list_voices_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_long_audio_synthesize_synthesize_long_audio_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_long_audio_synthesize_synthesize_long_audio_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_streaming_synthesize_async.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_streaming_synthesize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_streaming_synthesize_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_streaming_synthesize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_synthesize_speech_async.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_synthesize_speech_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_synthesize_speech_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_synthesize_speech_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/tests/__init__.py
+++ b/packages/google-cloud-texttospeech/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/tests/unit/__init__.py
+++ b/packages/google-cloud-texttospeech/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-texttospeech/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/tests/unit/gapic/texttospeech_v1/__init__.py
+++ b/packages/google-cloud-texttospeech/tests/unit/gapic/texttospeech_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/tests/unit/gapic/texttospeech_v1beta1/__init__.py
+++ b/packages/google-cloud-texttospeech/tests/unit/gapic/texttospeech_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/.flake8
+++ b/packages/google-cloud-tpu/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/MANIFEST.in
+++ b/packages/google-cloud-tpu/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu/gapic_version.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/gapic_version.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/client.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/pagers.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/base.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/grpc.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/grpc_asyncio.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/types/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/types/cloud_tpu.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/types/cloud_tpu.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/gapic_version.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/client.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/pagers.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/base.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/grpc.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/grpc_asyncio.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/rest.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/rest_base.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/types/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/types/cloud_tpu.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/types/cloud_tpu.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/gapic_version.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/client.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/pagers.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/base.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/grpc.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/grpc_asyncio.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/types/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/types/cloud_tpu.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/types/cloud_tpu.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_create_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_create_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_delete_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_delete_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_accelerator_type_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_accelerator_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_accelerator_type_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_accelerator_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_node_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_node_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_tensor_flow_version_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_tensor_flow_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_tensor_flow_version_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_tensor_flow_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_accelerator_types_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_accelerator_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_accelerator_types_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_accelerator_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_nodes_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_nodes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_nodes_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_tensor_flow_versions_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_tensor_flow_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_tensor_flow_versions_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_tensor_flow_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_reimage_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_reimage_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_start_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_start_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_stop_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_stop_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_create_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_create_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_create_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_create_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_delete_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_delete_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_delete_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_delete_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_generate_service_identity_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_generate_service_identity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_generate_service_identity_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_generate_service_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_accelerator_type_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_accelerator_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_accelerator_type_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_accelerator_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_guest_attributes_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_guest_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_guest_attributes_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_guest_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_node_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_node_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_queued_resource_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_queued_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_runtime_version_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_runtime_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_runtime_version_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_runtime_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_accelerator_types_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_accelerator_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_accelerator_types_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_accelerator_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_nodes_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_nodes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_nodes_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_queued_resources_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_queued_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_queued_resources_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_queued_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_runtime_versions_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_runtime_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_runtime_versions_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_runtime_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_reset_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_reset_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_start_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_start_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_stop_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_stop_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_update_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_update_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_create_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_create_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_create_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_create_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_delete_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_delete_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_delete_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_delete_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_generate_service_identity_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_generate_service_identity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_generate_service_identity_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_generate_service_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_accelerator_type_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_accelerator_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_accelerator_type_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_accelerator_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_guest_attributes_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_guest_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_guest_attributes_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_guest_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_node_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_node_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_queued_resource_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_queued_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_runtime_version_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_runtime_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_runtime_version_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_runtime_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_accelerator_types_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_accelerator_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_accelerator_types_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_accelerator_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_nodes_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_nodes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_nodes_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_queued_resources_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_queued_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_queued_resources_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_queued_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_reservations_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_reservations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_reservations_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_reservations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_runtime_versions_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_runtime_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_runtime_versions_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_runtime_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_perform_maintenance_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_perform_maintenance_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_perform_maintenance_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_reset_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_reset_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_simulate_maintenance_event_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_simulate_maintenance_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_start_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_start_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_stop_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_stop_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_update_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_update_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/tests/__init__.py
+++ b/packages/google-cloud-tpu/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/tests/unit/__init__.py
+++ b/packages/google-cloud-tpu/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-tpu/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/tests/unit/gapic/tpu_v1/__init__.py
+++ b/packages/google-cloud-tpu/tests/unit/gapic/tpu_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/tests/unit/gapic/tpu_v2/__init__.py
+++ b/packages/google-cloud-tpu/tests/unit/gapic/tpu_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/tests/unit/gapic/tpu_v2alpha1/__init__.py
+++ b/packages/google-cloud-tpu/tests/unit/gapic/tpu_v2alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/.flake8
+++ b/packages/google-cloud-trace/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/MANIFEST.in
+++ b/packages/google-cloud-trace/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace/gapic_version.py
+++ b/packages/google-cloud-trace/google/cloud/trace/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/gapic_version.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/async_client.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/client.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/pagers.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/base.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/grpc.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/rest.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/rest_base.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/types/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/types/trace.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/types/trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/gapic_version.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/async_client.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/client.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/base.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/grpc.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/rest.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/rest_base.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/types/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/types/trace.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/types/trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/types/tracing.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/types/tracing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_get_trace_async.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_get_trace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_get_trace_sync.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_get_trace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_list_traces_async.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_list_traces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_list_traces_sync.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_list_traces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_patch_traces_async.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_patch_traces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_patch_traces_sync.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_patch_traces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_batch_write_spans_async.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_batch_write_spans_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_batch_write_spans_sync.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_batch_write_spans_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_create_span_async.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_create_span_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_create_span_sync.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_create_span_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/tests/__init__.py
+++ b/packages/google-cloud-trace/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/tests/unit/__init__.py
+++ b/packages/google-cloud-trace/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-trace/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/tests/unit/gapic/trace_v1/__init__.py
+++ b/packages/google-cloud-trace/tests/unit/gapic/trace_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/tests/unit/gapic/trace_v2/__init__.py
+++ b/packages/google-cloud-trace/tests/unit/gapic/trace_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/.flake8
+++ b/packages/google-cloud-translate/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/MANIFEST.in
+++ b/packages/google-cloud-translate/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate/gapic_version.py
+++ b/packages/google-cloud-translate/google/cloud/translate/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/gapic_version.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/client.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/pagers.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/base.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/grpc.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/rest.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/rest_base.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/types/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/types/adaptive_mt.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/types/adaptive_mt.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/types/automl_translation.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/types/automl_translation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/types/common.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/types/translation_service.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/types/translation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/gapic_version.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/client.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/pagers.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/base.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/grpc.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/rest.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/rest_base.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/types/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/types/translation_service.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/types/translation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_adaptive_mt_translate_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_adaptive_mt_translate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_adaptive_mt_translate_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_adaptive_mt_translate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_batch_translate_document_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_batch_translate_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_batch_translate_text_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_batch_translate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_adaptive_mt_dataset_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_adaptive_mt_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_adaptive_mt_dataset_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_adaptive_mt_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_dataset_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_glossary_entry_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_glossary_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_glossary_entry_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_glossary_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_model_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_dataset_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_dataset_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_file_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_file_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_dataset_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_glossary_entry_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_glossary_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_glossary_entry_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_glossary_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_model_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_detect_language_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_detect_language_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_detect_language_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_detect_language_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_export_data_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_dataset_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_dataset_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_file_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_file_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_dataset_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_dataset_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_entry_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_entry_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_model_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_model_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_supported_languages_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_supported_languages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_supported_languages_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_supported_languages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_import_adaptive_mt_file_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_import_adaptive_mt_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_import_adaptive_mt_file_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_import_adaptive_mt_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_import_data_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_datasets_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_datasets_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_files_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_files_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_sentences_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_sentences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_sentences_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_sentences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_datasets_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_datasets_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_examples_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_examples_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_examples_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossaries_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossaries_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossary_entries_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossary_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossary_entries_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossary_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_models_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_models_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_romanize_text_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_romanize_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_romanize_text_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_romanize_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_document_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_document_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_text_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_text_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_update_glossary_entry_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_update_glossary_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_update_glossary_entry_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_update_glossary_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_update_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_update_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_batch_translate_document_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_batch_translate_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_batch_translate_text_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_batch_translate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_create_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_create_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_delete_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_delete_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_detect_language_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_detect_language_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_detect_language_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_detect_language_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_glossary_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_glossary_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_supported_languages_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_supported_languages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_supported_languages_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_supported_languages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_list_glossaries_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_list_glossaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_list_glossaries_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_list_glossaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_refine_text_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_refine_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_refine_text_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_refine_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_document_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_document_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_text_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_text_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/tests/__init__.py
+++ b/packages/google-cloud-translate/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/tests/unit/__init__.py
+++ b/packages/google-cloud-translate/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-translate/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/tests/unit/gapic/translate_v3/__init__.py
+++ b/packages/google-cloud-translate/tests/unit/gapic/translate_v3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/tests/unit/gapic/translate_v3beta1/__init__.py
+++ b/packages/google-cloud-translate/tests/unit/gapic/translate_v3beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/.flake8
+++ b/packages/google-cloud-vectorsearch/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/MANIFEST.in
+++ b/packages/google-cloud-vectorsearch/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch/gapic_version.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/gapic_version.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/async_client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/pagers.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/grpc.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/rest.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/rest_base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/async_client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/grpc.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/rest.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/rest_base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/pagers.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/grpc.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/rest.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/rest_base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/common.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/data_object.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/data_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/data_object_search_service.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/data_object_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/data_object_service.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/data_object_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/embedding_config.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/embedding_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/encryption_spec.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/encryption_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/vectorsearch_service.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/vectorsearch_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/gapic_version.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/async_client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/pagers.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/grpc.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/rest.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/rest_base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/async_client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/grpc.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/rest.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/rest_base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/pagers.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/grpc.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/rest.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/rest_base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/common.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/data_object.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/data_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/data_object_search_service.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/data_object_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/data_object_service.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/data_object_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/embedding_config.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/embedding_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/encryption_spec.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/encryption_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/vectorsearch_service.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/vectorsearch_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_aggregate_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_aggregate_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_aggregate_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_aggregate_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_batch_search_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_batch_search_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_batch_search_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_batch_search_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_query_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_query_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_query_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_query_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_search_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_search_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_search_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_search_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_create_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_create_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_create_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_create_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_delete_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_delete_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_delete_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_delete_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_update_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_update_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_update_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_update_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_create_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_create_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_create_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_create_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_delete_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_delete_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_delete_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_delete_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_get_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_get_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_get_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_get_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_update_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_update_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_update_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_update_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_create_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_create_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_create_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_create_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_delete_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_delete_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_delete_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_delete_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_export_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_export_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_collection_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_index_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_index_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_import_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_import_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_collections_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_collections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_collections_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_collections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_indexes_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_indexes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_indexes_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_indexes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_update_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_update_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_update_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_update_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_aggregate_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_aggregate_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_aggregate_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_aggregate_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_batch_search_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_batch_search_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_batch_search_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_batch_search_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_query_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_query_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_query_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_query_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_search_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_search_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_search_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_search_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_create_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_create_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_create_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_create_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_delete_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_delete_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_delete_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_delete_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_update_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_update_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_update_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_update_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_create_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_create_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_create_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_create_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_delete_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_delete_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_delete_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_delete_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_get_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_get_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_get_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_get_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_update_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_update_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_update_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_update_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_create_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_create_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_create_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_create_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_delete_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_delete_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_delete_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_delete_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_export_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_export_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_collection_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_index_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_index_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_import_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_import_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_collections_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_collections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_collections_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_collections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_indexes_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_indexes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_indexes_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_indexes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_update_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_update_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_update_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_update_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/tests/__init__.py
+++ b/packages/google-cloud-vectorsearch/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/tests/unit/__init__.py
+++ b/packages/google-cloud-vectorsearch/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-vectorsearch/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/tests/unit/gapic/vectorsearch_v1/__init__.py
+++ b/packages/google-cloud-vectorsearch/tests/unit/gapic/vectorsearch_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/tests/unit/gapic/vectorsearch_v1beta/__init__.py
+++ b/packages/google-cloud-vectorsearch/tests/unit/gapic/vectorsearch_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/.flake8
+++ b/packages/google-cloud-video-live-stream/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/MANIFEST.in
+++ b/packages/google-cloud-video-live-stream/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream/__init__.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream/gapic_version.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/gapic_version.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/__init__.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/__init__.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/client.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/pagers.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/__init__.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/base.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/grpc.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/rest.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/rest_base.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/__init__.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/outputs.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/outputs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/resources.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/service.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_asset_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_channel_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_clip_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_clip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_dvr_session_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_dvr_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_event_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_event_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_input_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_asset_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_channel_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_clip_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_clip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_dvr_session_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_dvr_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_event_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_event_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_input_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_asset_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_asset_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_channel_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_channel_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_clip_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_clip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_clip_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_clip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_dvr_session_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_dvr_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_dvr_session_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_dvr_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_event_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_event_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_input_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_input_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_pool_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_pool_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_assets_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_assets_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_channels_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_channels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_channels_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_channels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_clips_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_clips_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_clips_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_clips_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_dvr_sessions_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_dvr_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_dvr_sessions_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_dvr_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_events_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_events_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_inputs_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_inputs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_inputs_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_inputs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_preview_input_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_preview_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_preview_input_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_preview_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_start_channel_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_start_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_start_distribution_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_start_distribution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_stop_channel_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_stop_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_stop_distribution_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_stop_distribution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_channel_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_dvr_session_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_dvr_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_input_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_pool_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/tests/__init__.py
+++ b/packages/google-cloud-video-live-stream/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/tests/unit/__init__.py
+++ b/packages/google-cloud-video-live-stream/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-video-live-stream/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/tests/unit/gapic/live_stream_v1/__init__.py
+++ b/packages/google-cloud-video-live-stream/tests/unit/gapic/live_stream_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/.flake8
+++ b/packages/google-cloud-video-stitcher/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/MANIFEST.in
+++ b/packages/google-cloud-video-stitcher/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher/__init__.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher/gapic_version.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/gapic_version.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/__init__.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/__init__.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/client.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/pagers.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/__init__.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/base.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/grpc.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/rest.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/rest_base.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/__init__.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/ad_tag_details.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/ad_tag_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/cdn_keys.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/cdn_keys.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/companions.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/companions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/events.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/events.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/fetch_options.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/fetch_options.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/live_configs.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/live_configs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/sessions.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/sessions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/slates.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/slates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/stitch_details.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/stitch_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/video_stitcher_service.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/video_stitcher_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/vod_configs.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/vod_configs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_cdn_key_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_cdn_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_live_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_live_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_live_session_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_live_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_live_session_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_live_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_slate_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_slate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_vod_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_vod_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_vod_session_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_vod_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_vod_session_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_vod_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_cdn_key_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_cdn_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_live_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_live_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_slate_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_slate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_vod_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_vod_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_cdn_key_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_cdn_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_cdn_key_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_cdn_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_ad_tag_detail_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_ad_tag_detail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_ad_tag_detail_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_ad_tag_detail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_config_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_session_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_session_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_slate_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_slate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_slate_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_slate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_ad_tag_detail_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_ad_tag_detail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_ad_tag_detail_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_ad_tag_detail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_config_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_session_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_session_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_stitch_detail_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_stitch_detail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_stitch_detail_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_stitch_detail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_cdn_keys_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_cdn_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_cdn_keys_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_cdn_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_ad_tag_details_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_ad_tag_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_ad_tag_details_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_ad_tag_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_configs_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_configs_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_slates_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_slates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_slates_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_slates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_ad_tag_details_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_ad_tag_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_ad_tag_details_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_ad_tag_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_configs_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_configs_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_stitch_details_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_stitch_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_stitch_details_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_stitch_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_cdn_key_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_cdn_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_live_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_live_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_slate_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_slate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_vod_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_vod_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/tests/__init__.py
+++ b/packages/google-cloud-video-stitcher/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/tests/unit/__init__.py
+++ b/packages/google-cloud-video-stitcher/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-video-stitcher/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/tests/unit/gapic/stitcher_v1/__init__.py
+++ b/packages/google-cloud-video-stitcher/tests/unit/gapic/stitcher_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/.flake8
+++ b/packages/google-cloud-video-transcoder/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/MANIFEST.in
+++ b/packages/google-cloud-video-transcoder/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder/__init__.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder/gapic_version.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/gapic_version.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/__init__.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/__init__.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/async_client.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/client.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/pagers.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/__init__.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/base.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/grpc.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/rest.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/rest_base.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/types/__init__.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/types/resources.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/types/services.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/types/services.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_template_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_template_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_template_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_template_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_template_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_template_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_job_templates_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_job_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_job_templates_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_job_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_jobs_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_jobs_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/tests/__init__.py
+++ b/packages/google-cloud-video-transcoder/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/tests/unit/__init__.py
+++ b/packages/google-cloud-video-transcoder/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-video-transcoder/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/tests/unit/gapic/transcoder_v1/__init__.py
+++ b/packages/google-cloud-video-transcoder/tests/unit/gapic/transcoder_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/.flake8
+++ b/packages/google-cloud-videointelligence/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/MANIFEST.in
+++ b/packages/google-cloud-videointelligence/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence/gapic_version.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/gapic_version.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/grpc.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/rest.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/rest_base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/types/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/types/video_intelligence.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/types/video_intelligence.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/gapic_version.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/grpc.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/rest.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/rest_base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/types/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/types/video_intelligence.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/types/video_intelligence.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/gapic_version.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/grpc.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/rest.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/rest_base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/types/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/types/video_intelligence.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/types/video_intelligence.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/gapic_version.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/grpc.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/rest.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/rest_base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/types/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/types/video_intelligence.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/types/video_intelligence.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/gapic_version.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/async_client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/grpc.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/grpc.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/types/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/types/video_intelligence.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/types/video_intelligence.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1_generated_video_intelligence_service_annotate_video_sync.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1_generated_video_intelligence_service_annotate_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1beta2_generated_video_intelligence_service_annotate_video_sync.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1beta2_generated_video_intelligence_service_annotate_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p1beta1_generated_video_intelligence_service_annotate_video_sync.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p1beta1_generated_video_intelligence_service_annotate_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p2beta1_generated_video_intelligence_service_annotate_video_sync.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p2beta1_generated_video_intelligence_service_annotate_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p3beta1_generated_streaming_video_intelligence_service_streaming_annotate_video_async.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p3beta1_generated_streaming_video_intelligence_service_streaming_annotate_video_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p3beta1_generated_streaming_video_intelligence_service_streaming_annotate_video_sync.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p3beta1_generated_streaming_video_intelligence_service_streaming_annotate_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p3beta1_generated_video_intelligence_service_annotate_video_sync.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p3beta1_generated_video_intelligence_service_annotate_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1beta2/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p1beta1/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p2beta1/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p2beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p3beta1/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p3beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/.flake8
+++ b/packages/google-cloud-vision/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/MANIFEST.in
+++ b/packages/google-cloud-vision/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision/gapic_version.py
+++ b/packages/google-cloud-vision/google/cloud/vision/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/gapic_version.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/pagers.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/geometry.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/image_annotator.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/image_annotator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/product_search.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/product_search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/product_search_service.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/product_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/text_annotation.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/text_annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/web_detection.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/web_detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/gapic_version.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/async_client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/geometry.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/image_annotator.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/image_annotator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/text_annotation.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/text_annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/web_detection.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/web_detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/gapic_version.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/geometry.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/image_annotator.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/image_annotator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/text_annotation.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/text_annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/web_detection.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/web_detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/gapic_version.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/pagers.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/geometry.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/image_annotator.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/image_annotator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/product_search.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/product_search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/product_search_service.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/product_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/text_annotation.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/text_annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/web_detection.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/web_detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/gapic_version.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/pagers.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/face.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/face.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/geometry.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/image_annotator.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/image_annotator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/product_search.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/product_search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/product_search_service.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/product_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/text_annotation.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/text_annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/web_detection.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/web_detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_async_batch_annotate_files_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_async_batch_annotate_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_async_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_async_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_files_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_files_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_add_product_to_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_add_product_to_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_add_product_to_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_add_product_to_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_import_product_sets_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_import_product_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_product_sets_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_product_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_product_sets_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_product_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_in_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_in_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_in_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_in_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_reference_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_reference_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_reference_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_reference_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_purge_products_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_purge_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_remove_product_from_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_remove_product_from_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_remove_product_from_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_remove_product_from_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p1beta1_generated_image_annotator_batch_annotate_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p1beta1_generated_image_annotator_batch_annotate_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p1beta1_generated_image_annotator_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p1beta1_generated_image_annotator_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p2beta1_generated_image_annotator_async_batch_annotate_files_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p2beta1_generated_image_annotator_async_batch_annotate_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p2beta1_generated_image_annotator_batch_annotate_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p2beta1_generated_image_annotator_batch_annotate_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p2beta1_generated_image_annotator_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p2beta1_generated_image_annotator_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_image_annotator_async_batch_annotate_files_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_image_annotator_async_batch_annotate_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_image_annotator_batch_annotate_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_image_annotator_batch_annotate_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_image_annotator_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_image_annotator_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_add_product_to_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_add_product_to_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_add_product_to_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_add_product_to_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_import_product_sets_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_import_product_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_product_sets_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_product_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_product_sets_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_product_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_in_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_in_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_in_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_in_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_reference_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_reference_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_reference_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_reference_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_remove_product_from_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_remove_product_from_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_remove_product_from_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_remove_product_from_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_async_batch_annotate_files_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_async_batch_annotate_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_async_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_async_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_files_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_files_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_add_product_to_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_add_product_to_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_add_product_to_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_add_product_to_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_import_product_sets_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_import_product_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_product_sets_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_product_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_product_sets_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_product_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_in_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_in_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_in_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_in_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_reference_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_reference_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_reference_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_reference_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_purge_products_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_purge_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_remove_product_from_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_remove_product_from_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_remove_product_from_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_remove_product_from_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/__init__.py
+++ b/packages/google-cloud-vision/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/gapic/vision_v1/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/gapic/vision_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/gapic/vision_v1p1beta1/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/gapic/vision_v1p1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/gapic/vision_v1p2beta1/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/gapic/vision_v1p2beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/gapic/vision_v1p3beta1/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/gapic/vision_v1p3beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/gapic/vision_v1p4beta1/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/gapic/vision_v1p4beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/.flake8
+++ b/packages/google-cloud-visionai/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/MANIFEST.in
+++ b/packages/google-cloud-visionai/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai/gapic_version.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/gapic_version.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/async_client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/async_client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/annotations.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/annotations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/common.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/health_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/health_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/lva.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/lva.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/lva_resources.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/lva_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/lva_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/lva_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streaming_resources.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streaming_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streaming_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streaming_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streams_resources.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streams_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streams_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streams_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/warehouse.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/warehouse.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/async_client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/annotations.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/annotations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/common.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/lva.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/lva.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/lva_resources.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/lva_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/lva_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/lva_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streaming_resources.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streaming_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streaming_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streaming_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streams_resources.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streams_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streams_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streams_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/warehouse.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/warehouse.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_add_application_stream_input_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_add_application_stream_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_application_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_application_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_application_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_application_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_deploy_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_deploy_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_application_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_application_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_draft_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_draft_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_instance_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_instance_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_processor_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_processor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_applications_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_applications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_applications_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_drafts_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_drafts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_drafts_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_drafts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_instances_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_prebuilt_processors_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_prebuilt_processors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_prebuilt_processors_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_prebuilt_processors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_processors_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_processors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_processors_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_processors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_remove_application_stream_input_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_remove_application_stream_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_undeploy_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_undeploy_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_application_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_application_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_application_stream_input_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_application_stream_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_health_check_service_health_check_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_health_check_service_health_check_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_health_check_service_health_check_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_health_check_service_health_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_batch_run_process_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_batch_run_process_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_create_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_create_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_create_operator_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_create_operator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_create_process_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_create_process_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_delete_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_delete_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_delete_operator_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_delete_operator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_delete_process_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_delete_process_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_analysis_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_analysis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_operator_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_operator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_operator_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_operator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_process_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_process_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_process_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_process_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_analyses_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_analyses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_analyses_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_analyses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_operators_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_operators_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_operators_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_operators_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_processes_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_processes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_processes_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_processes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_public_operators_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_public_operators_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_public_operators_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_public_operators_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_resolve_operator_info_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_resolve_operator_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_resolve_operator_info_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_resolve_operator_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_update_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_update_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_update_operator_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_update_operator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_update_process_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_update_process_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_acquire_lease_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_acquire_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_acquire_lease_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_acquire_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_events_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_events_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_packets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_packets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_packets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_packets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_release_lease_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_release_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_release_lease_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_release_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_renew_lease_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_renew_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_renew_lease_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_renew_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_send_packets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_send_packets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_send_packets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_send_packets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_generate_stream_hls_token_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_generate_stream_hls_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_generate_stream_hls_token_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_generate_stream_hls_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_cluster_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_event_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_series_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_stream_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_stream_thumbnail_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_stream_thumbnail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_clusters_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_clusters_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_events_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_events_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_series_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_streams_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_streams_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_materialize_channel_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_materialize_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_add_application_stream_input_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_add_application_stream_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_application_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_application_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_application_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_application_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_deploy_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_deploy_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_application_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_application_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_draft_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_draft_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_instance_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_instance_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_processor_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_processor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_applications_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_applications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_applications_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_drafts_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_drafts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_drafts_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_drafts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_instances_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_prebuilt_processors_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_prebuilt_processors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_prebuilt_processors_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_prebuilt_processors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_processors_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_processors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_processors_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_processors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_remove_application_stream_input_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_remove_application_stream_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_undeploy_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_undeploy_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_application_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_application_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_application_stream_input_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_application_stream_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_create_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_create_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_delete_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_delete_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_get_analysis_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_get_analysis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_get_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_get_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_list_analyses_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_list_analyses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_list_analyses_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_list_analyses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_update_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_update_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_acquire_lease_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_acquire_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_acquire_lease_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_acquire_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_events_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_events_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_packets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_packets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_packets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_packets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_release_lease_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_release_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_release_lease_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_release_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_renew_lease_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_renew_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_renew_lease_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_renew_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_send_packets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_send_packets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_send_packets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_send_packets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_generate_stream_hls_token_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_generate_stream_hls_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_generate_stream_hls_token_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_generate_stream_hls_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_cluster_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_event_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_series_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_stream_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_clusters_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_clusters_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_events_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_events_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_series_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_streams_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_streams_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_materialize_channel_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_materialize_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_clip_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_clip_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_clip_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_clip_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_corpus_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_generate_hls_uri_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_generate_hls_uri_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_generate_hls_uri_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_generate_hls_uri_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_corpus_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_ingest_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_ingest_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_ingest_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_ingest_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_annotations_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_annotations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_annotations_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_annotations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_assets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_assets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_corpora_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_corpora_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_corpora_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_corpora_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_data_schemas_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_data_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_data_schemas_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_data_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_search_configs_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_search_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_search_configs_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_search_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_search_assets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_search_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_search_assets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_search_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_corpus_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_add_collection_item_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_add_collection_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_add_collection_item_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_add_collection_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_analyze_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_analyze_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_analyze_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_analyze_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_clip_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_clip_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_clip_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_clip_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_collection_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_index_endpoint_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_index_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_index_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_hypernym_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_hypernym_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_hypernym_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_hypernym_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_collection_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_corpus_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_index_endpoint_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_index_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_index_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_hypernym_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_hypernym_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_hypernym_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_hypernym_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_deploy_index_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_deploy_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_hls_uri_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_hls_uri_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_hls_uri_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_hls_uri_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_retrieval_url_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_retrieval_url_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_retrieval_url_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_retrieval_url_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_collection_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_collection_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_corpus_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_endpoint_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_endpoint_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_hypernym_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_hypernym_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_hypernym_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_hypernym_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_import_assets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_import_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_index_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_index_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_ingest_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_ingest_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_ingest_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_ingest_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_annotations_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_annotations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_annotations_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_annotations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_assets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_assets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_collections_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_collections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_collections_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_collections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_corpora_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_corpora_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_corpora_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_corpora_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_data_schemas_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_data_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_data_schemas_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_data_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_index_endpoints_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_index_endpoints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_index_endpoints_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_index_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_indexes_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_indexes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_indexes_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_indexes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_configs_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_configs_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_hypernyms_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_hypernyms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_hypernyms_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_hypernyms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_remove_collection_item_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_remove_collection_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_remove_collection_item_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_remove_collection_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_remove_index_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_remove_index_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_assets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_assets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_index_endpoint_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_index_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_index_endpoint_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_index_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_undeploy_index_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_undeploy_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_collection_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_collection_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_corpus_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_index_endpoint_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_index_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_index_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_hypernym_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_hypernym_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_hypernym_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_hypernym_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_upload_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_upload_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_collection_items_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_collection_items_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_collection_items_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_collection_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_indexed_assets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_indexed_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_indexed_assets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_indexed_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/tests/__init__.py
+++ b/packages/google-cloud-visionai/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/tests/unit/__init__.py
+++ b/packages/google-cloud-visionai/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-visionai/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/tests/unit/gapic/visionai_v1/__init__.py
+++ b/packages/google-cloud-visionai/tests/unit/gapic/visionai_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/tests/unit/gapic/visionai_v1alpha1/__init__.py
+++ b/packages/google-cloud-visionai/tests/unit/gapic/visionai_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/.flake8
+++ b/packages/google-cloud-vm-migration/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/MANIFEST.in
+++ b/packages/google-cloud-vm-migration/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration/__init__.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration/gapic_version.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/gapic_version.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/__init__.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/__init__.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/client.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/pagers.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/__init__.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/base.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/grpc.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/rest.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/rest_base.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/types/__init__.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/types/vmmigration.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/types/vmmigration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_add_group_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_add_group_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_clone_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_clone_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_cutover_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_cutover_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_disk_migration_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_disk_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_image_import_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_image_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_clone_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_clone_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_cutover_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_cutover_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_datacenter_connector_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_datacenter_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_disk_migration_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_disk_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_group_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_image_import_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_image_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_migrating_vm_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_migrating_vm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_source_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_target_project_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_target_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_utilization_report_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_utilization_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_datacenter_connector_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_datacenter_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_disk_migration_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_disk_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_group_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_image_import_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_image_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_migrating_vm_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_migrating_vm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_source_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_target_project_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_target_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_utilization_report_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_utilization_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_extend_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_extend_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_inventory_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_inventory_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_storage_inventory_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_storage_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_storage_inventory_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_storage_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_finalize_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_finalize_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_clone_job_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_clone_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_clone_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_clone_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_cutover_job_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_cutover_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_cutover_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_cutover_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_datacenter_connector_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_datacenter_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_datacenter_connector_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_datacenter_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_disk_migration_job_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_disk_migration_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_disk_migration_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_disk_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_group_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_group_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_job_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_migrating_vm_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_migrating_vm_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_migrating_vm_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_migrating_vm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_replication_cycle_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_replication_cycle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_replication_cycle_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_replication_cycle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_source_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_source_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_target_project_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_target_project_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_target_project_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_target_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_utilization_report_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_utilization_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_utilization_report_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_utilization_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_clone_jobs_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_clone_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_clone_jobs_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_clone_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_cutover_jobs_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_cutover_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_cutover_jobs_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_cutover_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_datacenter_connectors_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_datacenter_connectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_datacenter_connectors_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_datacenter_connectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_disk_migration_jobs_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_disk_migration_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_disk_migration_jobs_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_disk_migration_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_groups_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_groups_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_import_jobs_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_import_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_import_jobs_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_import_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_imports_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_imports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_imports_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_imports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_migrating_vms_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_migrating_vms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_migrating_vms_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_migrating_vms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_replication_cycles_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_replication_cycles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_replication_cycles_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_replication_cycles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_sources_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_sources_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_target_projects_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_target_projects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_target_projects_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_target_projects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_utilization_reports_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_utilization_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_utilization_reports_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_utilization_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_pause_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_pause_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_remove_group_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_remove_group_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_resume_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_resume_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_run_disk_migration_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_run_disk_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_start_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_start_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_disk_migration_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_disk_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_group_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_migrating_vm_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_migrating_vm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_source_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_target_project_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_target_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_upgrade_appliance_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_upgrade_appliance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/tests/__init__.py
+++ b/packages/google-cloud-vm-migration/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/tests/unit/__init__.py
+++ b/packages/google-cloud-vm-migration/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-vm-migration/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/tests/unit/gapic/vmmigration_v1/__init__.py
+++ b/packages/google-cloud-vm-migration/tests/unit/gapic/vmmigration_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/.flake8
+++ b/packages/google-cloud-vmwareengine/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/MANIFEST.in
+++ b/packages/google-cloud-vmwareengine/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine/__init__.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine/gapic_version.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/gapic_version.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/__init__.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/__init__.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/client.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/pagers.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/__init__.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/base.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/grpc.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/rest.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/rest_base.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/types/__init__.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/types/vmwareengine.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/types/vmwareengine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/types/vmwareengine_resources.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/types/vmwareengine_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_cluster_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_external_access_rule_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_external_access_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_external_address_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_external_address_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_hcx_activation_key_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_hcx_activation_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_logging_server_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_logging_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_management_dns_zone_binding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_management_dns_zone_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_network_peering_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_network_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_network_policy_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_network_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_private_cloud_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_private_cloud_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_private_connection_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_vmware_engine_network_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_vmware_engine_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_cluster_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_external_access_rule_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_external_access_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_external_address_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_external_address_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_logging_server_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_logging_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_management_dns_zone_binding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_management_dns_zone_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_network_peering_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_network_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_network_policy_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_network_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_private_cloud_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_private_cloud_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_private_connection_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_vmware_engine_network_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_vmware_engine_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_fetch_network_policy_external_addresses_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_fetch_network_policy_external_addresses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_fetch_network_policy_external_addresses_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_fetch_network_policy_external_addresses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_cluster_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_cluster_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_bind_permission_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_bind_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_bind_permission_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_bind_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_forwarding_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_forwarding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_forwarding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_forwarding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_access_rule_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_access_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_access_rule_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_access_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_address_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_address_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_address_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_address_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_hcx_activation_key_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_hcx_activation_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_hcx_activation_key_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_hcx_activation_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_logging_server_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_logging_server_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_logging_server_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_logging_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_management_dns_zone_binding_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_management_dns_zone_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_management_dns_zone_binding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_management_dns_zone_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_peering_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_peering_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_peering_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_policy_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_policy_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_type_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_type_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_cloud_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_cloud_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_cloud_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_cloud_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_connection_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_connection_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_subnet_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_subnet_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_subnet_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_vmware_engine_network_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_vmware_engine_network_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_vmware_engine_network_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_vmware_engine_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_grant_dns_bind_permission_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_grant_dns_bind_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_clusters_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_clusters_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_access_rules_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_access_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_access_rules_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_access_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_addresses_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_addresses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_addresses_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_addresses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_hcx_activation_keys_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_hcx_activation_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_hcx_activation_keys_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_hcx_activation_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_logging_servers_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_logging_servers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_logging_servers_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_logging_servers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_management_dns_zone_bindings_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_management_dns_zone_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_management_dns_zone_bindings_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_management_dns_zone_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_peerings_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_peerings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_peerings_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_peerings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_policies_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_policies_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_node_types_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_node_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_node_types_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_node_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_nodes_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_nodes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_nodes_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_peering_routes_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_peering_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_peering_routes_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_peering_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_clouds_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_clouds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_clouds_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_clouds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connection_peering_routes_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connection_peering_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connection_peering_routes_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connection_peering_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connections_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connections_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_subnets_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_subnets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_subnets_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_subnets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_vmware_engine_networks_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_vmware_engine_networks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_vmware_engine_networks_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_vmware_engine_networks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_repair_management_dns_zone_binding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_repair_management_dns_zone_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_reset_nsx_credentials_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_reset_nsx_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_reset_vcenter_credentials_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_reset_vcenter_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_revoke_dns_bind_permission_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_revoke_dns_bind_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_nsx_credentials_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_nsx_credentials_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_nsx_credentials_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_nsx_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_vcenter_credentials_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_vcenter_credentials_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_vcenter_credentials_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_vcenter_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_undelete_private_cloud_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_undelete_private_cloud_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_cluster_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_dns_forwarding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_dns_forwarding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_external_access_rule_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_external_access_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_external_address_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_external_address_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_logging_server_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_logging_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_management_dns_zone_binding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_management_dns_zone_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_network_peering_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_network_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_network_policy_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_network_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_private_cloud_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_private_cloud_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_private_connection_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_subnet_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_vmware_engine_network_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_vmware_engine_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/tests/__init__.py
+++ b/packages/google-cloud-vmwareengine/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/tests/unit/__init__.py
+++ b/packages/google-cloud-vmwareengine/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-vmwareengine/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/tests/unit/gapic/vmwareengine_v1/__init__.py
+++ b/packages/google-cloud-vmwareengine/tests/unit/gapic/vmwareengine_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/.flake8
+++ b/packages/google-cloud-vpc-access/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/MANIFEST.in
+++ b/packages/google-cloud-vpc-access/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess/__init__.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess/gapic_version.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/gapic_version.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/__init__.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/__init__.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/client.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/pagers.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/__init__.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/base.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/grpc.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/rest.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/rest_base.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/types/__init__.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/types/vpc_access.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/types/vpc_access.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_create_connector_sync.py
+++ b/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_create_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_delete_connector_sync.py
+++ b/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_delete_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_get_connector_async.py
+++ b/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_get_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_get_connector_sync.py
+++ b/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_get_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_list_connectors_async.py
+++ b/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_list_connectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_list_connectors_sync.py
+++ b/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_list_connectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/tests/__init__.py
+++ b/packages/google-cloud-vpc-access/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/tests/unit/__init__.py
+++ b/packages/google-cloud-vpc-access/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-vpc-access/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/tests/unit/gapic/vpcaccess_v1/__init__.py
+++ b/packages/google-cloud-vpc-access/tests/unit/gapic/vpcaccess_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/.flake8
+++ b/packages/google-cloud-webrisk/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/MANIFEST.in
+++ b/packages/google-cloud-webrisk/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk/gapic_version.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/gapic_version.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/client.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/base.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/grpc.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/rest.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/rest_base.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/types/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/types/webrisk.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/types/webrisk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/gapic_version.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/async_client.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/client.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/base.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/grpc.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/rest.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/rest_base.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/types/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/types/webrisk.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/types/webrisk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_compute_threat_list_diff_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_compute_threat_list_diff_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_compute_threat_list_diff_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_compute_threat_list_diff_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_create_submission_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_create_submission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_create_submission_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_create_submission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_hashes_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_hashes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_hashes_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_hashes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_uris_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_uris_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_uris_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_uris_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_submit_uri_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_submit_uri_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_compute_threat_list_diff_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_compute_threat_list_diff_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_compute_threat_list_diff_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_compute_threat_list_diff_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_hashes_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_hashes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_hashes_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_hashes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_uris_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_uris_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_uris_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_uris_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/tests/__init__.py
+++ b/packages/google-cloud-webrisk/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/tests/unit/__init__.py
+++ b/packages/google-cloud-webrisk/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-webrisk/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/tests/unit/gapic/webrisk_v1/__init__.py
+++ b/packages/google-cloud-webrisk/tests/unit/gapic/webrisk_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/tests/unit/gapic/webrisk_v1beta1/__init__.py
+++ b/packages/google-cloud-webrisk/tests/unit/gapic/webrisk_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/.flake8
+++ b/packages/google-cloud-websecurityscanner/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/MANIFEST.in
+++ b/packages/google-cloud-websecurityscanner/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner/gapic_version.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/gapic_version.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/async_client.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/client.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/pagers.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/base.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/grpc.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/grpc_asyncio.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/rest.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/rest_base.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/crawled_url.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/crawled_url.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/finding.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/finding_addon.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/finding_addon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/finding_type_stats.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/finding_type_stats.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_config.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_config_error.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_config_error.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run_error_trace.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run_error_trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run_log.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run_log.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run_warning_trace.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run_warning_trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/web_security_scanner.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/web_security_scanner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/gapic_version.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/async_client.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/client.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/pagers.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/base.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/grpc.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/grpc_asyncio.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/rest.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/rest_base.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/crawled_url.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/crawled_url.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/finding.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/finding_addon.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/finding_addon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/finding_type_stats.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/finding_type_stats.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/scan_config.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/scan_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/scan_run.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/scan_run.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/web_security_scanner.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/web_security_scanner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/gapic_version.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/async_client.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/client.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/pagers.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/base.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/grpc.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/grpc_asyncio.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/rest.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/rest_base.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/crawled_url.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/crawled_url.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/finding.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/finding_addon.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/finding_addon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/finding_type_stats.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/finding_type_stats.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_config.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_config_error.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_config_error.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_run.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_run.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_run_error_trace.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_run_error_trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_run_warning_trace.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_run_warning_trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/web_security_scanner.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/web_security_scanner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_create_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_create_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_create_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_create_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_delete_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_delete_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_delete_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_delete_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_finding_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_finding_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_crawled_urls_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_crawled_urls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_crawled_urls_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_crawled_urls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_finding_type_stats_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_finding_type_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_finding_type_stats_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_finding_type_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_findings_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_findings_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_configs_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_configs_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_runs_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_runs_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_start_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_start_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_start_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_start_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_stop_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_stop_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_stop_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_stop_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_update_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_update_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_update_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_update_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_create_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_create_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_create_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_create_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_delete_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_delete_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_delete_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_delete_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_finding_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_finding_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_crawled_urls_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_crawled_urls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_crawled_urls_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_crawled_urls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_finding_type_stats_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_finding_type_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_finding_type_stats_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_finding_type_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_findings_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_findings_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_configs_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_configs_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_runs_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_runs_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_start_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_start_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_start_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_start_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_stop_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_stop_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_stop_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_stop_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_update_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_update_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_update_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_update_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_create_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_create_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_create_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_create_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_delete_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_delete_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_delete_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_delete_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_finding_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_finding_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_crawled_urls_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_crawled_urls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_crawled_urls_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_crawled_urls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_finding_type_stats_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_finding_type_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_finding_type_stats_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_finding_type_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_findings_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_findings_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_configs_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_configs_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_runs_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_runs_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_start_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_start_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_start_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_start_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_stop_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_stop_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_stop_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_stop_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_update_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_update_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_update_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_update_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/tests/__init__.py
+++ b/packages/google-cloud-websecurityscanner/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/tests/unit/__init__.py
+++ b/packages/google-cloud-websecurityscanner/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-websecurityscanner/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/tests/unit/gapic/websecurityscanner_v1/__init__.py
+++ b/packages/google-cloud-websecurityscanner/tests/unit/gapic/websecurityscanner_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/tests/unit/gapic/websecurityscanner_v1alpha/__init__.py
+++ b/packages/google-cloud-websecurityscanner/tests/unit/gapic/websecurityscanner_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/tests/unit/gapic/websecurityscanner_v1beta/__init__.py
+++ b/packages/google-cloud-websecurityscanner/tests/unit/gapic/websecurityscanner_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/.flake8
+++ b/packages/google-cloud-workflows/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/MANIFEST.in
+++ b/packages/google-cloud-workflows/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions/gapic_version.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/gapic_version.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/async_client.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/client.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/pagers.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/base.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/grpc.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/types/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/types/executions.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/types/executions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/gapic_version.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/async_client.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/client.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/pagers.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/base.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/grpc.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/types/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/types/executions.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/types/executions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/gapic_version.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/gapic_version.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/client.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/pagers.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/base.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/grpc.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/rest.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/rest_base.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/types/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/gapic_version.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/client.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/pagers.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/base.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/grpc.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/rest.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/rest_base.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/types/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/types/workflows.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/types/workflows.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_create_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_create_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_delete_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_delete_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_get_workflow_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_get_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_get_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_get_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflow_revisions_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflow_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflow_revisions_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflow_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflows_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflows_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_update_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_update_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_create_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_create_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_delete_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_delete_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_get_workflow_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_get_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_get_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_get_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_list_workflows_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_list_workflows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_list_workflows_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_list_workflows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_update_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_update_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/__init__.py
+++ b/packages/google-cloud-workflows/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/unit/__init__.py
+++ b/packages/google-cloud-workflows/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-workflows/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/unit/gapic/executions_v1/__init__.py
+++ b/packages/google-cloud-workflows/tests/unit/gapic/executions_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/unit/gapic/executions_v1beta/__init__.py
+++ b/packages/google-cloud-workflows/tests/unit/gapic/executions_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/unit/gapic/workflows_v1/__init__.py
+++ b/packages/google-cloud-workflows/tests/unit/gapic/workflows_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/unit/gapic/workflows_v1beta/__init__.py
+++ b/packages/google-cloud-workflows/tests/unit/gapic/workflows_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/.flake8
+++ b/packages/google-cloud-workloadmanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/MANIFEST.in
+++ b/packages/google-cloud-workloadmanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager/__init__.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager/gapic_version.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/gapic_version.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/__init__.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/__init__.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/client.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/pagers.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/__init__.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/base.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/grpc.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/rest.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/rest_base.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/types/__init__.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/types/service.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_create_evaluation_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_create_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_delete_evaluation_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_delete_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_delete_execution_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_delete_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_evaluation_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_evaluation_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_execution_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_execution_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_evaluations_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_evaluations_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_execution_results_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_execution_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_execution_results_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_execution_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_executions_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_executions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_executions_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_executions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_rules_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_rules_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_scanned_resources_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_scanned_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_scanned_resources_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_scanned_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_run_evaluation_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_run_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_update_evaluation_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_update_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/tests/__init__.py
+++ b/packages/google-cloud-workloadmanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/tests/unit/__init__.py
+++ b/packages/google-cloud-workloadmanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-workloadmanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/tests/unit/gapic/workloadmanager_v1/__init__.py
+++ b/packages/google-cloud-workloadmanager/tests/unit/gapic/workloadmanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/.flake8
+++ b/packages/google-cloud-workstations/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/MANIFEST.in
+++ b/packages/google-cloud-workstations/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations/gapic_version.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/gapic_version.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/client.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/pagers.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/base.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/grpc.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/rest.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/rest_base.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/types/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/types/workstations.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/types/workstations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/gapic_version.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/client.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/pagers.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/base.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/grpc.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/rest.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/rest_base.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/types/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/types/workstations.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/types/workstations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_create_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_create_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_create_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_create_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_create_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_create_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_delete_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_delete_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_delete_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_delete_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_delete_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_delete_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_generate_access_token_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_generate_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_generate_access_token_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_generate_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_cluster_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_config_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstation_configs_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstation_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstation_configs_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstation_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstations_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstations_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_clusters_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_clusters_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_configs_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_configs_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstations_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstations_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_start_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_start_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_stop_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_stop_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_update_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_update_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_update_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_update_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_update_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_update_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_create_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_create_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_create_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_create_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_create_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_create_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_delete_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_delete_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_delete_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_delete_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_delete_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_delete_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_generate_access_token_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_generate_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_generate_access_token_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_generate_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_cluster_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_config_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstation_configs_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstation_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstation_configs_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstation_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstations_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstations_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_clusters_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_clusters_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_configs_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_configs_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstations_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstations_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_start_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_start_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_stop_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_stop_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_update_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_update_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_update_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_update_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_update_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_update_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/tests/__init__.py
+++ b/packages/google-cloud-workstations/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/tests/unit/__init__.py
+++ b/packages/google-cloud-workstations/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-workstations/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/tests/unit/gapic/workstations_v1/__init__.py
+++ b/packages/google-cloud-workstations/tests/unit/gapic/workstations_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/tests/unit/gapic/workstations_v1beta/__init__.py
+++ b/packages/google-cloud-workstations/tests/unit/gapic/workstations_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/.flake8
+++ b/packages/google-geo-type/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/MANIFEST.in
+++ b/packages/google-geo-type/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/google/geo/type/gapic_version.py
+++ b/packages/google-geo-type/google/geo/type/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/google/geo/type/services/__init__.py
+++ b/packages/google-geo-type/google/geo/type/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/google/geo/type/types/__init__.py
+++ b/packages/google-geo-type/google/geo/type/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/google/geo/type/types/viewport.py
+++ b/packages/google-geo-type/google/geo/type/types/viewport.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/tests/__init__.py
+++ b/packages/google-geo-type/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/tests/unit/__init__.py
+++ b/packages/google-geo-type/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/tests/unit/gapic/__init__.py
+++ b/packages/google-geo-type/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/tests/unit/gapic/type/__init__.py
+++ b/packages/google-geo-type/tests/unit/gapic/type/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/.flake8
+++ b/packages/google-maps-addressvalidation/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/MANIFEST.in
+++ b/packages/google-maps-addressvalidation/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation/__init__.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation/gapic_version.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/gapic_version.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/__init__.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/__init__.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/async_client.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/client.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/__init__.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/base.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/grpc.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/grpc_asyncio.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/rest.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/rest_base.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/__init__.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/address.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/address.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/address_validation_service.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/address_validation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/geocode.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/geocode.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/metadata_.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/metadata_.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/usps_data.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/usps_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_provide_validation_feedback_async.py
+++ b/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_provide_validation_feedback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_provide_validation_feedback_sync.py
+++ b/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_provide_validation_feedback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_validate_address_async.py
+++ b/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_validate_address_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_validate_address_sync.py
+++ b/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_validate_address_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/tests/__init__.py
+++ b/packages/google-maps-addressvalidation/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/tests/unit/__init__.py
+++ b/packages/google-maps-addressvalidation/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-addressvalidation/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/tests/unit/gapic/addressvalidation_v1/__init__.py
+++ b/packages/google-maps-addressvalidation/tests/unit/gapic/addressvalidation_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/.flake8
+++ b/packages/google-maps-areainsights/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/MANIFEST.in
+++ b/packages/google-maps-areainsights/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights/__init__.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights/gapic_version.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/gapic_version.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/__init__.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/__init__.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/async_client.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/client.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/__init__.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/base.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/grpc.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/grpc_asyncio.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/rest.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/rest_base.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/types/__init__.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/types/area_insights_service.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/types/area_insights_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/samples/generated_samples/areainsights_v1_generated_area_insights_compute_insights_async.py
+++ b/packages/google-maps-areainsights/samples/generated_samples/areainsights_v1_generated_area_insights_compute_insights_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/samples/generated_samples/areainsights_v1_generated_area_insights_compute_insights_sync.py
+++ b/packages/google-maps-areainsights/samples/generated_samples/areainsights_v1_generated_area_insights_compute_insights_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/tests/__init__.py
+++ b/packages/google-maps-areainsights/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/tests/unit/__init__.py
+++ b/packages/google-maps-areainsights/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-areainsights/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/tests/unit/gapic/areainsights_v1/__init__.py
+++ b/packages/google-maps-areainsights/tests/unit/gapic/areainsights_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/.flake8
+++ b/packages/google-maps-fleetengine-delivery/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/MANIFEST.in
+++ b/packages/google-maps-fleetengine-delivery/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery/gapic_version.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/gapic_version.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/async_client.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/client.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/pagers.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/base.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/grpc.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/grpc_asyncio.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/rest.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/rest_base.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/common.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/delivery_api.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/delivery_api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/delivery_vehicles.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/delivery_vehicles.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/header.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/header.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/task_tracking_info.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/task_tracking_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/tasks.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/tasks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_batch_create_tasks_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_batch_create_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_batch_create_tasks_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_batch_create_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_delivery_vehicle_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_delivery_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_delivery_vehicle_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_delivery_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_task_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_task_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_delivery_vehicle_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_delivery_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_delivery_vehicle_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_delivery_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_task_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_task_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_delivery_vehicle_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_delivery_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_delivery_vehicle_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_delivery_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_tracking_info_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_tracking_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_tracking_info_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_tracking_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_delivery_vehicles_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_delivery_vehicles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_delivery_vehicles_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_delivery_vehicles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_tasks_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_tasks_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_delivery_vehicle_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_delivery_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_delivery_vehicle_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_delivery_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_task_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_task_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/tests/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/tests/unit/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/tests/unit/gapic/fleetengine_delivery_v1/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/tests/unit/gapic/fleetengine_delivery_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/.flake8
+++ b/packages/google-maps-fleetengine/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/MANIFEST.in
+++ b/packages/google-maps-fleetengine/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine/gapic_version.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/gapic_version.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/async_client.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/client.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/pagers.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/base.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/grpc.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/grpc_asyncio.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/async_client.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/client.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/pagers.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/base.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/grpc.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/grpc_asyncio.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/fleetengine.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/fleetengine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/header.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/header.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/traffic.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/traffic.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/trip_api.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/trip_api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/trips.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/trips.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/vehicle_api.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/vehicle_api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/vehicles.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/vehicles.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_create_trip_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_create_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_create_trip_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_create_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_delete_trip_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_delete_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_delete_trip_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_delete_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_get_trip_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_get_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_get_trip_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_get_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_report_billable_trip_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_report_billable_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_report_billable_trip_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_report_billable_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_search_trips_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_search_trips_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_search_trips_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_search_trips_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_update_trip_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_update_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_update_trip_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_update_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_create_vehicle_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_create_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_create_vehicle_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_create_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_delete_vehicle_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_delete_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_delete_vehicle_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_delete_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_get_vehicle_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_get_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_get_vehicle_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_get_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_list_vehicles_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_list_vehicles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_list_vehicles_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_list_vehicles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_search_vehicles_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_search_vehicles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_search_vehicles_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_search_vehicles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_attributes_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_attributes_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/tests/__init__.py
+++ b/packages/google-maps-fleetengine/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/tests/unit/__init__.py
+++ b/packages/google-maps-fleetengine/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-fleetengine/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/tests/unit/gapic/fleetengine_v1/__init__.py
+++ b/packages/google-maps-fleetengine/tests/unit/gapic/fleetengine_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/.flake8
+++ b/packages/google-maps-geocode/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/MANIFEST.in
+++ b/packages/google-maps-geocode/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode/gapic_version.py
+++ b/packages/google-maps-geocode/google/maps/geocode/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/gapic_version.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/async_client.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/client.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/base.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/grpc.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/grpc_asyncio.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/rest.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/rest_base.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/async_client.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/client.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/base.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/grpc.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/grpc_asyncio.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/rest.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/rest_base.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/types/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/types/destination_service.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/types/destination_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/types/geocode_service.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/types/geocode_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_destination_service_search_destinations_async.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_destination_service_search_destinations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_destination_service_search_destinations_sync.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_destination_service_search_destinations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_address_async.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_address_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_address_sync.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_address_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_location_async.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_location_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_location_sync.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_location_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_place_async.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_place_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_place_sync.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_place_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/tests/__init__.py
+++ b/packages/google-maps-geocode/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/tests/unit/__init__.py
+++ b/packages/google-maps-geocode/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-geocode/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/tests/unit/gapic/geocode_v4/__init__.py
+++ b/packages/google-maps-geocode/tests/unit/gapic/geocode_v4/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/.flake8
+++ b/packages/google-maps-mapmanagement/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/MANIFEST.in
+++ b/packages/google-maps-mapmanagement/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement/__init__.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement/gapic_version.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/gapic_version.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/__init__.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/__init__.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/async_client.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/client.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/pagers.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/__init__.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/base.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/grpc.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/grpc_asyncio.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/rest.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/rest_base.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/types/__init__.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/types/map_management_service.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/types/map_management_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_context_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_context_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_context_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_context_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_style_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_style_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_style_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_style_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_context_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_context_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_context_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_context_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_style_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_style_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_style_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_style_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_context_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_context_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_context_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_context_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_style_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_style_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_style_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_style_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_configs_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_configs_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_context_configs_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_context_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_context_configs_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_context_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_style_configs_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_style_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_style_configs_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_style_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_context_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_context_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_context_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_context_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_style_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_style_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_style_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_style_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/tests/__init__.py
+++ b/packages/google-maps-mapmanagement/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/tests/unit/__init__.py
+++ b/packages/google-maps-mapmanagement/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-mapmanagement/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/tests/unit/gapic/mapmanagement_v2beta/__init__.py
+++ b/packages/google-maps-mapmanagement/tests/unit/gapic/mapmanagement_v2beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/.flake8
+++ b/packages/google-maps-mapsplatformdatasets/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/MANIFEST.in
+++ b/packages/google-maps-mapsplatformdatasets/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets/gapic_version.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/gapic_version.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/async_client.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/client.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/pagers.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/base.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/grpc.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/grpc_asyncio.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/rest.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/rest_base.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/data_source.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/data_source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/dataset.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/maps_platform_datasets.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/maps_platform_datasets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/maps_platform_datasets_service.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/maps_platform_datasets_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_create_dataset_async.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_create_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_create_dataset_sync.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_create_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_delete_dataset_async.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_delete_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_delete_dataset_sync.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_delete_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_fetch_dataset_errors_async.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_fetch_dataset_errors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_fetch_dataset_errors_sync.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_fetch_dataset_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_get_dataset_async.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_get_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_get_dataset_sync.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_get_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_list_datasets_async.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_list_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_list_datasets_sync.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_list_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_update_dataset_metadata_async.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_update_dataset_metadata_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_update_dataset_metadata_sync.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_update_dataset_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/tests/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/tests/unit/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/tests/unit/gapic/mapsplatformdatasets_v1/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/tests/unit/gapic/mapsplatformdatasets_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/.flake8
+++ b/packages/google-maps-navconnect/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/MANIFEST.in
+++ b/packages/google-maps-navconnect/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect/__init__.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect/gapic_version.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/gapic_version.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/__init__.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/__init__.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/async_client.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/client.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/__init__.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/base.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/grpc.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/grpc_asyncio.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/rest.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/rest_base.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/types/__init__.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/types/navconnect_service.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/types/navconnect_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_create_trip_async.py
+++ b/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_create_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_create_trip_sync.py
+++ b/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_create_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_get_trip_async.py
+++ b/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_get_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_get_trip_sync.py
+++ b/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_get_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/tests/__init__.py
+++ b/packages/google-maps-navconnect/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/tests/unit/__init__.py
+++ b/packages/google-maps-navconnect/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-navconnect/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/tests/unit/gapic/navconnect_v1/__init__.py
+++ b/packages/google-maps-navconnect/tests/unit/gapic/navconnect_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/.flake8
+++ b/packages/google-maps-places/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/MANIFEST.in
+++ b/packages/google-maps-places/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places/__init__.py
+++ b/packages/google-maps-places/google/maps/places/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places/gapic_version.py
+++ b/packages/google-maps-places/google/maps/places/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/gapic_version.py
+++ b/packages/google-maps-places/google/maps/places_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/__init__.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/__init__.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/async_client.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/client.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/transports/__init__.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/transports/base.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/transports/grpc.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/transports/grpc_asyncio.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/transports/rest.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/transports/rest_base.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/__init__.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/address_descriptor.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/address_descriptor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/attribution.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/attribution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/content_block.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/content_block.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/contextual_content.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/contextual_content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/ev_charging.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/ev_charging.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/fuel_options.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/fuel_options.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/geometry.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/photo.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/photo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/place.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/place.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/places_service.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/places_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/polyline.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/polyline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/price_range.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/price_range.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/reference.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/reference.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/review.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/review.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/route_modifiers.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/route_modifiers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/routing_preference.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/routing_preference.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/routing_summary.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/routing_summary.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/travel_mode.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/travel_mode.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/tests/__init__.py
+++ b/packages/google-maps-places/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/tests/unit/__init__.py
+++ b/packages/google-maps-places/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-places/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/tests/unit/gapic/places_v1/__init__.py
+++ b/packages/google-maps-places/tests/unit/gapic/places_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/.flake8
+++ b/packages/google-maps-routeoptimization/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/MANIFEST.in
+++ b/packages/google-maps-routeoptimization/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization/__init__.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization/gapic_version.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/gapic_version.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/__init__.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/__init__.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/client.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/__init__.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/base.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/grpc.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/grpc_asyncio.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/rest.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/rest_base.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/types/__init__.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_batch_optimize_tours_sync.py
+++ b/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_batch_optimize_tours_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_async.py
+++ b/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_long_running_sync.py
+++ b/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_long_running_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_sync.py
+++ b/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_uri_sync.py
+++ b/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_uri_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/tests/__init__.py
+++ b/packages/google-maps-routeoptimization/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/tests/unit/__init__.py
+++ b/packages/google-maps-routeoptimization/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-routeoptimization/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/tests/unit/gapic/routeoptimization_v1/__init__.py
+++ b/packages/google-maps-routeoptimization/tests/unit/gapic/routeoptimization_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/.flake8
+++ b/packages/google-maps-routing/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/MANIFEST.in
+++ b/packages/google-maps-routing/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing/__init__.py
+++ b/packages/google-maps-routing/google/maps/routing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing/gapic_version.py
+++ b/packages/google-maps-routing/google/maps/routing/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/gapic_version.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/__init__.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/__init__.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/async_client.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/client.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/__init__.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/base.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/grpc.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/grpc_asyncio.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/rest.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/rest_base.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/__init__.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/fallback_info.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/fallback_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/geocoding_results.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/geocoding_results.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/localized_time.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/localized_time.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/location.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/location.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/maneuver.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/maneuver.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/navigation_instruction.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/navigation_instruction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/polyline.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/polyline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/polyline_details.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/polyline_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/route.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/route.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/route_label.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/route_label.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/route_modifiers.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/route_modifiers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/route_travel_mode.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/route_travel_mode.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/routes_service.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/routes_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/routing_preference.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/routing_preference.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/speed_reading_interval.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/speed_reading_interval.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/toll_info.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/toll_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/traffic_model.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/traffic_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/transit.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/transit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/transit_preferences.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/transit_preferences.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/units.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/units.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/vehicle_emission_type.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/vehicle_emission_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/vehicle_info.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/vehicle_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/waypoint.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/waypoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_route_matrix_async.py
+++ b/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_route_matrix_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_route_matrix_sync.py
+++ b/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_route_matrix_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_routes_async.py
+++ b/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_routes_sync.py
+++ b/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/tests/__init__.py
+++ b/packages/google-maps-routing/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/tests/unit/__init__.py
+++ b/packages/google-maps-routing/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-routing/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/tests/unit/gapic/routing_v2/__init__.py
+++ b/packages/google-maps-routing/tests/unit/gapic/routing_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/.flake8
+++ b/packages/google-maps-solar/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/MANIFEST.in
+++ b/packages/google-maps-solar/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar/__init__.py
+++ b/packages/google-maps-solar/google/maps/solar/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar/gapic_version.py
+++ b/packages/google-maps-solar/google/maps/solar/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/gapic_version.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/__init__.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/__init__.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/async_client.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/client.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/__init__.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/base.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/grpc.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/grpc_asyncio.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/rest.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/rest_base.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/types/__init__.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/types/solar_service.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/types/solar_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_find_closest_building_insights_async.py
+++ b/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_find_closest_building_insights_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_find_closest_building_insights_sync.py
+++ b/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_find_closest_building_insights_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_data_layers_async.py
+++ b/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_data_layers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_data_layers_sync.py
+++ b/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_data_layers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_geo_tiff_async.py
+++ b/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_geo_tiff_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_geo_tiff_sync.py
+++ b/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_geo_tiff_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/tests/__init__.py
+++ b/packages/google-maps-solar/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/tests/unit/__init__.py
+++ b/packages/google-maps-solar/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-solar/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/tests/unit/gapic/solar_v1/__init__.py
+++ b/packages/google-maps-solar/tests/unit/gapic/solar_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/.flake8
+++ b/packages/google-shopping-css/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/MANIFEST.in
+++ b/packages/google-shopping-css/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css/gapic_version.py
+++ b/packages/google-shopping-css/google/shopping/css/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/gapic_version.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/async_client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/pagers.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/grpc.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/rest.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/rest_base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/async_client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/pagers.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/grpc.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/rest.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/rest_base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/async_client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/grpc.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/rest.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/rest_base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/async_client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/pagers.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/grpc.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/rest.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/rest_base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/async_client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/pagers.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/grpc.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/rest.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/rest_base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/accounts.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/accounts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/accounts_labels.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/accounts_labels.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/css_product_common.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/css_product_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/css_product_inputs.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/css_product_inputs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/css_products.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/css_products.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/quota.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/quota.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_create_account_label_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_create_account_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_create_account_label_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_create_account_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_delete_account_label_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_delete_account_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_delete_account_label_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_delete_account_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_list_account_labels_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_list_account_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_list_account_labels_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_list_account_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_update_account_label_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_update_account_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_update_account_label_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_update_account_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_get_account_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_get_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_get_account_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_get_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_list_child_accounts_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_list_child_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_list_child_accounts_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_list_child_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_update_labels_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_update_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_update_labels_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_update_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_delete_css_product_input_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_delete_css_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_delete_css_product_input_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_delete_css_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_insert_css_product_input_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_insert_css_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_insert_css_product_input_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_insert_css_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_update_css_product_input_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_update_css_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_update_css_product_input_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_update_css_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_get_css_product_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_get_css_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_get_css_product_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_get_css_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_list_css_products_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_list_css_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_list_css_products_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_list_css_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_quota_service_list_quota_groups_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_quota_service_list_quota_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_quota_service_list_quota_groups_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_quota_service_list_quota_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/tests/__init__.py
+++ b/packages/google-shopping-css/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/tests/unit/__init__.py
+++ b/packages/google-shopping-css/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-css/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/tests/unit/gapic/css_v1/__init__.py
+++ b/packages/google-shopping-css/tests/unit/gapic/css_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/.flake8
+++ b/packages/google-shopping-merchant-accounts/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/MANIFEST.in
+++ b/packages/google-shopping-merchant-accounts/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts/gapic_version.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accessright.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accessright.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accountissue.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accountissue.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accountrelationships.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accountrelationships.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accounts.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accounts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accountservices.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accountservices.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/autofeedsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/autofeedsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/automaticimprovements.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/automaticimprovements.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/businessidentity.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/businessidentity.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/businessinfo.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/businessinfo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/checkoutsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/checkoutsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/customerservice.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/customerservice.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/developerregistration.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/developerregistration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/emailpreferences.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/emailpreferences.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/gbpaccounts.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/gbpaccounts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/homepage.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/homepage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/lfpproviders.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/lfpproviders.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/omnichannelsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/omnichannelsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/online_return_policy.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/online_return_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/phoneverificationstate.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/phoneverificationstate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/programs.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/programs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/regions.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/regions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/shippingsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/shippingsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/termsofservice.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/termsofservice.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/termsofserviceagreementstate.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/termsofserviceagreementstate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/termsofservicekind.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/termsofservicekind.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/user.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/user.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/verificationmailsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/verificationmailsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accessright.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accessright.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/account_tax.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/account_tax.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accountissue.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accountissue.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accounts.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accounts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accountservices.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accountservices.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/autofeedsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/autofeedsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/automaticimprovements.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/automaticimprovements.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/businessidentity.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/businessidentity.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/businessinfo.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/businessinfo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/checkoutsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/checkoutsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/customerservice.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/customerservice.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/emailpreferences.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/emailpreferences.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/gbpaccounts.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/gbpaccounts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/homepage.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/homepage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/lfpproviders.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/lfpproviders.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/omnichannelsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/omnichannelsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/online_return_policy.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/online_return_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/phoneverificationstate.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/phoneverificationstate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/programs.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/programs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/regions.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/regions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/tax_rule.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/tax_rule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/termsofservice.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/termsofservice.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/termsofserviceagreementstate.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/termsofserviceagreementstate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/termsofservicekind.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/termsofservicekind.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/user.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/user.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/verificationmailsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/verificationmailsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_issue_service_list_account_issues_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_issue_service_list_account_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_issue_service_list_account_issues_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_issue_service_list_account_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_get_account_relationship_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_get_account_relationship_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_get_account_relationship_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_get_account_relationship_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_list_account_relationships_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_list_account_relationships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_list_account_relationships_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_list_account_relationships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_update_account_relationship_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_update_account_relationship_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_update_account_relationship_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_update_account_relationship_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_approve_account_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_approve_account_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_approve_account_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_approve_account_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_get_account_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_get_account_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_get_account_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_get_account_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_list_account_services_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_list_account_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_list_account_services_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_list_account_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_propose_account_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_propose_account_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_propose_account_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_propose_account_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_reject_account_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_reject_account_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_reject_account_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_reject_account_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_and_configure_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_and_configure_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_and_configure_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_and_configure_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_test_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_test_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_test_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_test_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_delete_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_delete_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_delete_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_delete_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_get_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_get_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_get_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_get_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_accounts_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_accounts_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_sub_accounts_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_sub_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_sub_accounts_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_sub_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_update_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_update_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_update_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_update_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_get_autofeed_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_get_autofeed_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_get_autofeed_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_get_autofeed_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_update_autofeed_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_update_autofeed_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_update_autofeed_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_update_autofeed_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_get_automatic_improvements_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_get_automatic_improvements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_get_automatic_improvements_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_get_automatic_improvements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_update_automatic_improvements_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_update_automatic_improvements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_update_automatic_improvements_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_update_automatic_improvements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_get_business_identity_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_get_business_identity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_get_business_identity_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_get_business_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_update_business_identity_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_update_business_identity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_update_business_identity_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_update_business_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_get_business_info_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_get_business_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_get_business_info_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_get_business_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_update_business_info_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_update_business_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_update_business_info_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_update_business_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_create_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_create_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_create_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_create_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_delete_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_delete_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_delete_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_delete_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_get_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_get_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_get_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_get_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_update_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_update_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_update_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_update_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_account_for_gcp_registration_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_account_for_gcp_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_account_for_gcp_registration_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_account_for_gcp_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_developer_registration_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_developer_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_developer_registration_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_developer_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_register_gcp_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_register_gcp_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_register_gcp_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_register_gcp_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_unregister_gcp_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_unregister_gcp_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_unregister_gcp_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_unregister_gcp_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_get_email_preferences_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_get_email_preferences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_get_email_preferences_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_get_email_preferences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_update_email_preferences_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_update_email_preferences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_update_email_preferences_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_update_email_preferences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_link_gbp_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_link_gbp_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_link_gbp_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_link_gbp_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_list_gbp_accounts_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_list_gbp_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_list_gbp_accounts_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_list_gbp_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_claim_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_claim_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_claim_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_claim_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_get_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_get_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_get_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_get_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_unclaim_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_unclaim_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_unclaim_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_unclaim_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_update_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_update_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_update_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_update_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_find_lfp_providers_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_find_lfp_providers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_find_lfp_providers_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_find_lfp_providers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_link_lfp_provider_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_link_lfp_provider_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_link_lfp_provider_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_link_lfp_provider_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_create_omnichannel_setting_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_create_omnichannel_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_create_omnichannel_setting_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_create_omnichannel_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_get_omnichannel_setting_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_get_omnichannel_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_get_omnichannel_setting_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_get_omnichannel_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_list_omnichannel_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_list_omnichannel_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_list_omnichannel_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_list_omnichannel_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_request_inventory_verification_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_request_inventory_verification_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_request_inventory_verification_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_request_inventory_verification_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_update_omnichannel_setting_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_update_omnichannel_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_update_omnichannel_setting_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_update_omnichannel_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_create_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_create_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_create_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_create_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_delete_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_delete_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_delete_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_delete_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_get_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_get_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_get_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_get_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_list_online_return_policies_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_list_online_return_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_list_online_return_policies_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_list_online_return_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_disable_program_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_disable_program_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_disable_program_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_disable_program_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_enable_program_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_enable_program_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_enable_program_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_enable_program_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_get_program_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_get_program_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_get_program_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_get_program_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_list_programs_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_list_programs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_list_programs_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_list_programs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_create_regions_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_create_regions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_create_regions_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_create_regions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_delete_regions_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_delete_regions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_delete_regions_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_delete_regions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_update_regions_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_update_regions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_update_regions_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_update_regions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_create_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_create_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_create_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_create_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_delete_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_delete_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_delete_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_delete_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_get_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_get_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_get_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_get_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_list_regions_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_list_regions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_list_regions_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_list_regions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_update_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_update_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_update_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_update_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_get_shipping_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_get_shipping_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_get_shipping_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_get_shipping_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_insert_shipping_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_insert_shipping_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_insert_shipping_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_insert_shipping_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_accept_terms_of_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_accept_terms_of_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_accept_terms_of_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_accept_terms_of_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_get_terms_of_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_get_terms_of_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_get_terms_of_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_get_terms_of_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_retrieve_latest_terms_of_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_retrieve_latest_terms_of_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_retrieve_latest_terms_of_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_retrieve_latest_terms_of_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_create_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_create_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_create_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_create_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_delete_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_delete_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_delete_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_delete_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_get_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_get_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_get_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_get_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_list_users_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_list_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_list_users_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_list_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_update_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_update_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_update_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_update_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_verify_self_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_verify_self_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_verify_self_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_verify_self_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_issue_service_list_account_issues_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_issue_service_list_account_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_issue_service_list_account_issues_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_issue_service_list_account_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_get_account_tax_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_get_account_tax_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_get_account_tax_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_get_account_tax_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_list_account_tax_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_list_account_tax_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_list_account_tax_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_list_account_tax_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_update_account_tax_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_update_account_tax_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_update_account_tax_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_update_account_tax_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_create_and_configure_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_create_and_configure_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_create_and_configure_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_create_and_configure_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_delete_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_delete_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_delete_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_delete_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_get_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_get_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_get_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_get_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_accounts_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_accounts_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_sub_accounts_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_sub_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_sub_accounts_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_sub_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_update_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_update_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_update_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_update_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_get_autofeed_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_get_autofeed_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_get_autofeed_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_get_autofeed_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_update_autofeed_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_update_autofeed_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_update_autofeed_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_update_autofeed_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_get_automatic_improvements_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_get_automatic_improvements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_get_automatic_improvements_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_get_automatic_improvements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_update_automatic_improvements_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_update_automatic_improvements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_update_automatic_improvements_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_update_automatic_improvements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_get_business_identity_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_get_business_identity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_get_business_identity_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_get_business_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_update_business_identity_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_update_business_identity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_update_business_identity_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_update_business_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_get_business_info_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_get_business_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_get_business_info_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_get_business_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_update_business_info_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_update_business_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_update_business_info_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_update_business_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_create_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_create_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_create_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_create_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_delete_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_delete_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_delete_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_delete_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_get_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_get_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_get_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_get_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_update_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_update_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_update_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_update_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_get_email_preferences_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_get_email_preferences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_get_email_preferences_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_get_email_preferences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_update_email_preferences_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_update_email_preferences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_update_email_preferences_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_update_email_preferences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_link_gbp_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_link_gbp_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_link_gbp_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_link_gbp_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_list_gbp_accounts_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_list_gbp_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_list_gbp_accounts_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_list_gbp_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_claim_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_claim_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_claim_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_claim_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_get_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_get_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_get_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_get_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_unclaim_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_unclaim_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_unclaim_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_unclaim_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_update_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_update_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_update_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_update_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_find_lfp_providers_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_find_lfp_providers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_find_lfp_providers_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_find_lfp_providers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_link_lfp_provider_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_link_lfp_provider_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_link_lfp_provider_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_link_lfp_provider_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_create_omnichannel_setting_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_create_omnichannel_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_create_omnichannel_setting_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_create_omnichannel_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_get_omnichannel_setting_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_get_omnichannel_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_get_omnichannel_setting_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_get_omnichannel_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_list_omnichannel_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_list_omnichannel_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_list_omnichannel_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_list_omnichannel_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_request_inventory_verification_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_request_inventory_verification_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_request_inventory_verification_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_request_inventory_verification_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_update_omnichannel_setting_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_update_omnichannel_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_update_omnichannel_setting_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_update_omnichannel_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_create_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_create_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_create_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_create_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_delete_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_delete_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_delete_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_delete_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_get_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_get_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_get_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_get_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_list_online_return_policies_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_list_online_return_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_list_online_return_policies_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_list_online_return_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_update_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_update_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_update_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_update_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_disable_program_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_disable_program_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_disable_program_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_disable_program_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_enable_program_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_enable_program_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_enable_program_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_enable_program_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_get_program_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_get_program_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_get_program_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_get_program_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_list_programs_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_list_programs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_list_programs_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_list_programs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_create_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_create_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_create_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_create_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_delete_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_delete_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_delete_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_delete_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_get_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_get_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_get_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_get_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_list_regions_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_list_regions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_list_regions_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_list_regions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_update_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_update_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_update_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_update_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_get_shipping_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_get_shipping_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_get_shipping_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_get_shipping_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_insert_shipping_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_insert_shipping_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_insert_shipping_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_insert_shipping_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_accept_terms_of_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_accept_terms_of_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_accept_terms_of_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_accept_terms_of_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_get_terms_of_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_get_terms_of_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_get_terms_of_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_get_terms_of_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_retrieve_latest_terms_of_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_retrieve_latest_terms_of_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_retrieve_latest_terms_of_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_retrieve_latest_terms_of_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_create_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_create_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_create_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_create_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_delete_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_delete_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_delete_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_delete_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_get_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_get_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_get_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_get_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_list_users_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_list_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_list_users_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_list_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_update_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_update_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_update_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_update_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/tests/__init__.py
+++ b/packages/google-shopping-merchant-accounts/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-accounts/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-accounts/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/tests/unit/gapic/merchant_accounts_v1/__init__.py
+++ b/packages/google-shopping-merchant-accounts/tests/unit/gapic/merchant_accounts_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/tests/unit/gapic/merchant_accounts_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-accounts/tests/unit/gapic/merchant_accounts_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/.flake8
+++ b/packages/google-shopping-merchant-conversions/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/MANIFEST.in
+++ b/packages/google-shopping-merchant-conversions/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions/gapic_version.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/async_client.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/client.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/pagers.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/base.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/rest.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/types/conversionsources.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/types/conversionsources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/async_client.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/client.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/pagers.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/base.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/rest.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/types/conversionsources.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/types/conversionsources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_create_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_create_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_create_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_create_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_delete_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_delete_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_delete_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_delete_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_get_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_get_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_get_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_get_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_list_conversion_sources_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_list_conversion_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_list_conversion_sources_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_list_conversion_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_undelete_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_undelete_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_undelete_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_undelete_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_update_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_update_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_update_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_update_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_create_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_create_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_create_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_create_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_delete_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_delete_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_delete_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_delete_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_get_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_get_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_get_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_get_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_list_conversion_sources_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_list_conversion_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_list_conversion_sources_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_list_conversion_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_undelete_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_undelete_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_undelete_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_undelete_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_update_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_update_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_update_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_update_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/tests/__init__.py
+++ b/packages/google-shopping-merchant-conversions/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-conversions/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-conversions/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/tests/unit/gapic/merchant_conversions_v1/__init__.py
+++ b/packages/google-shopping-merchant-conversions/tests/unit/gapic/merchant_conversions_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/tests/unit/gapic/merchant_conversions_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-conversions/tests/unit/gapic/merchant_conversions_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/.flake8
+++ b/packages/google-shopping-merchant-datasources/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/MANIFEST.in
+++ b/packages/google-shopping-merchant-datasources/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources/gapic_version.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/async_client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/pagers.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/rest.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/async_client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/rest.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/datasources.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/datasources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/datasourcetypes.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/datasourcetypes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/fileinputs.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/fileinputs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/fileuploads.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/fileuploads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/async_client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/pagers.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/rest.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/async_client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/rest.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/datasources.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/datasources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/datasourcetypes.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/datasourcetypes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/fileinputs.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/fileinputs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/fileuploads.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/fileuploads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_create_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_create_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_create_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_create_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_delete_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_delete_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_delete_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_delete_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_fetch_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_fetch_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_fetch_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_fetch_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_get_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_get_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_get_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_get_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_list_data_sources_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_list_data_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_list_data_sources_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_list_data_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_update_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_update_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_update_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_update_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_file_uploads_service_get_file_upload_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_file_uploads_service_get_file_upload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_file_uploads_service_get_file_upload_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_file_uploads_service_get_file_upload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_create_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_create_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_create_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_create_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_delete_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_delete_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_delete_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_delete_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_fetch_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_fetch_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_fetch_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_fetch_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_get_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_get_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_get_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_get_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_list_data_sources_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_list_data_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_list_data_sources_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_list_data_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_update_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_update_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_update_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_update_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_file_uploads_service_get_file_upload_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_file_uploads_service_get_file_upload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_file_uploads_service_get_file_upload_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_file_uploads_service_get_file_upload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/tests/__init__.py
+++ b/packages/google-shopping-merchant-datasources/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-datasources/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-datasources/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/tests/unit/gapic/merchant_datasources_v1/__init__.py
+++ b/packages/google-shopping-merchant-datasources/tests/unit/gapic/merchant_datasources_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/tests/unit/gapic/merchant_datasources_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-datasources/tests/unit/gapic/merchant_datasources_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/.flake8
+++ b/packages/google-shopping-merchant-inventories/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/MANIFEST.in
+++ b/packages/google-shopping-merchant-inventories/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories/gapic_version.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/async_client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/pagers.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/rest.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/async_client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/pagers.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/rest.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/inventories_common.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/inventories_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/localinventory.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/localinventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/regionalinventory.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/regionalinventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/async_client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/pagers.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/rest.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/async_client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/pagers.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/rest.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/types/localinventory.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/types/localinventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/types/regionalinventory.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/types/regionalinventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_delete_local_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_delete_local_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_delete_local_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_delete_local_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_insert_local_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_insert_local_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_insert_local_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_insert_local_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_list_local_inventories_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_list_local_inventories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_list_local_inventories_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_list_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_delete_regional_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_delete_regional_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_delete_regional_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_delete_regional_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_insert_regional_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_insert_regional_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_insert_regional_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_insert_regional_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_list_regional_inventories_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_list_regional_inventories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_list_regional_inventories_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_list_regional_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_delete_local_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_delete_local_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_delete_local_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_delete_local_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_insert_local_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_insert_local_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_insert_local_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_insert_local_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_list_local_inventories_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_list_local_inventories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_list_local_inventories_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_list_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_delete_regional_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_delete_regional_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_delete_regional_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_delete_regional_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_insert_regional_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_insert_regional_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_insert_regional_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_insert_regional_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_list_regional_inventories_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_list_regional_inventories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_list_regional_inventories_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_list_regional_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/tests/__init__.py
+++ b/packages/google-shopping-merchant-inventories/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-inventories/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-inventories/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/tests/unit/gapic/merchant_inventories_v1/__init__.py
+++ b/packages/google-shopping-merchant-inventories/tests/unit/gapic/merchant_inventories_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/tests/unit/gapic/merchant_inventories_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-inventories/tests/unit/gapic/merchant_inventories_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/.flake8
+++ b/packages/google-shopping-merchant-issueresolution/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/MANIFEST.in
+++ b/packages/google-shopping-merchant-issueresolution/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution/gapic_version.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/async_client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/pagers.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/rest.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/async_client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/rest.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/types/aggregateproductstatuses.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/types/aggregateproductstatuses.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/types/issueresolution.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/types/issueresolution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/async_client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/pagers.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/rest.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/async_client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/rest.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/types/aggregateproductstatuses.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/types/aggregateproductstatuses.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/types/issueresolution.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/types/issueresolution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_account_issues_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_account_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_account_issues_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_account_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_product_issues_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_product_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_product_issues_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_product_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_trigger_action_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_trigger_action_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_trigger_action_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_trigger_action_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_account_issues_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_account_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_account_issues_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_account_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_product_issues_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_product_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_product_issues_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_product_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_trigger_action_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_trigger_action_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_trigger_action_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_trigger_action_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/tests/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/tests/unit/gapic/merchant_issueresolution_v1/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/tests/unit/gapic/merchant_issueresolution_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/tests/unit/gapic/merchant_issueresolution_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/tests/unit/gapic/merchant_issueresolution_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/.flake8
+++ b/packages/google-shopping-merchant-lfp/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/MANIFEST.in
+++ b/packages/google-shopping-merchant-lfp/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp/gapic_version.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/pagers.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpinventory.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpinventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpmerchantstate.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpmerchantstate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpsale.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpsale.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpstore.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpstore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/pagers.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpinventory.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpinventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpmerchantstate.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpmerchantstate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpsale.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpsale.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpstore.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpstore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_inventory_service_insert_lfp_inventory_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_inventory_service_insert_lfp_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_inventory_service_insert_lfp_inventory_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_inventory_service_insert_lfp_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_merchant_state_service_get_lfp_merchant_state_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_merchant_state_service_get_lfp_merchant_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_merchant_state_service_get_lfp_merchant_state_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_merchant_state_service_get_lfp_merchant_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_sale_service_insert_lfp_sale_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_sale_service_insert_lfp_sale_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_sale_service_insert_lfp_sale_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_sale_service_insert_lfp_sale_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_delete_lfp_store_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_delete_lfp_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_delete_lfp_store_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_delete_lfp_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_get_lfp_store_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_get_lfp_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_get_lfp_store_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_get_lfp_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_insert_lfp_store_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_insert_lfp_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_insert_lfp_store_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_insert_lfp_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_list_lfp_stores_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_list_lfp_stores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_list_lfp_stores_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_list_lfp_stores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_inventory_service_insert_lfp_inventory_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_inventory_service_insert_lfp_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_inventory_service_insert_lfp_inventory_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_inventory_service_insert_lfp_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_merchant_state_service_get_lfp_merchant_state_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_merchant_state_service_get_lfp_merchant_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_merchant_state_service_get_lfp_merchant_state_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_merchant_state_service_get_lfp_merchant_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_sale_service_insert_lfp_sale_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_sale_service_insert_lfp_sale_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_sale_service_insert_lfp_sale_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_sale_service_insert_lfp_sale_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_delete_lfp_store_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_delete_lfp_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_delete_lfp_store_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_delete_lfp_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_get_lfp_store_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_get_lfp_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_get_lfp_store_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_get_lfp_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_insert_lfp_store_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_insert_lfp_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_insert_lfp_store_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_insert_lfp_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_list_lfp_stores_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_list_lfp_stores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_list_lfp_stores_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_list_lfp_stores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/tests/__init__.py
+++ b/packages/google-shopping-merchant-lfp/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-lfp/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-lfp/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/tests/unit/gapic/merchant_lfp_v1/__init__.py
+++ b/packages/google-shopping-merchant-lfp/tests/unit/gapic/merchant_lfp_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/tests/unit/gapic/merchant_lfp_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-lfp/tests/unit/gapic/merchant_lfp_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/.flake8
+++ b/packages/google-shopping-merchant-notifications/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/MANIFEST.in
+++ b/packages/google-shopping-merchant-notifications/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications/gapic_version.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/async_client.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/client.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/pagers.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/base.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/rest.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/types/notificationsapi.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/types/notificationsapi.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/async_client.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/client.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/pagers.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/base.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/rest.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/types/notificationsapi.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/types/notificationsapi.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_create_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_create_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_create_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_create_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_delete_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_delete_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_delete_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_delete_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_health_metrics_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_health_metrics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_health_metrics_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_health_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_list_notification_subscriptions_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_list_notification_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_list_notification_subscriptions_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_list_notification_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_update_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_update_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_update_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_update_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_create_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_create_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_create_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_create_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_delete_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_delete_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_delete_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_delete_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_get_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_get_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_get_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_get_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_list_notification_subscriptions_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_list_notification_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_list_notification_subscriptions_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_list_notification_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_update_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_update_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_update_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_update_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/tests/__init__.py
+++ b/packages/google-shopping-merchant-notifications/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-notifications/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-notifications/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/tests/unit/gapic/merchant_notifications_v1/__init__.py
+++ b/packages/google-shopping-merchant-notifications/tests/unit/gapic/merchant_notifications_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/tests/unit/gapic/merchant_notifications_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-notifications/tests/unit/gapic/merchant_notifications_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/.flake8
+++ b/packages/google-shopping-merchant-ordertracking/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/MANIFEST.in
+++ b/packages/google-shopping-merchant-ordertracking/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking/gapic_version.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/async_client.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/client.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/base.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/rest.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/types/order_tracking_signals.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/types/order_tracking_signals.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/async_client.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/client.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/base.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/rest.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/types/order_tracking_signals.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/types/order_tracking_signals.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1_generated_order_tracking_signals_service_create_order_tracking_signal_async.py
+++ b/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1_generated_order_tracking_signals_service_create_order_tracking_signal_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1_generated_order_tracking_signals_service_create_order_tracking_signal_sync.py
+++ b/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1_generated_order_tracking_signals_service_create_order_tracking_signal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1beta_generated_order_tracking_signals_service_create_order_tracking_signal_async.py
+++ b/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1beta_generated_order_tracking_signals_service_create_order_tracking_signal_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1beta_generated_order_tracking_signals_service_create_order_tracking_signal_sync.py
+++ b/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1beta_generated_order_tracking_signals_service_create_order_tracking_signal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/tests/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/tests/unit/gapic/merchant_ordertracking_v1/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/tests/unit/gapic/merchant_ordertracking_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/tests/unit/gapic/merchant_ordertracking_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/tests/unit/gapic/merchant_ordertracking_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/.flake8
+++ b/packages/google-shopping-merchant-products/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/MANIFEST.in
+++ b/packages/google-shopping-merchant-products/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products/gapic_version.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/async_client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/rest.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/async_client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/pagers.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/rest.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/productinputs.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/productinputs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/products.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/products.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/products_common.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/products_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/async_client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/rest.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/async_client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/pagers.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/rest.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/productinputs.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/productinputs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/products.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/products.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/products_common.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/products_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_delete_product_input_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_delete_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_delete_product_input_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_delete_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_insert_product_input_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_insert_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_insert_product_input_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_insert_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_update_product_input_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_update_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_update_product_input_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_update_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_get_product_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_get_product_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_list_products_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_list_products_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_delete_product_input_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_delete_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_delete_product_input_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_delete_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_insert_product_input_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_insert_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_insert_product_input_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_insert_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_update_product_input_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_update_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_update_product_input_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_update_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_get_product_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_get_product_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_list_products_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_list_products_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/tests/__init__.py
+++ b/packages/google-shopping-merchant-products/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-products/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-products/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/tests/unit/gapic/merchant_products_v1/__init__.py
+++ b/packages/google-shopping-merchant-products/tests/unit/gapic/merchant_products_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/tests/unit/gapic/merchant_products_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-products/tests/unit/gapic/merchant_products_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/.flake8
+++ b/packages/google-shopping-merchant-productstudio/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/MANIFEST.in
+++ b/packages/google-shopping-merchant-productstudio/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio/gapic_version.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/gapic_version.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/async_client.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/client.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/base.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/rest.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/async_client.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/client.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/base.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/rest.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/image.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/productstudio_common.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/productstudio_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/textsuggestions.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/textsuggestions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_generate_product_image_background_async.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_generate_product_image_background_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_generate_product_image_background_sync.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_generate_product_image_background_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_remove_product_image_background_async.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_remove_product_image_background_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_remove_product_image_background_sync.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_remove_product_image_background_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_upscale_product_image_async.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_upscale_product_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_upscale_product_image_sync.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_upscale_product_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_text_suggestions_service_generate_product_text_suggestions_async.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_text_suggestions_service_generate_product_text_suggestions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_text_suggestions_service_generate_product_text_suggestions_sync.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_text_suggestions_service_generate_product_text_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/tests/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/tests/unit/gapic/merchant_productstudio_v1alpha/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/tests/unit/gapic/merchant_productstudio_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/.flake8
+++ b/packages/google-shopping-merchant-promotions/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/MANIFEST.in
+++ b/packages/google-shopping-merchant-promotions/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions/gapic_version.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/async_client.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/client.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/pagers.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/base.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/rest.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/types/promotions.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/types/promotions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/types/promotions_common.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/types/promotions_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/async_client.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/client.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/pagers.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/base.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/rest.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/types/promotions.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/types/promotions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/types/promotions_common.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/types/promotions_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_get_promotion_async.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_get_promotion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_get_promotion_sync.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_get_promotion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_insert_promotion_async.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_insert_promotion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_insert_promotion_sync.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_insert_promotion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_list_promotions_async.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_list_promotions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_list_promotions_sync.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_list_promotions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_get_promotion_async.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_get_promotion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_get_promotion_sync.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_get_promotion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_insert_promotion_async.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_insert_promotion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_insert_promotion_sync.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_insert_promotion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_list_promotions_async.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_list_promotions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_list_promotions_sync.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_list_promotions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/tests/__init__.py
+++ b/packages/google-shopping-merchant-promotions/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-promotions/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-promotions/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/tests/unit/gapic/merchant_promotions_v1/__init__.py
+++ b/packages/google-shopping-merchant-promotions/tests/unit/gapic/merchant_promotions_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/tests/unit/gapic/merchant_promotions_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-promotions/tests/unit/gapic/merchant_promotions_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/.flake8
+++ b/packages/google-shopping-merchant-quota/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/MANIFEST.in
+++ b/packages/google-shopping-merchant-quota/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota/gapic_version.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/async_client.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/client.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/pagers.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/base.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/rest.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/async_client.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/client.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/pagers.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/base.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/rest.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/types/accountlimits.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/types/accountlimits.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/types/quota.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/types/quota.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/async_client.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/client.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/pagers.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/base.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/rest.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/types/quota.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/types/quota.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_get_account_limit_async.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_get_account_limit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_get_account_limit_sync.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_get_account_limit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_list_account_limits_async.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_list_account_limits_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_list_account_limits_sync.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_list_account_limits_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_quota_service_list_quota_groups_async.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_quota_service_list_quota_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_quota_service_list_quota_groups_sync.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_quota_service_list_quota_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1beta_generated_quota_service_list_quota_groups_async.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1beta_generated_quota_service_list_quota_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1beta_generated_quota_service_list_quota_groups_sync.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1beta_generated_quota_service_list_quota_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/tests/__init__.py
+++ b/packages/google-shopping-merchant-quota/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-quota/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-quota/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/tests/unit/gapic/merchant_quota_v1/__init__.py
+++ b/packages/google-shopping-merchant-quota/tests/unit/gapic/merchant_quota_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/tests/unit/gapic/merchant_quota_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-quota/tests/unit/gapic/merchant_quota_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/.flake8
+++ b/packages/google-shopping-merchant-reports/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/MANIFEST.in
+++ b/packages/google-shopping-merchant-reports/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports/gapic_version.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/async_client.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/client.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/pagers.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/base.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/rest.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/gapic_version.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/async_client.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/client.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/pagers.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/base.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/rest.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/types/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/async_client.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/client.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/pagers.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/base.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/rest.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1_generated_report_service_search_async.py
+++ b/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1_generated_report_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1_generated_report_service_search_sync.py
+++ b/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1_generated_report_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1alpha_generated_report_service_search_async.py
+++ b/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1alpha_generated_report_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1alpha_generated_report_service_search_sync.py
+++ b/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1alpha_generated_report_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1beta_generated_report_service_search_async.py
+++ b/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1beta_generated_report_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1beta_generated_report_service_search_sync.py
+++ b/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1beta_generated_report_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/tests/__init__.py
+++ b/packages/google-shopping-merchant-reports/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-reports/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-reports/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/tests/unit/gapic/merchant_reports_v1/__init__.py
+++ b/packages/google-shopping-merchant-reports/tests/unit/gapic/merchant_reports_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/tests/unit/gapic/merchant_reports_v1alpha/__init__.py
+++ b/packages/google-shopping-merchant-reports/tests/unit/gapic/merchant_reports_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/tests/unit/gapic/merchant_reports_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-reports/tests/unit/gapic/merchant_reports_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/.flake8
+++ b/packages/google-shopping-merchant-reviews/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/MANIFEST.in
+++ b/packages/google-shopping-merchant-reviews/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews/gapic_version.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/async_client.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/client.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/pagers.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/base.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/rest.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/async_client.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/client.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/pagers.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/base.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/rest.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/merchantreviews.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/merchantreviews.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/merchantreviews_common.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/merchantreviews_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/productreviews.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/productreviews.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/productreviews_common.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/productreviews_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_delete_merchant_review_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_delete_merchant_review_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_delete_merchant_review_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_delete_merchant_review_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_get_merchant_review_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_get_merchant_review_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_get_merchant_review_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_get_merchant_review_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_insert_merchant_review_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_insert_merchant_review_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_insert_merchant_review_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_insert_merchant_review_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_list_merchant_reviews_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_list_merchant_reviews_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_list_merchant_reviews_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_list_merchant_reviews_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_delete_product_review_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_delete_product_review_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_delete_product_review_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_delete_product_review_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_get_product_review_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_get_product_review_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_get_product_review_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_get_product_review_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_insert_product_review_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_insert_product_review_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_insert_product_review_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_insert_product_review_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_list_product_reviews_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_list_product_reviews_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_list_product_reviews_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_list_product_reviews_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/tests/__init__.py
+++ b/packages/google-shopping-merchant-reviews/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-reviews/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-reviews/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/tests/unit/gapic/merchant_reviews_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-reviews/tests/unit/gapic/merchant_reviews_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/.flake8
+++ b/packages/google-shopping-type/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/MANIFEST.in
+++ b/packages/google-shopping-type/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/google/shopping/type/gapic_version.py
+++ b/packages/google-shopping-type/google/shopping/type/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/google/shopping/type/services/__init__.py
+++ b/packages/google-shopping-type/google/shopping/type/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/google/shopping/type/types/__init__.py
+++ b/packages/google-shopping-type/google/shopping/type/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/google/shopping/type/types/types.py
+++ b/packages/google-shopping-type/google/shopping/type/types/types.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/tests/__init__.py
+++ b/packages/google-shopping-type/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/tests/unit/__init__.py
+++ b/packages/google-shopping-type/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-type/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/tests/unit/gapic/type/__init__.py
+++ b/packages/google-shopping-type/tests/unit/gapic/type/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/.flake8
+++ b/packages/grafeas/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/MANIFEST.in
+++ b/packages/grafeas/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas/__init__.py
+++ b/packages/grafeas/grafeas/grafeas/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas/gapic_version.py
+++ b/packages/grafeas/grafeas/grafeas/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/gapic_version.py
+++ b/packages/grafeas/grafeas/grafeas_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/__init__.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/__init__.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/async_client.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/client.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/pagers.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/__init__.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/base.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/grpc.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/grpc_asyncio.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/rest.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/rest_base.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/__init__.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/attestation.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/attestation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/build.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/build.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/common.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/compliance.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/compliance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/cvss.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/cvss.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/deployment.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/deployment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/discovery.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/discovery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/dsse_attestation.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/dsse_attestation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/grafeas.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/grafeas.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/image.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/intoto_provenance.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/intoto_provenance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/intoto_statement.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/intoto_statement.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/package.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/package.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/provenance.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/provenance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/risk.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/risk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/sbom.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/sbom.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/secret.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/secret.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/severity.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/severity.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/slsa_provenance.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/slsa_provenance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/slsa_provenance_zero_two.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/slsa_provenance_zero_two.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/upgrade.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/upgrade.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/vex.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/vex.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/vulnerability.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/vulnerability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_notes_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_notes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_notes_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_notes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_occurrences_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_occurrences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_occurrences_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_occurrences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_note_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_note_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_note_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_note_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_occurrence_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_occurrence_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_occurrence_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_occurrence_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_note_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_note_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_note_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_note_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_occurrence_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_occurrence_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_occurrence_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_occurrence_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_note_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_note_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_note_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_note_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_note_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_note_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_note_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_note_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_note_occurrences_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_note_occurrences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_note_occurrences_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_note_occurrences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_notes_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_notes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_notes_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_notes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_occurrences_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_occurrences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_occurrences_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_occurrences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_note_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_note_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_note_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_note_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_occurrence_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_occurrence_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_occurrence_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_occurrence_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/tests/__init__.py
+++ b/packages/grafeas/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/tests/unit/__init__.py
+++ b/packages/grafeas/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/tests/unit/gapic/__init__.py
+++ b/packages/grafeas/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/tests/unit/gapic/grafeas_v1/__init__.py
+++ b/packages/grafeas/tests/unit/gapic/grafeas_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is the result of regenerating all packages, but only committing files which have only changed in a single line, and that's a copyright line.
